### PR TITLE
Generalise local schema validation beyond DeepSeek

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,25 @@
 
 ## Bug fixes
 
+* `qlm_code()` gains a `structured` argument controlling how the output schema
+  is obtained, generalising the local-validation path added in #128 beyond
+  DeepSeek. `"structured"` trusts the provider; `"json"` puts the schema in the
+  system prompt and validates every response against `codebook$schema` locally;
+  `"auto"` (the default) attempts the structured call and falls back to
+  `"json"` when it fails. This matters because ellmer sends
+  `response_format = {type: "json_schema", strict: true}` to every
+  OpenAI-compatible provider and takes the result on trust, and measurement
+  shows several do not honour it — Kimi violated a schema it was given on 2 of
+  3 identical requests through one gateway. Non-conformance arrives as `NA`,
+  indistinguishable from missing data, so `qlm_code()` now also emits a
+  one-time note when coding against an endpoint whose enforcement it cannot
+  verify, silenced with `options(quallmer.quiet_schema_note = TRUE)`. Whether
+  an endpoint is trusted is derived from ellmer's own request path rather than
+  a list of vendors, so a provider added to ellmer later defaults to
+  unverified. Failure is detected both from an error and from a result in which
+  every required field is `NA` in every row, which is what an endpoint that
+  accepted the schema and ignored it produces (#134).
+
 * `qlm_code()` can now code with DeepSeek, and no longer trusts providers that
   accept a JSON Schema without enforcing it. The DeepSeek API rejects the
   `response_format` that `ellmer::parallel_chat_structured()` sends

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,18 @@
   a list of vendors, so a provider added to ellmer later defaults to
   unverified. Failure is detected both from an error and from a result in which
   every required field is `NA` in every row, which is what an endpoint that
-  accepted the schema and ignored it produces (#134).
+  accepted the schema and ignored it produces. That check reads required
+  scalar properties, since required arrays and nested objects become
+  list-columns in which a missing value and a schema-valid empty one are
+  indistinguishable -- so for a codebook whose required properties are all
+  arrays or nested objects, `"auto"` on an unverified endpoint validates
+  locally from the start rather than making a call it could not check, and
+  reports why (#134).
+
+* `qlm_code()` now rejects `convert = FALSE` with an explanation. It has never
+  worked: `ellmer` returns a bare list, which has no rows to carry an `.id` and
+  no columns to reorder, and the call failed later with `incorrect number of
+  dimensions` (#134).
 
 * `qlm_code()` can now code with DeepSeek, and no longer trusts providers that
   accept a JSON Schema without enforcing it. The DeepSeek API rejects the

--- a/NEWS.md
+++ b/NEWS.md
@@ -74,8 +74,13 @@
   send one vendor's credential to the other. The model is still passed as
   `model`, and registered `tools` are never carried over (#125).
 
-* `qlm_replicate()` also carries `max_retries` over from the original run, when
-  the model being replicated onto can still honour it (#128).
+* `qlm_replicate()` also reproduces the coding path and `max_retries` of the
+  original run. The path is derived from the backend the run actually used
+  rather than the mode it requested, so a run that asked for
+  `structured = "auto"` and fell back to JSON mode replicates as `"json"`:
+  requesting `"auto"` again would let an intermittently conforming endpoint
+  take the structured path instead, silently skipping the local validation the
+  original relied on and leaving the two runs incomparable (#128, #134).
 
 * `qlm_trail()` no longer emits "unknown column" warnings or crashes with
   `the condition has length > 1` when passed a `qlm_comparison` or

--- a/NEWS.md
+++ b/NEWS.md
@@ -63,8 +63,16 @@
   and the resulting `qlm_compare()` would read as a model-stability measurement
   when it was partly a settings-difference measurement. Chat arguments are now
   restored alongside execution arguments, with overrides in `...` taking
-  precedence. Two exceptions: the model is still passed as `model`, and
-  registered `tools` are not carried over, being provider-specific (#125).
+  precedence. Provider-specific arguments such as credentials and endpoint
+  settings are restored only when the provider is unchanged; when changing
+  endpoint, an informational message names any inherited arguments that were
+  omitted and not explicitly replaced. An endpoint is identified by both the
+  provider prefix and `base_url`, because every provider ellmer has no
+  `chat_*()` for is reached as `openai_compatible/<model>` -- so Qwen through
+  Alibaba Model Studio and Kimi through Moonshot share a prefix while being
+  different services with different credentials, and a prefix-only check would
+  send one vendor's credential to the other. The model is still passed as
+  `model`, and registered `tools` are never carried over (#125).
 
 * `qlm_replicate()` also carries `max_retries` over from the original run, when
   the model being replicated onto can still honour it (#128).
@@ -308,4 +316,3 @@ The new API uses the `qlm_` prefix to avoid namespace conflicts (e.g., with `ggp
 - Improved error messages in `qlm_compare()` and `qlm_validate()` now show which objects are missing the requested variable and list available alternatives.
 - Adopt tidyverse-style error messaging via `cli::cli_abort()` and `cli::cli_warn()` throughout the package, replacing all `stop()`, `stopifnot()`, and `warning()` calls with structured, informative error messages.
 - Documentation and CI notes refreshed.
-

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -18,12 +18,18 @@
 #'   that provider). Passed to the `name` argument of [ellmer::chat()].
 #'   Examples: `"openai/gpt-4o-mini"`, `"anthropic/claude-3-5-sonnet-20241022"`,
 #'   `"ollama/llama3.2"`, `"openai"` (uses default OpenAI model).
+#' @param structured How the output schema is obtained. `"structured"` uses
+#'   [ellmer::parallel_chat_structured()] and trusts the provider to enforce
+#'   the schema. `"json"` asks for JSON, puts the schema in the system prompt,
+#'   and validates every response against the codebook locally. `"auto"` (the
+#'   default) attempts the structured call and falls back to `"json"` if it
+#'   fails. See Details for which to use.
 #' @param max_retries Number of additional attempts made for a response that
-#'   arrives intact but does not conform to the codebook schema. Applies only to
-#'   providers coded in JSON mode (see Details); setting it for any other
-#'   provider is an error. Default is 2, giving at most three attempts per unit.
-#'   This is separate from ellmer's transport-level retries for rate limits and
-#'   server errors, which apply to every provider and are set with
+#'   arrives intact but does not conform to the codebook schema. Applies on the
+#'   JSON path only, so setting it alongside `structured = "structured"` is an
+#'   error. Default is 2, giving at most three attempts per unit. This is
+#'   separate from ellmer's transport-level retries for rate limits and server
+#'   errors, which apply to every provider and are set with
 #'   `options(ellmer_max_tries = )`.
 #' @param batch Logical. If `TRUE`, uses [ellmer::batch_chat_structured()]
 #'   instead of [ellmer::parallel_chat_structured()]. Batch processing is more
@@ -46,16 +52,40 @@
 #' function. Set `verbose = TRUE` to see progress messages during coding.
 #' Retry logic for API failures should be configured through ellmer's options.
 #'
-#' Some providers accept a JSON Schema but do not enforce it, so a response can
-#' come back parseable but non-conforming, and the non-conformance then arrives
-#' silently as `NA`. For those providers `qlm_code()` routes to a JSON-mode
-#' handler that puts the schema in the system prompt, validates every response
-#' against the codebook schema locally, and re-prompts the model with the
-#' specific validation error when a response does not conform. This currently
-#' applies to `"deepseek"`. Units that never validate have `NA` coded values and
-#' a `.error` list-column recording the reason. `max_retries` controls how many
-#' repair attempts each unit gets. Batch processing and image codebooks are not
-#' supported on this path.
+#' @section Schema enforcement:
+#'
+#' Some providers accept a JSON Schema without enforcing it, so a response can
+#' come back parseable but non-conforming — and the non-conformance then arrives
+#' silently as `NA`, indistinguishable from missing data. Providers reached
+#' through ellmer's generic OpenAI-compatible request path are all in this
+#' position: `strict = TRUE` is sent and may simply be ignored. `qlm_code()`
+#' emits a one-time note when it detects one, which
+#' `options(quallmer.quiet_schema_note = TRUE)` silences.
+#'
+#' `structured` chooses what to do about it:
+#'
+#' \describe{
+#'   \item{`"structured"`}{Trust the provider. Fails loudly if the call fails.}
+#'   \item{`"json"`}{Never trust it: ask for JSON, put the schema in the system
+#'     prompt, and validate each response against `codebook$schema` locally,
+#'     re-prompting with the specific validation error when one does not
+#'     conform. The reliable choice for an endpoint known not to enforce.}
+#'   \item{`"auto"`}{Attempt the structured call; fall back to `"json"` if it
+#'     errors, or if it returns a result in which every required field is `NA`
+#'     in every row, which is what an endpoint that ignored the schema
+#'     produces.}
+#' }
+#'
+#' `"auto"` catches wholesale non-enforcement, not the intermittent kind: a
+#' single non-conforming row among many leaves that check silent. Only
+#' `"json"` catches that, at the cost of putting the schema in the prompt.
+#'
+#' On the JSON path, units that never validate have `NA` coded values and a
+#' `.error` list-column recording the reason, and `max_retries` controls how
+#' many repair attempts each unit gets. Batch processing and image codebooks
+#' are not supported there, so `"auto"` will not fall back under
+#' `batch = TRUE`. The path actually taken is recorded in the run metadata as
+#' `backend`.
 #'
 #' When `batch = TRUE`, the function uses [ellmer::batch_chat_structured()]
 #' which submits jobs to the provider's batch API. This is typically more
@@ -91,11 +121,15 @@
 #' }
 #'
 #' @export
-qlm_code <- function(x, codebook, model, ..., batch = FALSE, max_retries = 2L,
-                     name = NULL, notes = NULL) {
+qlm_code <- function(x, codebook, model, ...,
+                     batch = FALSE,
+                     structured = c("auto", "structured", "json"),
+                     max_retries = 2L, name = NULL, notes = NULL) {
   # Distinguishes a value the user chose from the default, so that the default
   # never errors but an explicit setting is never silently ignored.
   explicit_retries <- !missing(max_retries)
+  explicit_structured <- !missing(structured)
+  structured <- match.arg(structured)
 
   # Accept both qlm_codebook and task objects, converting if needed
   if (inherits(codebook, "task") && !inherits(codebook, "qlm_codebook")) {
@@ -140,17 +174,20 @@ qlm_code <- function(x, codebook, model, ..., batch = FALSE, max_retries = 2L,
     ))
   }
 
-  # Providers that do not enforce the output schema are coded by a dedicated
-  # handler instead of ellmer::parallel_chat_structured(); see code_handler_for().
-  handler <- code_handler_for(model)
+  # Providers whose API rejects the schema-constrained request skip straight to
+  # JSON mode rather than spending a wasted round trip; see
+  # default_structured_mode().
+  if (!explicit_structured) {
+    structured <- default_structured_mode(model)
+  }
 
-  # Repairing a response requires validating it, which only the JSON-mode
-  # handler does. Setting it for any other provider would have no effect, so
-  # say so rather than accepting a value that will not be applied.
-  if (explicit_retries && is.null(handler)) {
+  # Repairing a response requires validating it, which only the JSON-mode path
+  # does. Under `structured = "structured"` that path is never reached, so say
+  # so rather than accepting a value that will not be applied.
+  if (explicit_retries && identical(structured, "structured")) {
     cli::cli_abort(c(
-      "{.arg max_retries} is not supported for model {.val {model}}.",
-      "i" = "It applies only to providers coded in JSON mode, such as {.val deepseek}.",
+      "{.arg max_retries} is not supported with {.code structured = \"structured\"}.",
+      "i" = "It applies to the JSON-mode path; use {.code structured = \"auto\"} or {.code \"json\"}.",
       "i" = "For transport-level retries on any provider, set {.code options(ellmer_max_tries = )}."
     ))
   }
@@ -165,11 +202,55 @@ qlm_code <- function(x, codebook, model, ..., batch = FALSE, max_retries = 2L,
   # to pass through to ellmer::chat() which forwards them to the provider
   chat_args <- dots[!dot_names %in% execution_arg_names]
 
-  # Metadata contributed by a provider-specific handler (empty for the default path)
+  # Metadata contributed by the coding path
   backend_meta <- list()
+  results <- NULL
+  fallback_reason <- NULL
 
-  if (!is.null(handler)) {
-    results <- handler(
+  # ---- schema-constrained structured output -------------------------------
+  if (structured %in% c("auto", "structured")) {
+    attempt <- try_structured_call(
+      x = x, codebook = codebook, model = model,
+      chat_args = chat_args, execution_args = execution_args, batch = batch
+    )
+
+    if (isTRUE(attempt$ok)) {
+      results <- attempt$value
+      backend_meta <- list(backend = "structured")
+      incomplete <- n_incomplete(results, codebook$schema)
+      if (incomplete) {
+        cli::cli_warn(
+          "{incomplete} row{?s} from the structured call {?is/are} missing at least one required field."
+        )
+      }
+    } else if (identical(structured, "structured")) {
+      cli::cli_abort(c(
+        "Structured output failed for model {.val {model}}.",
+        set_bullets(attempt$error),
+        "i" = "Use {.code structured = \"auto\"} to fall back to JSON mode with local validation."
+      ))
+    } else if (batch) {
+      # JSON mode drives its own parallel requests and has no batch API path,
+      # so under batch there is nothing to fall back to. Say that, rather than
+      # letting the handler abort later with a message about `batch`.
+      cli::cli_abort(c(
+        "Structured output failed for model {.val {model}}.",
+        set_bullets(attempt$error),
+        "i" = "JSON-mode coding has no batch path, so {.code structured = \"auto\"} cannot fall back here.",
+        "i" = "Re-run with {.code batch = FALSE} to use local validation instead."
+      ))
+    } else {
+      fallback_reason <- attempt$error
+      cli::cli_warn(c(
+        "Structured output failed; falling back to JSON mode with local validation.",
+        set_bullets(attempt$error)
+      ))
+    }
+  }
+
+  # ---- JSON mode with local validation ------------------------------------
+  if (is.null(results)) {
+    results <- code_handler_json(
       x = x,
       codebook = codebook,
       model = model,
@@ -180,50 +261,11 @@ qlm_code <- function(x, codebook, model, ..., batch = FALSE, max_retries = 2L,
     )
     backend_meta <- attr(results, "qlm_backend_meta") %||% list()
     attr(results, "qlm_backend_meta") <- NULL
-  } else {
-    # Build system prompt from role and instructions
-    system_prompt <- if (!is.null(codebook$role)) {
-      paste(codebook$role, codebook$instructions, sep = "\n\n")
-    } else {
-      codebook$instructions
-    }
+  }
 
-    # Build chat object using ellmer::chat()
-    chat <- do.call(ellmer::chat, c(
-      list(
-        name = model,
-        system_prompt = system_prompt
-      ),
-      chat_args
-    ))
-
-    # Prepare prompts based on input type
-    if (codebook$input_type == "image") {
-      prompts <- lapply(x, ellmer::content_image_file)
-    } else {
-      prompts <- as.list(x)
-    }
-
-    # Execute with appropriate function based on batch parameter
-    if (batch) {
-      results <- do.call(ellmer::batch_chat_structured, c(
-        list(
-          chat = chat,
-          prompts = prompts,
-          type = codebook$schema
-        ),
-        execution_args
-      ))
-    } else {
-      results <- do.call(ellmer::parallel_chat_structured, c(
-        list(
-          chat = chat,
-          prompts = prompts,
-          type = codebook$schema
-        ),
-        execution_args
-      ))
-    }
+  backend_meta$structured <- structured
+  if (!is.null(fallback_reason)) {
+    backend_meta$fallback_reason <- fallback_reason
   }
 
   # Add ID column from input names or sequence
@@ -267,27 +309,152 @@ qlm_code <- function(x, codebook, model, ..., batch = FALSE, max_retries = 2L,
   )
 }
 
-#' Resolve the coding handler for a model
+#' Default structured-output mode for a model
 #'
-#' Providers that accept a JSON Schema but do not enforce it are coded by a
-#' dedicated handler rather than by [ellmer::parallel_chat_structured()]. This
-#' is the registry mapping a provider to its handler; adding a provider means
-#' adding an entry here and a handler function, not another branch in
-#' [qlm_code()].
+#' Providers whose API rejects the schema-constrained request outright should
+#' not spend a guaranteed-wasted round trip discovering that. DeepSeek is the
+#' known case: its endpoint answers `response_format` of type `json_schema`
+#' with HTTP 400, "This response_format type is unavailable now". Everything
+#' else defaults to attempting the structured call.
+#'
+#' Only a *default*: an explicit `structured =` always wins.
 #'
 #' @param model Provider (and optionally model) name, as passed to [qlm_code()].
 #'
-#' @return The handler function, or `NULL` when the default
-#'   [ellmer::parallel_chat_structured()] path should be used.
+#' @return One of `"auto"`, `"structured"` or `"json"`.
 #' @keywords internal
 #' @noRd
-code_handler_for <- function(model) {
+default_structured_mode <- function(model) {
   provider <- sub("/.*$", "", model)
 
   switch(provider,
-    deepseek = code_handler_json,
-    NULL
+    deepseek = "json",
+    "auto"
   )
+}
+
+
+#' Attempt schema-constrained structured output
+#'
+#' Wraps the [ellmer::parallel_chat_structured()] path so that [qlm_code()] can
+#' decide what to do when it does not work. Two things count as failure: the
+#' call throwing, and the call returning a table in which every required field
+#' is `NA` in every row, which is what an endpoint that accepted the schema and
+#' ignored it produces.
+#'
+#' @param x,codebook,model,chat_args,execution_args,batch As in [qlm_code()].
+#'
+#' @return A list with `ok`, and either `value` (the results) or `error`.
+#' @keywords internal
+#' @noRd
+try_structured_call <- function(x, codebook, model, chat_args, execution_args, batch) {
+  system_prompt <- if (!is.null(codebook$role)) {
+    paste(codebook$role, codebook$instructions, sep = "\n\n")
+  } else {
+    codebook$instructions
+  }
+
+  if (codebook$input_type == "image") {
+    prompts <- lapply(x, ellmer::content_image_file)
+  } else {
+    prompts <- as.list(x)
+  }
+
+  run <- function(prompt) {
+    chat <- do.call(ellmer::chat, c(
+      list(name = model, system_prompt = prompt),
+      chat_args
+    ))
+    warn_unenforced_schema(chat, model)
+
+    if (batch) {
+      do.call(ellmer::batch_chat_structured, c(
+        list(chat = chat, prompts = prompts, type = codebook$schema),
+        execution_args
+      ))
+    } else {
+      do.call(ellmer::parallel_chat_structured, c(
+        list(chat = chat, prompts = prompts, type = codebook$schema),
+        execution_args
+      ))
+    }
+  }
+
+  attempt <- tryCatch(
+    list(ok = TRUE, value = run(system_prompt)),
+    error = function(e) list(ok = FALSE, error = strip_ansi(conditionMessage(e)))
+  )
+
+  # Alibaba Model Studio refuses `response_format` unless the word "json"
+  # appears in the messages. That is a request-shape requirement, not a coding
+  # one, and the endpoint does enforce the schema once the request is accepted
+  # -- so satisfy it and retry rather than falling back and losing enforcement.
+  # The added sentence concerns output format only and names no coding
+  # criterion, so the substantive instrument is unchanged.
+  #
+  # Defensive: not reachable against ellmer's current request shape, which
+  # sends json_schema rather than json_object. See is_json_word_error().
+  if (!isTRUE(attempt$ok) && is_json_word_error(attempt$error)) {
+    retry_prompt <- paste(
+      system_prompt,
+      "Return your answer as a single JSON object.",
+      sep = "\n\n"
+    )
+    attempt <- tryCatch(
+      list(ok = TRUE, value = run(retry_prompt)),
+      error = function(e) list(ok = FALSE, error = strip_ansi(conditionMessage(e)))
+    )
+  }
+
+  if (isTRUE(attempt$ok) && all_required_missing(attempt$value, codebook$schema)) {
+    attempt <- list(
+      ok = FALSE,
+      error = paste0(
+        "the structured call returned no usable values (every required field ",
+        "was NA in all ", nrow(attempt$value), " row{s}); the endpoint appears ",
+        "not to honour the JSON schema"
+      )
+    )
+  }
+
+  attempt
+}
+
+
+#' Note when the provider does not guarantee schema enforcement
+#'
+#' Emitted once per session. The structured path is being trusted to return
+#' conforming output, and for anything on ellmer's generic OpenAI-compatible
+#' request path that trust is unverified: `strict = TRUE` is sent and may
+#' simply be ignored. Informational rather than a warning, because it describes
+#' a property of the endpoint, not a problem with this run.
+#'
+#' @param chat An [ellmer::Chat] object.
+#' @param model The model string, for the message.
+#'
+#' @return Invisibly `NULL`.
+#' @keywords internal
+#' @noRd
+warn_unenforced_schema <- function(chat, model) {
+  if (isTRUE(getOption("quallmer.quiet_schema_note", FALSE))) {
+    return(invisible(NULL))
+  }
+  provider <- tryCatch(chat$get_provider(), error = function(e) NULL)
+  if (is.null(provider) || provider_enforces_schema(provider)) {
+    return(invisible(NULL))
+  }
+
+  cli::cli_inform(
+    c(
+      "!" = "{.val {model}} is reached through an OpenAI-compatible endpoint, which may accept the output schema without enforcing it.",
+      "i" = "Non-conforming values arrive as {.val NA}, indistinguishable from missing data.",
+      "i" = "Use {.code structured = \"json\"} to validate each response against the codebook locally.",
+      "i" = "Silence this with {.code options(quallmer.quiet_schema_note = TRUE)}."
+    ),
+    .frequency = "once",
+    .frequency_id = "quallmer_schema_enforcement"
+  )
+  invisible(NULL)
 }
 
 
@@ -355,6 +522,9 @@ new_qlm_coded <- function(results, codebook, data, input_type, chat_args,
   if (!is.null(metadata$backend)) {
     object_meta$backend <- metadata$backend
   }
+  if (!is.null(metadata$structured)) {
+    object_meta$structured <- metadata$structured
+  }
 
   # Build user metadata: start with name and notes, then add custom metadata
   user_meta <- list(
@@ -364,7 +534,7 @@ new_qlm_coded <- function(results, codebook, data, input_type, chat_args,
 
   # Add any custom metadata fields (exclude system, object, and user-handled fields)
   system_fields <- c("timestamp", "ellmer_version", "quallmer_version", "R_version")
-  object_fields <- c("n_units", "source", "is_gold", "backend")
+  object_fields <- c("n_units", "source", "is_gold", "backend", "structured")
   user_handled <- c("name", "notes")
   exclude_fields <- c(system_fields, object_fields, user_handled)
 

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -52,6 +52,53 @@
 #' function. Set `verbose = TRUE` to see progress messages during coding.
 #' Retry logic for API failures should be configured through ellmer's options.
 #'
+#' @section Provider-specific parameters:
+#'
+#' `params` and `api_args` are forwarded to [ellmer::chat()] unchanged.
+#' quallmer does not inspect or rewrite either, so which of the two a setting
+#' belongs in is determined by ellmer and the provider, not here.
+#'
+#' The distinction matters. [ellmer::params()] carries provider-agnostic
+#' settings that ellmer translates per provider; `api_args` goes into the raw
+#' request body untouched. A setting placed in the wrong one is not
+#' necessarily rejected. For OpenAI-compatible providers ellmer maps `top_k`
+#' onto the OpenAI field `top_logprobs`, which asks for log-probabilities per
+#' token and has nothing to do with top-k sampling — so
+#' `params(top_k = 20)` is rejected by Alibaba Model Studio
+#' (`Range of top_logprobs should be [0, 5]`), while `params(top_k = 3)` is
+#' accepted and silently applies no sampling setting at all. Non-OpenAI
+#' sampling controls therefore belong in `api_args`:
+#'
+#' ```r
+#' # Qwen through Alibaba Model Studio
+#' qlm_code(
+#'   x, codebook,
+#'   model = "openai_compatible/qwen3-max",
+#'   base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+#'   credentials = function() {
+#'     list(Authorization = paste("Bearer", Sys.getenv("DASHSCOPE_API_KEY")))
+#'   },
+#'   params = ellmer::params(temperature = 0.6, top_p = 0.95),
+#'   api_args = list(top_k = 20, min_p = 0, enable_thinking = TRUE)
+#' )
+#'
+#' # Kimi K3 through Moonshot, whose temperature and top_p are fixed by the
+#' # provider and documented as needing to be omitted rather than set
+#' qlm_code(
+#'   x, codebook,
+#'   model = "openai_compatible/kimi-k3",
+#'   base_url = "https://api.moonshot.ai/v1",
+#'   credentials = function() {
+#'     list(Authorization = paste("Bearer", Sys.getenv("MOONSHOT_API_KEY")))
+#'   },
+#'   api_args = list(reasoning_effort = "max")
+#' )
+#' ```
+#'
+#' Passing a model parameter such as `temperature` or `max_tokens` at the top
+#' level does not work: those reach [ellmer::chat()], which has no such
+#' argument. Use `params`.
+#'
 #' @section Schema enforcement:
 #'
 #' Some providers accept a JSON Schema without enforcing it, so a response can
@@ -79,6 +126,15 @@
 #' `"auto"` catches wholesale non-enforcement, not the intermittent kind: a
 #' single non-conforming row among many leaves that check silent. Only
 #' `"json"` catches that, at the cost of putting the schema in the prompt.
+#'
+#' That check also needs something to look at. It reads required scalar
+#' properties, because those become ordinary columns; required arrays and
+#' nested objects become list-columns in which a missing value and a
+#' schema-valid empty one are the same zero-length cell, and cannot be told
+#' apart. So for a codebook whose required properties are all arrays or nested
+#' objects, `"auto"` on an unverified endpoint validates locally from the
+#' start rather than making a call it could not check, and says so. Use
+#' `"structured"` to rely on the provider regardless.
 #'
 #' On the JSON path, units that never validate have `NA` coded values and a
 #' `.error` list-column recording the reason, and `max_retries` controls how
@@ -202,6 +258,18 @@ qlm_code <- function(x, codebook, model, ...,
   # to pass through to ellmer::chat() which forwards them to the provider
   chat_args <- dots[!dot_names %in% execution_arg_names]
 
+  # ellmer returns a bare list under convert = FALSE, which has no rows to
+  # merge an .id into and no columns for new_qlm_coded() to reorder. It has
+  # never worked here; say so rather than failing later with "incorrect number
+  # of dimensions".
+  if (identical(execution_args$convert, FALSE)) {
+    cli::cli_abort(c(
+      "{.code convert = FALSE} is not supported by {.fn qlm_code}.",
+      "i" = "A {.cls qlm_coded} object is built from the converted table, one row per unit.",
+      "i" = "For the unconverted list, call {.fn ellmer::parallel_chat_structured} directly."
+    ))
+  }
+
   # Metadata contributed by the coding path
   backend_meta <- list()
   results <- NULL
@@ -211,7 +279,8 @@ qlm_code <- function(x, codebook, model, ...,
   if (structured %in% c("auto", "structured")) {
     attempt <- try_structured_call(
       x = x, codebook = codebook, model = model,
-      chat_args = chat_args, execution_args = execution_args, batch = batch
+      chat_args = chat_args, execution_args = execution_args, batch = batch,
+      allow_skip = identical(structured, "auto") && !batch
     )
 
     if (isTRUE(attempt$ok)) {
@@ -223,6 +292,16 @@ qlm_code <- function(x, codebook, model, ...,
           "{incomplete} row{?s} from the structured call {?is/are} missing at least one required field."
         )
       }
+    } else if (isTRUE(attempt$undetectable)) {
+      # Not a failure: no request was made. Informational, because the choice
+      # is a consequence of the codebook and the endpoint, not of anything
+      # going wrong.
+      fallback_reason <- attempt$error
+      cli::cli_inform(c(
+        "i" = "Coding {.val {model}} in JSON mode with local validation.",
+        "i" = attempt$error,
+        "i" = "Use {.code structured = \"structured\"} to rely on the provider instead."
+      ))
     } else if (identical(structured, "structured")) {
       cli::cli_abort(c(
         "Structured output failed for model {.val {model}}.",
@@ -347,7 +426,8 @@ default_structured_mode <- function(model) {
 #' @return A list with `ok`, and either `value` (the results) or `error`.
 #' @keywords internal
 #' @noRd
-try_structured_call <- function(x, codebook, model, chat_args, execution_args, batch) {
+try_structured_call <- function(x, codebook, model, chat_args, execution_args, batch,
+                                allow_skip = FALSE) {
   system_prompt <- if (!is.null(codebook$role)) {
     paste(codebook$role, codebook$instructions, sep = "\n\n")
   } else {
@@ -360,13 +440,42 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
     prompts <- as.list(x)
   }
 
-  run <- function(prompt) {
-    chat <- do.call(ellmer::chat, c(
-      list(name = model, system_prompt = prompt),
-      chat_args
-    ))
-    warn_unenforced_schema(chat, model)
+  build_chat <- function(prompt) {
+    do.call(ellmer::chat, c(list(name = model, system_prompt = prompt), chat_args))
+  }
+  chat <- build_chat(system_prompt)
 
+  # Whether a failed structured call would even be visible depends on the
+  # codebook. Failure is detected from required scalar fields coming back all
+  # NA; a codebook whose required properties are all arrays or nested objects
+  # offers no such signal, because ellmer renders those as list-columns where a
+  # missing value and a schema-valid empty one are the same zero-length cell.
+  #
+  # So on an endpoint whose enforcement cannot be verified, a structured call
+  # over such a codebook would be trusted with no way to check it. Validate
+  # locally instead, and say why. `structured = "structured"` remains the way
+  # to ask for provider enforcement regardless.
+  provider <- tryCatch(chat$get_provider(), error = function(e) NULL)
+  undetectable <- allow_skip &&
+    !is.null(provider) &&
+    !provider_enforces_schema(provider) &&
+    !length(required_scalar_fields(codebook$schema))
+
+  if (undetectable) {
+    return(list(
+      ok = FALSE,
+      undetectable = TRUE,
+      error = paste0(
+        "this endpoint's schema enforcement cannot be verified, and the ",
+        "codebook has no required scalar field whose absence would reveal a ",
+        "failed structured call"
+      )
+    ))
+  }
+
+  warn_unenforced_schema(chat, model)
+
+  run <- function(chat) {
     if (batch) {
       do.call(ellmer::batch_chat_structured, c(
         list(chat = chat, prompts = prompts, type = codebook$schema),
@@ -381,7 +490,7 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
   }
 
   attempt <- tryCatch(
-    list(ok = TRUE, value = run(system_prompt)),
+    list(ok = TRUE, value = run(chat)),
     error = function(e) list(ok = FALSE, error = strip_ansi(conditionMessage(e)))
   )
 
@@ -401,7 +510,7 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
       sep = "\n\n"
     )
     attempt <- tryCatch(
-      list(ok = TRUE, value = run(retry_prompt)),
+      list(ok = TRUE, value = run(build_chat(retry_prompt))),
       error = function(e) list(ok = FALSE, error = strip_ansi(conditionMessage(e)))
     )
   }
@@ -411,7 +520,9 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
       ok = FALSE,
       error = paste0(
         "the structured call returned no usable values (every required field ",
-        "was NA in all ", nrow(attempt$value), " row{s}); the endpoint appears ",
+        "was NA in all ", nrow(attempt$value),
+        if (nrow(attempt$value) == 1L) " row" else " rows",
+        "); the endpoint appears ",
         "not to honour the JSON schema"
       )
     )

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -208,14 +208,8 @@ qlm_code <- function(x, codebook, model, ...,
   }
 
   # Get valid argument names from ellmer functions
-  chat_arg_names <- names(formals(ellmer::chat))
   pcs_arg_names <- names(formals(ellmer::parallel_chat_structured))
   batch_arg_names <- names(formals(ellmer::batch_chat_structured))
-
-  # Common model parameters that should go in params
-  model_param_names <- c("temperature", "max_tokens", "top_p", "top_k",
-                         "frequency_penalty", "presence_penalty", "stop",
-                         "seed", "response_format")
 
   # Route ... arguments
   # execution_args go to parallel_chat_structured or batch_chat_structured

--- a/R/qlm_code_json.R
+++ b/R/qlm_code_json.R
@@ -143,16 +143,17 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
         # unauthorised. A refusal or an over-long document also arrives as a
         # fatal status, but says nothing about the run as a whole, so neither
         # counts towards the all-failed abort below.
+        refusal <- is_content_refusal(checked$error)
+        length_rejection <- is_length_rejection(checked$error)
         fatal[[i]] <- is_fatal_status(turns$status[[j]]) &&
-          !is_content_refusal(checked$error) &&
-          !is_length_rejection(checked$error)
+          !refusal && !length_rejection
         # Content refusals are deliberately retried. They look deterministic
         # and are not: the same document is refused on one pass and coded on
         # the next, at more than one provider. Refusals are rejected before
         # generation and billed at zero tokens, so a wasted attempt is free,
         # whereas dropping the unit discards a coding a retry would have got.
         # Only a context-length rejection is provably unrecoverable.
-        if (!is_length_rejection(checked$error)) {
+        if (!length_rejection && !fatal[[i]]) {
           next_pending <- c(next_pending, i)
         }
       }
@@ -160,9 +161,9 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
 
     # A run that fails in its entirety on the first attempt is misconfigured --
     # a wrong model name, a bad credential -- so stop before spending retries
-    # on it. Checked here rather than by dropping individual units, so that a
-    # single unit failing with the same status (an over-long document, a
-    # refusal) is still retried.
+    # on it. Checked at run level so a content refusal does not masquerade as
+    # bad configuration; refusals remain retryable, while over-long documents
+    # and other terminal per-unit failures have already left the retry queue.
     if (attempt == 0L && all(vapply(parsed, is.null, logical(1))) && all(fatal)) {
       break
     }
@@ -611,9 +612,21 @@ api_error_detail <- function(cnd) {
     jsonlite::fromJSON(text, simplifyVector = FALSE),
     error = function(e) NULL
   )
-  # OpenAI-compatible errors nest the message under `error`; some providers
-  # put it at the top level.
-  detail <- parsed$error$message %||% parsed$message %||% parsed$error
+  if (!is.list(parsed)) {
+    return(NA_character_)
+  }
+  # OpenAI-compatible errors usually nest the message under `error`, but some
+  # providers return a scalar `error` string or put `message` at the top level.
+  nested_error <- parsed$error
+  nested_detail <- if (is.list(nested_error)) {
+    nested_error$message
+  } else if (is.character(nested_error) && length(nested_error) == 1L &&
+             nzchar(nested_error)) {
+    nested_error
+  } else {
+    NULL
+  }
+  detail <- nested_detail %||% parsed$message
   if (!is.character(detail) || length(detail) != 1L || !nzchar(detail)) {
     return(NA_character_)
   }
@@ -722,9 +735,14 @@ is_length_rejection <- function(msg) {
     return(FALSE)
   }
   grepl(
-    "maximum context length|context length|range of input length|too long|exceeds .*token",
+    paste0(
+      "maximum context length|context[ -]?length|context window|",
+      "range of input length|(?:input|prompt|document)(?: is|'s)? too long|",
+      "exceeds?.{0,40}(?:token|context)|too many (?:input )?tokens"
+    ),
     msg,
-    ignore.case = TRUE
+    ignore.case = TRUE,
+    perl = TRUE
   )
 }
 

--- a/R/qlm_code_json.R
+++ b/R/qlm_code_json.R
@@ -785,3 +785,143 @@ ellmer_convert_from_type <- function(x, type) {
   }
   converter(x, type)
 }
+
+
+#' Required properties whose absence is detectable in the result table
+#'
+#' Restricted to required scalar properties, because those are the ones
+#' [ellmer::parallel_chat_structured()] renders as a single column that can be
+#' checked for `NA`. Arrays and nested objects become list-columns, where "the
+#' model returned nothing useful" has no simple representation.
+#'
+#' @param schema An [ellmer::type_object()].
+#'
+#' @return A character vector of property names.
+#' @keywords internal
+#' @noRd
+required_scalar_fields <- function(schema) {
+  if (!inherits(schema, "ellmer::TypeObject")) {
+    return(character())
+  }
+  properties <- schema@properties
+  keep <- vapply(properties, function(p) {
+    isTRUE(p@required) && inherits(p, c("ellmer::TypeBasic", "ellmer::TypeEnum"))
+  }, logical(1))
+  names(properties)[keep]
+}
+
+
+#' Did the structured call return nothing usable at all?
+#'
+#' A structured call can succeed at the HTTP level and still return a table in
+#' which every required field is `NA` in every row: the endpoint accepted the
+#' JSON schema and ignored it, so ellmer had nothing to map onto the type and
+#' emitted `NA` rather than an error. Observed with `qwen3.5-397b-a17b` through
+#' Alibaba Model Studio. Erroring is therefore not a sufficient test of whether
+#' the structured path worked.
+#'
+#' @param results The result of [ellmer::parallel_chat_structured()].
+#' @param schema An [ellmer::type_object()].
+#'
+#' @return `TRUE` when the call produced no usable values.
+#' @keywords internal
+#' @noRd
+all_required_missing <- function(results, schema) {
+  # A user may have passed convert = FALSE, in which case there is no table to
+  # inspect and no basis for calling the attempt a failure.
+  if (!is.data.frame(results) || !nrow(results)) {
+    return(FALSE)
+  }
+  fields <- intersect(required_scalar_fields(schema), names(results))
+  if (!length(fields)) {
+    return(FALSE)
+  }
+  all(vapply(fields, function(f) all(is.na(results[[f]])), logical(1)))
+}
+
+
+#' How many rows are missing at least one required field?
+#'
+#' Partial failure, which is worth reporting but is not grounds for discarding
+#' the whole attempt and re-coding in JSON mode.
+#'
+#' @param results The result of [ellmer::parallel_chat_structured()].
+#' @param schema An [ellmer::type_object()].
+#'
+#' @return An integer count.
+#' @keywords internal
+#' @noRd
+n_incomplete <- function(results, schema) {
+  if (!is.data.frame(results) || !nrow(results)) {
+    return(0L)
+  }
+  fields <- intersect(required_scalar_fields(schema), names(results))
+  if (!length(fields)) {
+    return(0L)
+  }
+  sum(Reduce(`|`, lapply(fields, function(f) is.na(results[[f]]))))
+}
+
+
+#' Does this provider enforce the output schema by construction?
+#'
+#' Derived from ellmer's own dispatch rather than from a list of vendors.
+#' These provider classes define their own `chat_body()` method using a
+#' mechanism the provider is documented to enforce: OpenAI's `/responses`
+#' format with `strict = TRUE`, Anthropic's native structured output or a
+#' forced tool call, Gemini's `response_schema`, Bedrock's forced tool call,
+#' Snowflake's typed `response_format`.
+#'
+#' Everything else falls through to `ProviderOpenAICompatible`'s method, which
+#' sends `response_format = {type: "json_schema", strict: true}` and takes the
+#' answer on trust. Whether that is honoured is up to the endpoint, and
+#' measurement shows it often is not.
+#'
+#' Deriving this rather than tabulating it means a provider ellmer adds later
+#' defaults to "cannot vouch for this", which is the safe direction.
+#'
+#' @param provider A provider object from `chat$get_provider()`.
+#'
+#' @return `TRUE` when the schema is enforced by the provider's mechanism.
+#' @keywords internal
+#' @noRd
+provider_enforces_schema <- function(provider) {
+  enforcing <- c(
+    "ellmer::ProviderOpenAI",
+    "ellmer::ProviderAnthropic",
+    "ellmer::ProviderGoogleGemini",
+    "ellmer::ProviderAWSBedrock",
+    "ellmer::ProviderSnowflakeCortex"
+  )
+  any(class(provider) %in% enforcing)
+}
+
+
+#' Is this the DashScope "messages must contain the word json" rejection?
+#'
+#' Alibaba Model Studio rejects any request that sets `response_format` unless
+#' the word "json" appears somewhere in the messages, and
+#' [ellmer::parallel_chat_structured()] sets `response_format` from the schema.
+#' The structured call would therefore fail for a reason that has nothing to do
+#' with the codebook, on an endpoint that does enforce the schema once the
+#' request is accepted. Recognising it lets us satisfy the requirement and keep
+#' the enforcement, rather than falling back and losing it.
+#'
+#' NOT OBSERVED against ellmer's current request shape. The rejection was seen
+#' on 2026-08-12 with `response_format` of type `json_object`; ellmer sends type
+#' `json_schema`, which Model Studio accepted without complaint when this was
+#' checked live on 2026-09-02. This is therefore defensive: if the requirement
+#' does apply, one retry preserves enforcement; if it never fires, nothing
+#' happens. Do not read its presence as evidence that the quirk is live.
+#'
+#' @param msg An error message.
+#'
+#' @return `TRUE` when the request needs the word "json" in its prompt.
+#' @keywords internal
+#' @noRd
+is_json_word_error <- function(msg) {
+  if (!length(msg) || is.na(msg)) {
+    return(FALSE)
+  }
+  grepl("must contain the word ['\"]?json", msg, ignore.case = TRUE)
+}

--- a/R/qlm_replicate.R
+++ b/R/qlm_replicate.R
@@ -7,6 +7,12 @@
 #' Credentials and endpoint settings are an exception, and are carried over
 #' only while the endpoint itself is unchanged.
 #'
+#' The coding path is reproduced from the path the original run actually took,
+#' not the `structured` mode it requested: a run that asked for `"auto"` and
+#' fell back to JSON mode replicates as `"json"`, so that an intermittently
+#' conforming endpoint cannot quietly skip the local validation the original
+#' relied on. Pass `structured` explicitly to override.
+#'
 #' @param x A `qlm_coded` object.
 #' @param ... Optional overrides passed to [qlm_code()], such as `params`,
 #'   `api_args`, or `max_active`. Any setting not overridden is restored from
@@ -163,12 +169,28 @@ qlm_replicate <- function(x, ..., codebook = NULL, model = NULL, batch = NULL, n
   call_args <- modifyList(original_args, overrides)
 
   # `structured` and `max_retries` are formals of qlm_code(), so they are
-  # recorded in the run metadata rather than in chat_args. Reproducing the
-  # original run means reproducing the coding path it took, not just its chat
-  # settings. An explicit override in `...` is left alone.
-  original_structured <- meta_attr$object$structured
-  if (!"structured" %in% names(call_args) && !is.null(original_structured)) {
-    call_args$structured <- original_structured
+  # recorded in the run metadata rather than in chat_args. An explicit override
+  # in `...` is left alone.
+  #
+  # Derived from `backend`, the path the run actually took, NOT from
+  # `structured`, the mode it asked for. A run that requested "auto" and fell
+  # back to JSON mode must replicate in JSON mode: requesting "auto" again
+  # would let an intermittently-conforming endpoint take the structured path
+  # this time, skipping the local validation the original relied on, so the two
+  # runs would not be comparable -- which is the whole point of replicating.
+  #
+  # Deriving from `backend` also covers objects coded before `structured`
+  # existed, which record a backend but no mode.
+  original_backend <- meta_attr$object$backend
+  original_mode <- if (identical(original_backend, "json_mode")) {
+    "json"
+  } else if (identical(original_backend, "structured")) {
+    "structured"
+  } else {
+    NULL
+  }
+  if (!"structured" %in% names(call_args) && !is.null(original_mode)) {
+    call_args$structured <- original_mode
   }
   # max_retries has no effect on the purely structured path, where supplying it
   # is an error, so carry it only where it can apply.

--- a/R/qlm_replicate.R
+++ b/R/qlm_replicate.R
@@ -4,13 +4,23 @@
 #' modified settings. If no overrides are provided, uses identical settings
 #' to the original coding: both the execution arguments and the arguments the
 #' original run passed to [ellmer::chat()], such as `params` and `api_args`.
+#' Credentials and endpoint settings are an exception, and are carried over
+#' only while the endpoint itself is unchanged.
 #'
 #' @param x A `qlm_coded` object.
 #' @param ... Optional overrides passed to [qlm_code()], such as `params`,
 #'   `api_args`, or `max_active`. Any setting not overridden is restored from
-#'   the original run, including the arguments it passed to [ellmer::chat()].
-#'   Registered `tools` are the one exception: they are provider-specific and
-#'   are not carried over.
+#'   the original run when the endpoint is unchanged, including the arguments
+#'   it passed to [ellmer::chat()]. An endpoint is identified by both the
+#'   provider prefix and `base_url`, since every provider ellmer has no
+#'   `chat_*()` for is reached as `openai_compatible/<model>` — so Qwen through
+#'   Alibaba Model Studio and Kimi through Moonshot share a prefix while being
+#'   different services with different credentials. When either changes, only
+#'   portable chat settings (`params` and `echo`) are carried over; supply
+#'   credentials, endpoint settings and other endpoint-specific arguments
+#'   explicitly. An informational message names inherited arguments that were
+#'   omitted and not explicitly replaced. Registered `tools` are never carried
+#'   over.
 #' @param codebook Optional replacement codebook. If `NULL` (default), uses
 #'   the codebook from `x`.
 #' @param model Optional replacement model (e.g., `"openai/gpt-4o"`). If `NULL`
@@ -62,10 +72,10 @@ qlm_replicate <- function(x, ..., codebook = NULL, model = NULL, batch = NULL, n
   # Ensure it's always a list (empty if NULL)
   original_execution_args <- meta_attr$object$execution_args %||% list()
   # Everything the original passed to ellmer::chat() -- params, api_args,
-  # base_url, credentials -- must be restored too, or a replication runs with
-  # different model settings than the run it claims to replicate. Two
-  # exclusions: `name` is the model and is passed separately, and `tools` are
-  # provider-specific objects that would error against a different provider.
+  # base_url, credentials -- must be restored for the same provider, or a
+  # replication runs with different model settings than the run it claims to
+  # replicate. Two exclusions: `name` is the model and is passed separately,
+  # and registered `tools` are not safe to recreate automatically.
   original_chat_args <- meta_attr$object$chat_args %||% list()
   original_chat_args[c("name", "tools")] <- NULL
   # Extract batch flag (default to FALSE for backward compatibility)
@@ -81,6 +91,57 @@ qlm_replicate <- function(x, ..., codebook = NULL, model = NULL, batch = NULL, n
   # Apply overrides (NULL means use original)
   use_codebook <- codebook %||% original_codebook
   use_model <- model %||% original_model
+  overrides <- list(...)
+
+  # Credentials and endpoint settings belong to an endpoint, not to a model in
+  # the abstract. Carrying them across endpoints can send a credential to the
+  # wrong service, or point the replacement model at the original host.
+  #
+  # The prefix alone is not enough to identify an endpoint. Providers ellmer
+  # has no `chat_*()` for are all reached as `openai_compatible/<model>`, so
+  # Qwen through Alibaba Model Studio and Kimi through Moonshot share a prefix
+  # while being entirely different services with different credentials. What
+  # distinguishes them is `base_url`, so that is part of the identity too.
+  #
+  # A `base_url` supplied in `...` counts as a change: the caller is pointing
+  # this run at a different host, so the credential inherited for the old one
+  # must not travel with it.
+  original_endpoint <- list(
+    provider = sub("/.*$", "", original_model),
+    base_url = original_chat_args$base_url %||% NA_character_
+  )
+  use_endpoint <- list(
+    provider = sub("/.*$", "", use_model),
+    base_url = overrides$base_url %||% original_chat_args$base_url %||% NA_character_
+  )
+
+  if (!identical(original_endpoint, use_endpoint)) {
+    portable_chat_args <- c("params", "echo")
+    endpoint_bound_args <- setdiff(names(original_chat_args), portable_chat_args)
+    omitted_args <- setdiff(endpoint_bound_args, names(overrides))
+    omitted_args <- unique(omitted_args[nzchar(omitted_args)])
+    if (length(omitted_args)) {
+      changed <- if (!identical(original_endpoint$provider, use_endpoint$provider)) {
+        paste0("provider from \"", original_endpoint$provider, "\" to \"",
+               use_endpoint$provider, "\"")
+      } else {
+        paste0("endpoint from \"", original_endpoint$base_url, "\" to \"",
+               use_endpoint$base_url, "\"")
+      }
+      omitted_text <- paste0("`", omitted_args, "`", collapse = ", ")
+      cli::cli_inform(c(
+        "i" = paste0(
+          "Changing ", changed, "; not carrying over endpoint-specific argument",
+          if (length(omitted_args) == 1L) "" else "s", ": ", omitted_text,
+          ". Supply ", if (length(omitted_args) == 1L) "it" else "them",
+          " explicitly in `...` if needed."
+        )
+      ))
+    }
+    original_chat_args <- original_chat_args[
+      names(original_chat_args) %in% portable_chat_args
+    ]
+  }
 
   # Determine run name
   if (is.null(name)) {
@@ -98,7 +159,6 @@ qlm_replicate <- function(x, ..., codebook = NULL, model = NULL, batch = NULL, n
   # execution_args are disjoint by construction -- qlm_code() splits `...`
   # between them by name -- so they can be merged here and re-split there,
   # keeping one source of truth for the routing rules.
-  overrides <- list(...)
   original_args <- c(original_chat_args, original_execution_args)
   call_args <- modifyList(original_args, overrides)
 

--- a/R/qlm_replicate.R
+++ b/R/qlm_replicate.R
@@ -102,14 +102,18 @@ qlm_replicate <- function(x, ..., codebook = NULL, model = NULL, batch = NULL, n
   original_args <- c(original_chat_args, original_execution_args)
   call_args <- modifyList(original_args, overrides)
 
-  # max_retries is a formal of qlm_code(), so it is recorded in the run
-  # metadata rather than in chat_args. Carry it only when the target model can
-  # still honour it: replicating with a different provider is legitimate, and
-  # passing it to one without a JSON-mode handler would abort. An explicit
-  # override in `...` is left alone, so that case errors as it should.
+  # `structured` and `max_retries` are formals of qlm_code(), so they are
+  # recorded in the run metadata rather than in chat_args. Reproducing the
+  # original run means reproducing the coding path it took, not just its chat
+  # settings. An explicit override in `...` is left alone.
+  original_structured <- meta_attr$object$structured
+  if (!"structured" %in% names(call_args) && !is.null(original_structured)) {
+    call_args$structured <- original_structured
+  }
+  # max_retries has no effect on the purely structured path, where supplying it
+  # is an error, so carry it only where it can apply.
   if (!"max_retries" %in% names(call_args) &&
-      is.character(use_model) && length(use_model) == 1L &&
-      !is.null(code_handler_for(use_model))) {
+      !identical(call_args$structured, "structured")) {
     original_retries <- meta_attr$user$max_retries
     if (!is.null(original_retries)) {
       call_args$max_retries <- original_retries

--- a/dev/deepseek-live-check.R
+++ b/dev/deepseek-live-check.R
@@ -38,8 +38,9 @@ texts <- c(
 # Confirms routing and the guard rails without spending anything.
 
 stopifnot(
-  identical(quallmer:::code_handler_for(MODEL)$fn, quallmer:::code_handler_json),
-  is.null(quallmer:::code_handler_for("openai/gpt-4o-mini"))
+  # DeepSeek rejects the schema-constrained request, so it starts in JSON mode
+  identical(quallmer:::default_structured_mode(MODEL), "json"),
+  identical(quallmer:::default_structured_mode("openai/gpt-4o-mini"), "auto")
 )
 
 # The exact system prompt DeepSeek will receive. Worth reading once: if the

--- a/dev/probe-schema-enforcement.R
+++ b/dev/probe-schema-enforcement.R
@@ -146,6 +146,38 @@ if (interactive()) {
   ), right = FALSE, row.names = FALSE)
 }
 
+# Natural-rate probe: the same question without the adversarial instruction.
+# The adversarial probe answers "does this endpoint enforce"; this one answers
+# "how often does it actually matter", which is a different and lower number.
+# convert = FALSE again, or convert_from_type() hides the evidence.
+probe_natural <- function(label, base_url, key, model, codebook, texts) {
+  ch <- ellmer::chat_openai_compatible(
+    base_url = base_url, credentials = function() key, model = model,
+    echo = "none",
+    system_prompt = if (is.null(codebook$role)) codebook$instructions
+                    else paste(codebook$role, codebook$instructions, sep = "\n\n"))
+  out <- tryCatch(
+    ellmer::parallel_chat_structured(ch, as.list(texts), type = codebook$schema,
+                                     convert = FALSE),
+    error = function(e) e)
+  if (inherits(out, "error")) {
+    return(data.frame(model = label, verdict = "error",
+                      detail = substr(conditionMessage(out), 1, 60)))
+  }
+  bad <- character()
+  for (v in out) {
+    if (is.null(v)) next
+    chk <- tryCatch(quallmer:::validate_against_type(v, codebook$schema, "$"),
+                    error = function(e) e)
+    if (inherits(chk, "error")) bad <- c(bad, conditionMessage(chk))
+  }
+  data.frame(model = label,
+             verdict = if (length(bad)) "NOT ENFORCED" else "no violation seen",
+             detail = sprintf("%d/%d non-conforming%s", length(bad), length(texts),
+                              if (length(bad)) paste0(": ", bad[[1]]) else ""))
+}
+
+
 # Observed 2026-09-01, ellmer 0.4.2, 3 trials each:
 #
 #   openai/gpt-4o-mini               no violation seen   0/3
@@ -162,3 +194,19 @@ if (interactive()) {
 #
 # Note kimi-k3 differs by route, and both failures were intermittent. The probe
 # can prove non-enforcement; it cannot prove enforcement.
+#
+# Natural rate, 2026-09-02, probe_natural():
+#
+#   data_codebook_sentiment (1 enum, 1 integer), 25 texts
+#     kimi-k3 [dashscope]  0/25        kimi-k3 [moonshot]  0/25
+#
+#   complex codebook (nested array, 4 enums, bounded numbers), 15 passages
+#     kimi-k3 [dashscope]  1/15  -> $ has unexpected properties: in_group, out_group
+#     kimi-k3 [moonshot]   0/15        qwen-flash [dashscope]  0/15
+#
+# So: low on a simple schema, non-zero on a complex one. That single violation
+# is instructive -- the instructions asked for an in-group and out-group, the
+# schema had no slot for either, and the model invented two properties.
+# additionalProperties: false makes that impossible on an enforcing endpoint,
+# and under the default convert = TRUE the extra keys are silently dropped and
+# the row looks perfect.

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -10,6 +10,7 @@ qlm_code(
   model,
   ...,
   batch = FALSE,
+  structured = c("auto", "structured", "json"),
   max_retries = 2L,
   name = NULL,
   notes = NULL
@@ -41,12 +42,19 @@ instead of \code{\link[ellmer:parallel_chat_structured]{ellmer::parallel_chat_st
 cost-effective for large jobs but may have longer turnaround times.
 Default is \code{FALSE}. See \code{\link[ellmer:batch_chat_structured]{ellmer::batch_chat_structured()}} for details.}
 
+\item{structured}{How the output schema is obtained. \code{"structured"} uses
+\code{\link[ellmer:parallel_chat_structured]{ellmer::parallel_chat_structured()}} and trusts the provider to enforce
+the schema. \code{"json"} asks for JSON, puts the schema in the system prompt,
+and validates every response against the codebook locally. \code{"auto"} (the
+default) attempts the structured call and falls back to \code{"json"} if it
+fails. See Details for which to use.}
+
 \item{max_retries}{Number of additional attempts made for a response that
-arrives intact but does not conform to the codebook schema. Applies only to
-providers coded in JSON mode (see Details); setting it for any other
-provider is an error. Default is 2, giving at most three attempts per unit.
-This is separate from ellmer's transport-level retries for rate limits and
-server errors, which apply to every provider and are set with
+arrives intact but does not conform to the codebook schema. Applies on the
+JSON path only, so setting it alongside \code{structured = "structured"} is an
+error. Default is 2, giving at most three attempts per unit. This is
+separate from ellmer's transport-level retries for rate limits and server
+errors, which apply to every provider and are set with
 \code{options(ellmer_max_tries = )}.}
 
 \item{name}{Character string identifying this coding run. Default is \code{NULL}.}
@@ -79,17 +87,42 @@ Progress indicators and error handling are provided by the underlying
 \code{\link[ellmer:parallel_chat_structured]{ellmer::parallel_chat_structured()}} or \code{\link[ellmer:batch_chat_structured]{ellmer::batch_chat_structured()}}
 function. Set \code{verbose = TRUE} to see progress messages during coding.
 Retry logic for API failures should be configured through ellmer's options.
+}
+\section{Schema enforcement}{
 
-Some providers accept a JSON Schema but do not enforce it, so a response can
-come back parseable but non-conforming, and the non-conformance then arrives
-silently as \code{NA}. For those providers \code{qlm_code()} routes to a JSON-mode
-handler that puts the schema in the system prompt, validates every response
-against the codebook schema locally, and re-prompts the model with the
-specific validation error when a response does not conform. This currently
-applies to \code{"deepseek"}. Units that never validate have \code{NA} coded values and
-a \code{.error} list-column recording the reason. \code{max_retries} controls how many
-repair attempts each unit gets. Batch processing and image codebooks are not
-supported on this path.
+
+Some providers accept a JSON Schema without enforcing it, so a response can
+come back parseable but non-conforming — and the non-conformance then arrives
+silently as \code{NA}, indistinguishable from missing data. Providers reached
+through ellmer's generic OpenAI-compatible request path are all in this
+position: \code{strict = TRUE} is sent and may simply be ignored. \code{qlm_code()}
+emits a one-time note when it detects one, which
+\code{options(quallmer.quiet_schema_note = TRUE)} silences.
+
+\code{structured} chooses what to do about it:
+
+\describe{
+\item{\code{"structured"}}{Trust the provider. Fails loudly if the call fails.}
+\item{\code{"json"}}{Never trust it: ask for JSON, put the schema in the system
+prompt, and validate each response against \code{codebook$schema} locally,
+re-prompting with the specific validation error when one does not
+conform. The reliable choice for an endpoint known not to enforce.}
+\item{\code{"auto"}}{Attempt the structured call; fall back to \code{"json"} if it
+errors, or if it returns a result in which every required field is \code{NA}
+in every row, which is what an endpoint that ignored the schema
+produces.}
+}
+
+\code{"auto"} catches wholesale non-enforcement, not the intermittent kind: a
+single non-conforming row among many leaves that check silent. Only
+\code{"json"} catches that, at the cost of putting the schema in the prompt.
+
+On the JSON path, units that never validate have \code{NA} coded values and a
+\code{.error} list-column recording the reason, and \code{max_retries} controls how
+many repair attempts each unit gets. Batch processing and image codebooks
+are not supported there, so \code{"auto"} will not fall back under
+\code{batch = TRUE}. The path actually taken is recorded in the run metadata as
+\code{backend}.
 
 When \code{batch = TRUE}, the function uses \code{\link[ellmer:batch_chat_structured]{ellmer::batch_chat_structured()}}
 which submits jobs to the provider's batch API. This is typically more
@@ -97,6 +130,7 @@ cost-effective but has longer turnaround times. The \code{path} argument specifi
 where batch results are cached, \code{wait} controls whether to wait for completion,
 and \code{ignore_hash} can force reprocessing of cached results.
 }
+
 \examples{
 # Requires API credentials and internet access; not run in package checks.
 \dontrun{

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -88,6 +88,54 @@ Progress indicators and error handling are provided by the underlying
 function. Set \code{verbose = TRUE} to see progress messages during coding.
 Retry logic for API failures should be configured through ellmer's options.
 }
+\section{Provider-specific parameters}{
+
+
+\code{params} and \code{api_args} are forwarded to \code{\link[ellmer:chat]{ellmer::chat()}} unchanged.
+quallmer does not inspect or rewrite either, so which of the two a setting
+belongs in is determined by ellmer and the provider, not here.
+
+The distinction matters. \code{\link[ellmer:params]{ellmer::params()}} carries provider-agnostic
+settings that ellmer translates per provider; \code{api_args} goes into the raw
+request body untouched. A setting placed in the wrong one is not
+necessarily rejected. For OpenAI-compatible providers ellmer maps \code{top_k}
+onto the OpenAI field \code{top_logprobs}, which asks for log-probabilities per
+token and has nothing to do with top-k sampling — so
+\code{params(top_k = 20)} is rejected by Alibaba Model Studio
+(\verb{Range of top_logprobs should be [0, 5]}), while \code{params(top_k = 3)} is
+accepted and silently applies no sampling setting at all. Non-OpenAI
+sampling controls therefore belong in \code{api_args}:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Qwen through Alibaba Model Studio
+qlm_code(
+  x, codebook,
+  model = "openai_compatible/qwen3-max",
+  base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+  credentials = function() \{
+    list(Authorization = paste("Bearer", Sys.getenv("DASHSCOPE_API_KEY")))
+  \},
+  params = ellmer::params(temperature = 0.6, top_p = 0.95),
+  api_args = list(top_k = 20, min_p = 0, enable_thinking = TRUE)
+)
+
+# Kimi K3 through Moonshot, whose temperature and top_p are fixed by the
+# provider and documented as needing to be omitted rather than set
+qlm_code(
+  x, codebook,
+  model = "openai_compatible/kimi-k3",
+  base_url = "https://api.moonshot.ai/v1",
+  credentials = function() \{
+    list(Authorization = paste("Bearer", Sys.getenv("MOONSHOT_API_KEY")))
+  \},
+  api_args = list(reasoning_effort = "max")
+)
+}\if{html}{\out{</div>}}
+
+Passing a model parameter such as \code{temperature} or \code{max_tokens} at the top
+level does not work: those reach \code{\link[ellmer:chat]{ellmer::chat()}}, which has no such
+argument. Use \code{params}.
+}
+
 \section{Schema enforcement}{
 
 
@@ -116,6 +164,15 @@ produces.}
 \code{"auto"} catches wholesale non-enforcement, not the intermittent kind: a
 single non-conforming row among many leaves that check silent. Only
 \code{"json"} catches that, at the cost of putting the schema in the prompt.
+
+That check also needs something to look at. It reads required scalar
+properties, because those become ordinary columns; required arrays and
+nested objects become list-columns in which a missing value and a
+schema-valid empty one are the same zero-length cell, and cannot be told
+apart. So for a codebook whose required properties are all arrays or nested
+objects, \code{"auto"} on an unverified endpoint validates locally from the
+start rather than making a call it could not check, and says so. Use
+\code{"structured"} to rely on the provider regardless.
 
 On the JSON path, units that never validate have \code{NA} coded values and a
 \code{.error} list-column recording the reason, and \code{max_retries} controls how

--- a/man/qlm_replicate.Rd
+++ b/man/qlm_replicate.Rd
@@ -19,9 +19,17 @@ qlm_replicate(
 
 \item{...}{Optional overrides passed to \code{\link[=qlm_code]{qlm_code()}}, such as \code{params},
 \code{api_args}, or \code{max_active}. Any setting not overridden is restored from
-the original run, including the arguments it passed to \code{\link[ellmer:chat]{ellmer::chat()}}.
-Registered \code{tools} are the one exception: they are provider-specific and
-are not carried over.}
+the original run when the endpoint is unchanged, including the arguments
+it passed to \code{\link[ellmer:chat]{ellmer::chat()}}. An endpoint is identified by both the
+provider prefix and \code{base_url}, since every provider ellmer has no
+\verb{chat_*()} for is reached as \verb{openai_compatible/<model>} — so Qwen through
+Alibaba Model Studio and Kimi through Moonshot share a prefix while being
+different services with different credentials. When either changes, only
+portable chat settings (\code{params} and \code{echo}) are carried over; supply
+credentials, endpoint settings and other endpoint-specific arguments
+explicitly. An informational message names inherited arguments that were
+omitted and not explicitly replaced. Registered \code{tools} are never carried
+over.}
 
 \item{codebook}{Optional replacement codebook. If \code{NULL} (default), uses
 the codebook from \code{x}.}
@@ -49,6 +57,8 @@ Re-executes a coding task from a \code{qlm_coded} object, optionally with
 modified settings. If no overrides are provided, uses identical settings
 to the original coding: both the execution arguments and the arguments the
 original run passed to \code{\link[ellmer:chat]{ellmer::chat()}}, such as \code{params} and \code{api_args}.
+Credentials and endpoint settings are an exception, and are carried over
+only while the endpoint itself is unchanged.
 }
 \examples{
 \donttest{

--- a/man/qlm_replicate.Rd
+++ b/man/qlm_replicate.Rd
@@ -60,6 +60,13 @@ original run passed to \code{\link[ellmer:chat]{ellmer::chat()}}, such as \code{
 Credentials and endpoint settings are an exception, and are carried over
 only while the endpoint itself is unchanged.
 }
+\details{
+The coding path is reproduced from the path the original run actually took,
+not the \code{structured} mode it requested: a run that asked for \code{"auto"} and
+fell back to JSON mode replicates as \code{"json"}, so that an intermittently
+conforming endpoint cannot quietly skip the local validation the original
+relied on. Pass \code{structured} explicitly to override.
+}
 \examples{
 \donttest{
 # First create a coded object

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -285,11 +285,14 @@ test_that("qlm_code passes provider-specific arguments to ellmer::chat", {
   }
   mock_results <- data.frame(id = 1:2, score = c(0.5, 0.8))
 
-  mockery::stub(qlm_code, "ellmer::chat", mock_chat)
-  mockery::stub(qlm_code, "ellmer::parallel_chat_structured", mock_results)
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", mock_chat)
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", mock_results)
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
 
   # Call with a provider-specific argument (like base_url for openai_compatible)
-  qlm_code(c("text1", "text2"), codebook, model = "test/model",
+  f(c("text1", "text2"), codebook, model = "test/model",
            base_url = "https://my-api.com/v1")
 
   # Verify the provider-specific argument was passed through to ellmer::chat
@@ -308,13 +311,14 @@ test_that("qlm_code uses parallel_chat_structured when batch=FALSE", {
   mock_chat <- structure(list(), class = "ellmer_chat")
   mock_results <- data.frame(id = 1:2, score = c(0.5, 0.8))
 
-  mockery::stub(qlm_code, "ellmer::chat", mock_chat)
-
-  # Mock parallel_chat_structured and verify it's called
   mock_pcs <- mockery::mock(mock_results, cycle = TRUE)
-  mockery::stub(qlm_code, "ellmer::parallel_chat_structured", mock_pcs)
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", mock_chat)
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", mock_pcs)
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
 
-  result <- qlm_code(c("text1", "text2"), codebook,
+  result <- f(c("text1", "text2"), codebook,
                      model = "test/model", batch = FALSE)
 
   # Verify parallel_chat_structured was called
@@ -336,17 +340,18 @@ test_that("qlm_code uses batch_chat_structured when batch=TRUE", {
   mock_chat <- structure(list(), class = "ellmer_chat")
   mock_results <- data.frame(id = 1:2, score = c(0.5, 0.8))
 
-  mockery::stub(qlm_code, "ellmer::chat", mock_chat)
-
-  # Mock batch_chat_structured and verify it's called
   mock_bcs <- mockery::mock(mock_results, cycle = TRUE)
-  mockery::stub(qlm_code, "ellmer::batch_chat_structured", mock_bcs)
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", mock_chat)
+  mockery::stub(tsc, "ellmer::batch_chat_structured", mock_bcs)
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
 
   # Use an execution arg that's valid (convert is in both parallel and batch)
   result <- suppressWarnings(
-    qlm_code(c("text1", "text2"), codebook,
-             model = "test/model", batch = TRUE,
-             convert = TRUE)
+    f(c("text1", "text2"), codebook,
+      model = "test/model", batch = TRUE,
+      convert = TRUE)
   )
 
   # Verify batch_chat_structured was called
@@ -369,11 +374,14 @@ test_that("qlm_code builds metadata correctly", {
   mock_chat <- structure(list(), class = "ellmer_chat")
   mock_results <- data.frame(id = 1:3, score = c(0.5, 0.8, 0.2))
 
-  mockery::stub(qlm_code, "ellmer::chat", mock_chat)
-  mockery::stub(qlm_code, "ellmer::parallel_chat_structured", mock_results)
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", mock_chat)
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", mock_results)
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
 
-  result <- qlm_code(c("text1", "text2", "text3"), codebook,
-                     model = "test/model")
+  result <- f(c("text1", "text2", "text3"), codebook,
+              model = "test/model")
 
   meta_attr <- attr(result, "meta")
 
@@ -425,13 +433,15 @@ test_that("qlm_code stores notes in metadata", {
 })
 
 
-test_that("code_handler_for routes only providers that need JSON-mode coding", {
-  expect_null(code_handler_for("openai/gpt-4o-mini"))
-  expect_null(code_handler_for("anthropic/claude-sonnet-4-5"))
-  expect_null(code_handler_for("openai"))
+test_that("default_structured_mode skips the structured call only where it cannot work", {
+  # DeepSeek's API answers `response_format` with HTTP 400, so attempting it is
+  # a guaranteed-wasted round trip
+  expect_equal(default_structured_mode("deepseek/deepseek-v4-pro"), "json")
+  expect_equal(default_structured_mode("deepseek"), "json")
 
-  expect_identical(code_handler_for("deepseek/deepseek-chat"), code_handler_json)
-  expect_identical(code_handler_for("deepseek"), code_handler_json)
+  expect_equal(default_structured_mode("openai/gpt-4o-mini"), "auto")
+  expect_equal(default_structured_mode("anthropic/claude-sonnet-4-5"), "auto")
+  expect_equal(default_structured_mode("openai_compatible/kimi-k3"), "auto")
 })
 
 
@@ -452,7 +462,7 @@ test_that("qlm_code delegates to the handler and records the backend", {
   }
 
   f <- qlm_code
-  mockery::stub(f, "code_handler_for", function(...) fake_handler)
+  mockery::stub(f, "code_handler_json", fake_handler)
 
   result <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
               max_retries = 5, max_active = 3)
@@ -476,44 +486,49 @@ test_that("qlm_code still uses parallel_chat_structured for other providers", {
   type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
   codebook <- qlm_codebook("Test", "Prompt", type_obj)
 
-  mock_chat <- structure(list(), class = "Chat")
   mock_pcs <- mockery::mock(data.frame(score = c(0.5, 0.8)), cycle = TRUE)
-
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", structure(list(), class = "Chat"))
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", mock_pcs)
   f <- qlm_code
-  mockery::stub(f, "ellmer::chat", mock_chat)
-  mockery::stub(f, "ellmer::parallel_chat_structured", mock_pcs)
+  mockery::stub(f, "try_structured_call", tsc)
 
   result <- f(c("a", "b"), codebook, model = "openai/gpt-4o-mini")
 
   mockery::expect_called(mock_pcs, 1)
-  expect_null(qlm_meta(result, type = "object")$backend)
+  # Every run now says which path produced it
+  expect_equal(qlm_meta(result, type = "object")$backend, "structured")
+  expect_equal(qlm_meta(result, type = "object")$structured, "auto")
 })
 
 
-test_that("qlm_code errors on max_retries only when it is set explicitly", {
+test_that("qlm_code errors on max_retries only where JSON mode cannot be reached", {
   skip_if_not_installed("mockery")
 
   type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
   codebook <- qlm_codebook("Test", "Prompt", type_obj)
 
-  # Explicitly set for a provider that cannot honour it
+  # `structured` forbids the JSON path, so repair attempts can never happen
   expect_error(
-    qlm_code(c("a"), codebook, model = "openai/gpt-4o-mini", max_retries = 2),
-    "not supported for model"
+    qlm_code(c("a"), codebook, model = "openai/gpt-4o-mini",
+             structured = "structured", max_retries = 2),
+    "not supported with"
   )
   # Even when the value happens to equal the default
   expect_error(
-    qlm_code(c("a"), codebook, model = "openai/gpt-4o-mini", max_retries = 2L),
-    "not supported for model"
+    qlm_code(c("a"), codebook, model = "openai/gpt-4o-mini",
+             structured = "structured", max_retries = 2L),
+    "not supported with"
   )
 
-  # Left at the default, the same call proceeds
-  mock_chat <- structure(list(), class = "Chat")
+  # Under "auto" the JSON path is reachable, so the argument applies
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", structure(list(), class = "Chat"))
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", data.frame(score = 0.5))
   f <- qlm_code
-  mockery::stub(f, "ellmer::chat", mock_chat)
-  mockery::stub(f, "ellmer::parallel_chat_structured", data.frame(score = 0.5))
+  mockery::stub(f, "try_structured_call", tsc)
   expect_s3_class(
-    f(c("a"), codebook, model = "openai/gpt-4o-mini"),
+    f(c("a"), codebook, model = "openai/gpt-4o-mini", max_retries = 4),
     "qlm_coded"
   )
 })
@@ -532,7 +547,7 @@ test_that("qlm_code passes its max_retries default to the handler", {
     tibble::tibble(score = 0.5)
   }
   f <- qlm_code
-  mockery::stub(f, "code_handler_for", function(...) fake_handler)
+  mockery::stub(f, "code_handler_json", fake_handler)
 
   f("a", codebook, model = "deepseek/deepseek-chat")
   expect_equal(seen, 2L)
@@ -547,4 +562,270 @@ test_that("qlm_code requires a single model string", {
     qlm_code(c("a"), codebook, model = c("openai", "anthropic")),
     "must be a single string"
   )
+})
+
+
+# structured = c("auto", "structured", "json") --------------------------------
+
+# A try_structured_call() with the ellmer calls stubbed out. `results` is
+# returned by the structured call; `errors` is a character vector of messages
+# to throw, one per attempt, NA meaning "succeed".
+structured_stub <- function(results = data.frame(score = 0.5), errors = NULL,
+                            calls = NULL) {
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", function(...) structure(list(), class = "Chat"))
+  mockery::stub(tsc, "warn_unenforced_schema", function(...) invisible(NULL))
+  i <- 0L
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", function(chat, prompts, type, ...) {
+    i <<- i + 1L
+    if (!is.null(calls)) {
+      calls$n <- i
+    }
+    err <- if (!is.null(errors) && i <= length(errors)) errors[[i]] else NA_character_
+    if (!is.na(err)) stop(err, call. = FALSE)
+    results
+  })
+  tsc
+}
+
+json_stub <- function(calls = NULL) {
+  function(x, codebook, model, chat_args, execution_args, batch, max_retries) {
+    if (!is.null(calls)) {
+      calls$json <- TRUE
+      calls$max_retries <- max_retries
+    }
+    results <- tibble::tibble(score = rep(0.99, length(x)))
+    attr(results, "qlm_backend_meta") <- list(backend = "json_mode", n_invalid = 0)
+    results
+  }
+}
+
+structured_test_codebook <- function() {
+  qlm_codebook("Test", "Prompt", ellmer::type_object(score = ellmer::type_number("Score")))
+}
+
+
+test_that("structured = 'structured' never reaches the JSON path", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", structured_stub())
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  result <- f("a", structured_test_codebook(), model = "openai/gpt-4o-mini",
+              structured = "structured")
+
+  expect_null(calls$json)
+  expect_equal(result$score, 0.5)
+  expect_equal(qlm_meta(result, type = "object")$backend, "structured")
+})
+
+
+test_that("structured = 'json' never attempts the structured call", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", structured_stub(calls = calls))
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  result <- f("a", structured_test_codebook(), model = "openai/gpt-4o-mini",
+              structured = "json")
+
+  expect_null(calls$n)
+  expect_true(calls$json)
+  expect_equal(result$score, 0.99)
+  expect_equal(qlm_meta(result, type = "object")$backend, "json_mode")
+  expect_equal(qlm_meta(result, type = "object")$structured, "json")
+})
+
+
+test_that("structured = 'auto' falls back to JSON mode when the call errors", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call",
+                structured_stub(errors = "HTTP 400 Bad Request.", calls = calls))
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  expect_warning(
+    result <- f("a", structured_test_codebook(), model = "openai_compatible/kimi-k3",
+                base_url = "https://example.com/v1"),
+    "falling back to JSON mode"
+  )
+
+  expect_true(calls$json)
+  expect_equal(qlm_meta(result, type = "object")$backend, "json_mode")
+  # The reason is kept, so a run that switched path can say why
+  expect_match(qlm_meta(result, type = "user")$fallback_reason, "400")
+})
+
+
+test_that("structured = 'auto' falls back when every required field is NA", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  # HTTP 200, but the endpoint accepted the schema and ignored it
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call",
+                structured_stub(results = data.frame(score = c(NA_real_, NA_real_))))
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  expect_warning(
+    result <- f(c("a", "b"), structured_test_codebook(), model = "openai_compatible/x",
+                base_url = "https://example.com/v1"),
+    "no usable values"
+  )
+  expect_true(calls$json)
+})
+
+
+test_that("a partly incomplete structured result warns without falling back", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call",
+                structured_stub(results = data.frame(score = c(1, NA_real_, 3))))
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  expect_warning(
+    result <- f(c("a", "b", "c"), structured_test_codebook(), model = "openai/gpt-4o-mini"),
+    "1 row from the structured call is missing"
+  )
+  expect_null(calls$json)
+  expect_equal(qlm_meta(result, type = "object")$backend, "structured")
+})
+
+
+test_that("structured = 'structured' aborts rather than falling back", {
+  skip_if_not_installed("mockery")
+
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", structured_stub(errors = "the endpoint said no"))
+
+  expect_error(
+    f("a", structured_test_codebook(), model = "openai/gpt-4o-mini",
+      structured = "structured"),
+    "the endpoint said no"
+  )
+})
+
+
+test_that("auto cannot fall back under batch, and says so", {
+  skip_if_not_installed("mockery")
+
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", structured_stub(errors = "batch call failed"))
+
+  expect_error(
+    f("a", structured_test_codebook(), model = "openai/gpt-4o-mini", batch = TRUE),
+    "has no batch path"
+  )
+})
+
+
+test_that("the DashScope json-word rejection retries structured before falling back", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  json_word <- paste(
+    "<400> InternalError.Algo.InvalidParameter: 'messages' must contain the word",
+    "'json' in some form, to use 'response_format' of type 'json_object'"
+  )
+  # Fails once with the json-word error, succeeds on the retry
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call",
+                structured_stub(errors = json_word, calls = calls))
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  result <- f("a", structured_test_codebook(), model = "openai_compatible/qwen-flash",
+              base_url = "https://example.com/v1")
+
+  # Two structured attempts, and enforcement is kept rather than abandoned
+  expect_equal(calls$n, 2)
+  expect_null(calls$json)
+  expect_equal(qlm_meta(result, type = "object")$backend, "structured")
+})
+
+
+test_that("an unrelated error falls back without a second structured attempt", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call",
+                structured_stub(errors = "HTTP 500 Internal Server Error.", calls = calls))
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  suppressWarnings(
+    f("a", structured_test_codebook(), model = "openai_compatible/x",
+      base_url = "https://example.com/v1")
+  )
+
+  expect_equal(calls$n, 1)
+  expect_true(calls$json)
+})
+
+
+test_that("max_retries reaches the JSON path under auto", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", structured_stub(errors = "nope"))
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  suppressWarnings(
+    f("a", structured_test_codebook(), model = "openai/gpt-4o-mini", max_retries = 7)
+  )
+  expect_equal(calls$max_retries, 7)
+})
+
+
+test_that("the enforcement note fires for unverifiable endpoints only", {
+  skip_if_not_installed("mockery")
+  # The note is once-per-session; disable that so the test does not depend on
+  # whether something earlier in the suite already consumed it
+  withr::local_options(quallmer.quiet_schema_note = FALSE,
+                       rlib_message_verbosity = "verbose")
+
+  fake_chat <- function(provider_class) {
+    list(get_provider = function() structure(list(), class = c(provider_class, "S7_object")))
+  }
+
+  # A provider whose own chat_body() uses an enforced mechanism: nothing to say
+  expect_silent(
+    warn_unenforced_schema(fake_chat("ellmer::ProviderOpenAI"), "openai/gpt-4o-mini")
+  )
+  expect_silent(
+    warn_unenforced_schema(fake_chat("ellmer::ProviderAnthropic"), "anthropic/claude")
+  )
+
+  # Anything on the generic OpenAI-compatible path is unverified
+  expect_message(
+    warn_unenforced_schema(fake_chat("ellmer::ProviderOpenAICompatible"),
+                           "openai_compatible/kimi-k3"),
+    "may accept the output schema without enforcing it"
+  )
+})
+
+
+test_that("the enforcement note can be silenced", {
+  withr::local_options(quallmer.quiet_schema_note = TRUE)
+  fake <- list(get_provider = function() {
+    structure(list(), class = c("ellmer::ProviderOpenAICompatible", "S7_object"))
+  })
+
+  expect_silent(warn_unenforced_schema(fake, "openai_compatible/kimi-k3"))
+})
+
+
+test_that("the enforcement note survives a provider it cannot inspect", {
+  withr::local_options(quallmer.quiet_schema_note = FALSE)
+  broken <- list(get_provider = function() stop("no provider"))
+
+  expect_silent(warn_unenforced_schema(broken, "some/model"))
 })

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -829,3 +829,212 @@ test_that("the enforcement note survives a provider it cannot inspect", {
 
   expect_silent(warn_unenforced_schema(broken, "some/model"))
 })
+
+
+test_that("auto validates locally when a failed structured call would be invisible", {
+  skip_if_not_installed("mockery")
+
+  # Required properties are all arrays, so there is no scalar field whose
+  # absence would reveal a failed structured call
+  array_codebook <- qlm_codebook(
+    "Test", "Prompt",
+    ellmer::type_object(
+      claims = ellmer::type_array(ellmer::type_string("A claim"))
+    )
+  )
+  expect_length(required_scalar_fields(array_codebook$schema), 0)
+
+  calls <- new.env()
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", function(...) {
+    list(get_provider = function() {
+      structure(list(), class = c("ellmer::ProviderOpenAICompatible", "S7_object"))
+    })
+  })
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", function(...) {
+    calls$structured <- TRUE
+    tibble::tibble(claims = list("x"))
+  })
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  expect_message(
+    result <- f("a", array_codebook, model = "openai_compatible/kimi-k3",
+                base_url = "https://example.com/v1"),
+    "no required scalar field whose absence would reveal"
+  )
+
+  # No request was spent on a call that could not be checked
+  expect_null(calls$structured)
+  expect_true(calls$json)
+  expect_equal(qlm_meta(result, type = "object")$backend, "json_mode")
+  # ... and the reason is recorded, not just printed
+  expect_match(qlm_meta(result, type = "user")$fallback_reason, "cannot be verified")
+})
+
+
+test_that("the undetectable skip applies only where it is warranted", {
+  skip_if_not_installed("mockery")
+
+  array_codebook <- qlm_codebook(
+    "Test", "Prompt",
+    ellmer::type_object(claims = ellmer::type_array(ellmer::type_string("A claim")))
+  )
+  results <- tibble::tibble(claims = list("x"))
+
+  make_tsc <- function(provider_class) {
+    tsc <- try_structured_call
+    mockery::stub(tsc, "ellmer::chat", function(...) {
+      list(get_provider = function() structure(list(), class = c(provider_class, "S7_object")))
+    })
+    mockery::stub(tsc, "ellmer::parallel_chat_structured", results)
+    tsc
+  }
+
+  # An endpoint that enforces by construction needs no local validation
+  calls <- new.env()
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", make_tsc("ellmer::ProviderOpenAI"))
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+  expect_silent(f("a", array_codebook, model = "openai/gpt-4o-mini"))
+  expect_null(calls$json)
+
+  # And an explicit `structured` is never overridden. The enforcement note may
+  # still fire here -- trusting an unverified endpoint is exactly when it
+  # should -- so assert on the skip reason rather than on silence.
+  calls <- new.env()
+  f2 <- qlm_code
+  mockery::stub(f2, "try_structured_call", make_tsc("ellmer::ProviderOpenAICompatible"))
+  mockery::stub(f2, "code_handler_json", json_stub(calls))
+  emitted <- testthat::capture_messages(
+    f2("a", array_codebook, model = "openai_compatible/x",
+       base_url = "https://example.com/v1", structured = "structured")
+  )
+  expect_false(any(grepl("no required scalar field", emitted)))
+  expect_null(calls$json)
+})
+
+
+test_that("a schema-valid empty array is not mistaken for a failure", {
+  skip_if_not_installed("mockery")
+
+  # An empty array is valid JSON Schema output for a required array, and after
+  # conversion is indistinguishable from a missing one -- so detection must not
+  # guess, and a codebook with a checkable scalar alongside must not fall back
+  codebook <- qlm_codebook(
+    "Test", "Prompt",
+    ellmer::type_object(
+      score  = ellmer::type_number("Score"),
+      claims = ellmer::type_array(ellmer::type_string("A claim"))
+    )
+  )
+  results <- tibble::tibble(score = c(1, 2), claims = list(character(0), character(0)))
+
+  expect_false(all_required_missing(results, codebook$schema))
+  expect_equal(n_incomplete(results, codebook$schema), 0)
+
+  calls <- new.env()
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", function(...) {
+    list(get_provider = function() {
+      structure(list(), class = c("ellmer::ProviderOpenAICompatible", "S7_object"))
+    })
+  })
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", results)
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  suppressMessages(result <- f(c("a", "b"), codebook, model = "openai_compatible/x",
+                               base_url = "https://example.com/v1"))
+  expect_null(calls$json)
+  expect_equal(qlm_meta(result, type = "object")$backend, "structured")
+})
+
+
+test_that("qlm_code rejects convert = FALSE rather than failing downstream", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+
+  expect_error(
+    qlm_code("a", codebook, model = "openai/gpt-4o-mini", convert = FALSE),
+    "is not supported"
+  )
+  # TRUE is the default and must still be accepted
+  skip_if_not_installed("mockery")
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", structure(list(), class = "Chat"))
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", data.frame(score = 0.5))
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
+  expect_s3_class(
+    f("a", codebook, model = "openai/gpt-4o-mini", convert = TRUE),
+    "qlm_coded"
+  )
+})
+
+
+test_that("qlm_code forwards params and api_args to ellmer unchanged", {
+  skip_if_not_installed("mockery")
+
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+
+  # Which of the two a setting belongs in is ellmer's and the provider's
+  # business. quallmer must not inspect or rewrite either object -- notably it
+  # must not "helpfully" move top_k out of params, even though ellmer maps that
+  # onto the unrelated OpenAI field top_logprobs for OpenAI-compatible
+  # providers.
+  user_params <- ellmer::params(temperature = 0.6, top_p = 0.95, top_k = 20)
+  user_api_args <- list(top_k = 20, min_p = 0, enable_thinking = TRUE)
+
+  seen <- NULL
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", function(...) {
+    seen <<- list(...)
+    structure(list(), class = "Chat")
+  })
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", data.frame(score = 0.5))
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
+
+  f("a", codebook, model = "openai_compatible/qwen3-max",
+    base_url = "https://example.com/v1",
+    params = user_params, api_args = user_api_args)
+
+  expect_identical(seen$params, user_params)
+  expect_identical(seen$api_args, user_api_args)
+  expect_equal(seen$base_url, "https://example.com/v1")
+})
+
+
+test_that("the JSON path forwards api_args too, adding only the response format", {
+  skip_if_not_installed("mockery")
+
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+  user_params <- ellmer::params(temperature = 0.6)
+
+  seen <- NULL
+  h <- code_handler_json
+  mockery::stub(h, "ellmer::chat", function(...) {
+    seen <<- list(...)
+    structure(list(), class = "Chat")
+  })
+  mockery::stub(h, "json_chat_turns", function(chat, prompts, pc_args) {
+    list(text = "{\"score\":1}", error = NA_character_, status = NA_integer_,
+         usage = matrix(0, 1, 4, dimnames = list(
+           NULL, c("input_tokens", "output_tokens", "cached_input_tokens", "cost"))))
+  })
+
+  h(x = "a", codebook = codebook, model = "openai_compatible/kimi-k3",
+    chat_args = list(params = user_params,
+                     api_args = list(reasoning_effort = "max")),
+    execution_args = list())
+
+  expect_identical(seen$params, user_params)
+  expect_equal(seen$api_args$reasoning_effort, "max")
+  # JSON mode is the one thing this path must set
+  expect_equal(seen$api_args$response_format, list(type = "json_object"))
+})

--- a/tests/testthat/test-qlm_code_json.R
+++ b/tests/testthat/test-qlm_code_json.R
@@ -667,3 +667,91 @@ test_that("code_handler_json names the reasons in its warning", {
     "Context length exceeded"
   )
 })
+
+
+# Structured-failure detection ------------------------------------------------
+
+test_that("required_scalar_fields covers only checkable properties", {
+  schema <- ellmer::type_object(
+    code     = ellmer::type_enum("A code", values = c("a", "b")),
+    n        = ellmer::type_integer("N"),
+    optional = ellmer::type_string("Optional", required = FALSE),
+    claims   = ellmer::type_array(ellmer::type_string("A claim"))
+  )
+  # Arrays become list-columns, where "nothing useful came back" has no simple
+  # NA representation, so they are not checkable this way
+  expect_setequal(required_scalar_fields(schema), c("code", "n"))
+  expect_equal(required_scalar_fields("not a schema"), character())
+})
+
+test_that("all_required_missing detects a call that returned nothing usable", {
+  schema <- json_test_codebook()$schema
+
+  expect_true(all_required_missing(
+    data.frame(score = c(NA_real_, NA_real_), lab = c(NA_character_, NA_character_)),
+    schema
+  ))
+  # One good row is enough to say the endpoint did something
+  expect_false(all_required_missing(
+    data.frame(score = c(1, NA_real_), lab = c("pos", NA_character_)),
+    schema
+  ))
+  expect_false(all_required_missing(
+    data.frame(score = c(1, 2), lab = c("pos", "neg")),
+    schema
+  ))
+})
+
+test_that("all_required_missing does not misread a non-table result", {
+  schema <- json_test_codebook()$schema
+  # convert = FALSE returns a list; there is no table to inspect and so no
+  # basis for calling the attempt a failure
+  expect_false(all_required_missing(list(list(score = 1, lab = "pos")), schema))
+  expect_false(all_required_missing(data.frame(), schema))
+  expect_false(all_required_missing(NULL, schema))
+})
+
+test_that("n_incomplete counts partially failed rows", {
+  schema <- json_test_codebook()$schema
+  results <- data.frame(score = c(1, NA_real_, 3), lab = c("pos", "neg", NA_character_))
+
+  expect_equal(n_incomplete(results, schema), 2)
+  expect_equal(n_incomplete(data.frame(score = 1, lab = "pos"), schema), 0)
+  expect_equal(n_incomplete(list(), schema), 0L)
+})
+
+
+# Provider capability ---------------------------------------------------------
+
+test_that("provider_enforces_schema follows ellmer's mechanism, not a vendor list", {
+  withr::local_envvar(OPENAI_API_KEY = "x", ANTHROPIC_API_KEY = "x",
+                      GROQ_API_KEY = "x", MISTRAL_API_KEY = "x")
+  # ellmer::chat() derives the model from the name string, so it must not also
+  # be passed through `...`
+  provider_of <- function(name, ...) {
+    suppressWarnings(ellmer::chat(name, echo = "none", ...)$get_provider())
+  }
+
+  # Own chat_body() using a mechanism the provider enforces
+  expect_true(provider_enforces_schema(provider_of("openai/gpt-4o-mini")))
+  expect_true(provider_enforces_schema(provider_of("anthropic/claude-sonnet-4-5")))
+
+  # Falls through to ProviderOpenAICompatible, which sends strict = TRUE and
+  # takes the answer on trust
+  expect_false(provider_enforces_schema(provider_of("groq/llama-3.1-8b-instant")))
+  expect_false(provider_enforces_schema(provider_of("mistral/mistral-large-latest")))
+  expect_false(provider_enforces_schema(
+    provider_of("openai_compatible/some-model", base_url = "https://example.com/v1",
+                credentials = function() "k")
+  ))
+})
+
+test_that("is_json_word_error recognises the DashScope rejection", {
+  expect_true(is_json_word_error(paste(
+    "<400> InternalError.Algo.InvalidParameter: 'messages' must contain the word",
+    "'json' in some form, to use 'response_format' of type 'json_object'"
+  )))
+  expect_false(is_json_word_error("HTTP 429 Too Many Requests."))
+  expect_false(is_json_word_error(NA_character_))
+  expect_false(is_json_word_error(character(0)))
+})

--- a/tests/testthat/test-qlm_code_json.R
+++ b/tests/testthat/test-qlm_code_json.R
@@ -240,6 +240,10 @@ test_that("is_length_rejection recognises over-long input only", {
   expect_true(is_length_rejection("Range of input length should be [1, 129024]"))
   expect_true(is_length_rejection("the prompt is too long"))
 
+  # Generic latency language is transient, not evidence of a context overflow.
+  expect_false(is_length_rejection("upstream server took too long to respond"))
+  expect_false(is_length_rejection("request waited too long in queue"))
+
   # Content refusals must NOT be treated as unrecoverable: they are
   # non-deterministic, and the same document is coded on a later attempt.
   expect_false(is_length_rejection(
@@ -565,6 +569,21 @@ test_that("api_error_detail copes with bodies it cannot use", {
   expect_true(is.na(api_error_detail(make_cnd(raw(0)))))
   expect_true(is.na(api_error_detail(make_cnd(charToRaw("<html>nope</html>")))))
   expect_true(is.na(api_error_detail(make_cnd(charToRaw('{"ok":true}')))))
+  expect_equal(
+    api_error_detail(make_cnd(charToRaw('{"error":"bad request"}'))),
+    "bad request"
+  )
+  expect_equal(
+    api_error_detail(make_cnd(charToRaw('{"message":"top-level failure"}'))),
+    "top-level failure"
+  )
+  expect_equal(
+    api_error_detail(make_cnd(charToRaw(
+      '{"error":{"type":"invalid_request"},"message":"fallback failure"}'
+    ))),
+    "fallback failure"
+  )
+  expect_true(is.na(api_error_detail(make_cnd(charToRaw('"not an object"')))))
   expect_true(is.na(api_error_detail(simpleError("boom"))))
   expect_equal(api_error_message(simpleError("boom")), "boom")
   expect_equal(api_error_message(NULL), "the request failed")
@@ -616,6 +635,32 @@ test_that("code_handler_json aborts when the provider rejects every request", {
 
   # No point re-sending a request the provider rejected outright
   expect_equal(calls$n, 1)
+})
+
+test_that("code_handler_json does not retry a fatal failure in a mixed batch", {
+  calls <- new.env()
+  h <- json_test_handler(
+    list(list(
+      text = c(NA_character_, "{\"score\":1,\"lab\":\"pos\"}"),
+      error = c("HTTP 400 Bad Request. Invalid request body.", NA_character_),
+      status = c(400L, NA_integer_)
+    )),
+    calls = calls
+  )
+
+  expect_warning(
+    result <- h(
+      x = c("a", "b"), codebook = json_test_codebook(),
+      model = "deepseek/deepseek-v4-pro", chat_args = list(),
+      execution_args = list()
+    ),
+    "1 response could not be coded, out of 2"
+  )
+
+  expect_equal(calls$n, 1)
+  expect_true(is.na(result$score[[1]]))
+  expect_equal(result$score[[2]], 1)
+  expect_match(json_test_messages(result)[[1]], "Invalid request body")
 })
 
 test_that("code_handler_json retries transient failures but not fatal ones", {

--- a/tests/testthat/test-qlm_replicate.R
+++ b/tests/testthat/test-qlm_replicate.R
@@ -515,6 +515,62 @@ test_that("qlm_replicate lets overrides win over restored chat_args", {
 })
 
 
+test_that("qlm_replicate drops provider-bound arguments when provider changes", {
+  skip_if_not_installed("mockery")
+
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+  old_credentials <- function() "old-provider-key"
+
+  coded <- new_qlm_coded(
+    results = data.frame(id = 1L, score = 0.5),
+    codebook = codebook, data = "a", input_type = "text",
+    chat_args = list(
+      name = "deepseek/deepseek-v4-flash",
+      params = list(temperature = 0),
+      echo = "none",
+      credentials = old_credentials,
+      base_url = "https://api.deepseek.example",
+      api_args = list(seed = 42),
+      api_headers = c(`X-Provider` = "deepseek")
+    ),
+    execution_args = list(max_active = 3),
+    batch = FALSE, metadata = list(n_units = 1), name = "run1",
+    call = quote(qlm_code())
+  )
+
+  seen <- NULL
+  f <- qlm_replicate
+  mockery::stub(f, "qlm_code", function(...) {
+    seen <<- list(...)
+    coded
+  })
+  expect_message(
+    f(coded, model = "openai/gpt-4o-mini", name = "run2"),
+    paste0(
+      "not carrying over endpoint-specific arguments: `credentials`, ",
+      "`base_url`, `api_args`, `api_headers`"
+    )
+  )
+
+  expect_equal(seen$params, list(temperature = 0))
+  expect_equal(seen$echo, "none")
+  expect_equal(seen$max_active, 3)
+  expect_false(any(c("credentials", "base_url", "api_args", "api_headers") %in% names(seen)))
+
+  # Explicit settings for the replacement provider still pass through.
+  replacement_credentials <- function() "replacement-key"
+  expect_message(
+    f(coded, model = "openai/gpt-4o-mini", name = "run3",
+      credentials = replacement_credentials,
+      base_url = "https://api.openai.example"),
+    "not carrying over endpoint-specific arguments: `api_args`, `api_headers`"
+  )
+  expect_identical(seen$credentials, replacement_credentials)
+  expect_equal(seen$base_url, "https://api.openai.example")
+})
+
+
 test_that("qlm_replicate does not carry tools across a replication", {
   skip_if_not_installed("mockery")
 
@@ -624,4 +680,127 @@ test_that("qlm_replicate reproduces the coding path, not just the chat settings"
   seen <- NULL
   f(make("json", backend = "json_mode"), structured = "structured", name = "run4")
   expect_equal(seen$structured, "structured")
+})
+
+
+test_that("qlm_replicate drops credentials when the endpoint changes but the prefix does not", {
+  skip_if_not_installed("mockery")
+
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+
+  # Kimi through Moonshot. Qwen through Alibaba Model Studio has the same
+  # prefix, so only base_url distinguishes the two services.
+  moonshot <- new_qlm_coded(
+    results = data.frame(id = 1L, score = 0.5),
+    codebook = codebook, data = "a", input_type = "text",
+    chat_args = list(
+      name = "openai_compatible/kimi-k3",
+      base_url = "https://api.moonshot.ai/v1",
+      credentials = function() list(Authorization = "Bearer moonshot-key"),
+      api_headers = c(`X-Trace` = "1"),
+      api_args = list(reasoning_effort = "max"),
+      params = list(temperature = 0)
+    ),
+    execution_args = list(), batch = FALSE,
+    metadata = list(n_units = 1), name = "run1", call = quote(qlm_code())
+  )
+
+  seen <- NULL
+  f <- qlm_replicate
+  mockery::stub(f, "qlm_code", function(...) {
+    seen <<- list(...)
+    moonshot
+  })
+
+  # Repointing at DashScope keeps the prefix identical, so a prefix-only check
+  # would send Moonshot's credential to Alibaba
+  expect_message(
+    f(moonshot, base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      name = "run2"),
+    "not carrying over endpoint-specific arguments"
+  )
+
+  expect_false("credentials" %in% names(seen))
+  expect_false("api_headers" %in% names(seen))
+  expect_false("api_args" %in% names(seen))
+  # The new endpoint is used, and portable settings still travel
+  expect_equal(seen$base_url, "https://dashscope-intl.aliyuncs.com/compatible-mode/v1")
+  expect_equal(seen$params, list(temperature = 0))
+})
+
+
+test_that("qlm_replicate keeps credentials when the endpoint is unchanged", {
+  skip_if_not_installed("mockery")
+
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+
+  coded <- new_qlm_coded(
+    results = data.frame(id = 1L, score = 0.5),
+    codebook = codebook, data = "a", input_type = "text",
+    chat_args = list(
+      name = "openai_compatible/kimi-k3",
+      base_url = "https://api.moonshot.ai/v1",
+      credentials = function() list(Authorization = "Bearer moonshot-key")
+    ),
+    execution_args = list(), batch = FALSE,
+    metadata = list(n_units = 1), name = "run1", call = quote(qlm_code())
+  )
+
+  seen <- NULL
+  f <- qlm_replicate
+  mockery::stub(f, "qlm_code", function(...) {
+    seen <<- list(...)
+    coded
+  })
+
+  # A different model on the same host is the same endpoint: nothing to drop
+  expect_silent(f(coded, model = "openai_compatible/kimi-k2.6", name = "run2"))
+  expect_true("credentials" %in% names(seen))
+  expect_equal(seen$base_url, "https://api.moonshot.ai/v1")
+
+  # And a plain replication of the same run keeps everything
+  seen <- NULL
+  expect_silent(f(coded, name = "run3"))
+  expect_true("credentials" %in% names(seen))
+})
+
+
+test_that("qlm_replicate keeps an explicitly supplied credential across an endpoint change", {
+  skip_if_not_installed("mockery")
+
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+
+  coded <- new_qlm_coded(
+    results = data.frame(id = 1L, score = 0.5),
+    codebook = codebook, data = "a", input_type = "text",
+    chat_args = list(
+      name = "openai_compatible/kimi-k3",
+      base_url = "https://api.moonshot.ai/v1",
+      credentials = function() list(Authorization = "Bearer moonshot-key")
+    ),
+    execution_args = list(), batch = FALSE,
+    metadata = list(n_units = 1), name = "run1", call = quote(qlm_code())
+  )
+
+  seen <- NULL
+  f <- qlm_replicate
+  mockery::stub(f, "qlm_code", function(...) {
+    seen <<- list(...)
+    coded
+  })
+
+  # Replacing the credential alongside the endpoint is the supported route,
+  # and is not reported as omitted
+  expect_silent(
+    f(coded,
+      base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      credentials = function() list(Authorization = "Bearer dashscope-key"),
+      name = "run2")
+  )
+  expect_equal(
+    seen$credentials()$Authorization, "Bearer dashscope-key"
+  )
 })

--- a/tests/testthat/test-qlm_replicate.R
+++ b/tests/testthat/test-qlm_replicate.R
@@ -639,19 +639,19 @@ test_that("qlm_replicate carries max_retries only where it applies", {
 })
 
 
-test_that("qlm_replicate reproduces the coding path, not just the chat settings", {
+test_that("qlm_replicate reproduces the path taken, not the mode requested", {
   skip_if_not_installed("mockery")
 
   type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
   codebook <- qlm_codebook("Test", "Prompt", type_obj)
 
-  make <- function(structured, ...) {
+  make <- function(..., model = "openai_compatible/kimi-k3") {
     new_qlm_coded(
       results = data.frame(id = 1L, score = 0.5),
       codebook = codebook, data = "a", input_type = "text",
-      chat_args = list(name = "openai_compatible/kimi-k3"),
+      chat_args = list(name = model),
       execution_args = list(), batch = FALSE,
-      metadata = c(list(n_units = 1, structured = structured), list(...)),
+      metadata = c(list(n_units = 1), list(...)),
       name = "run1", call = quote(qlm_code())
     )
   }
@@ -660,26 +660,57 @@ test_that("qlm_replicate reproduces the coding path, not just the chat settings"
   f <- qlm_replicate
   mockery::stub(f, "qlm_code", function(...) {
     seen <<- list(...)
-    make("json")
+    make(structured = "json", backend = "json_mode")
   })
 
-  # A run that validated locally must replicate the same way, or the
-  # replication is not comparable to the run it claims to reproduce
-  f(make("json", backend = "json_mode", max_retries = 4L), name = "run2")
+  # The case that matters: the run asked for "auto" and the endpoint failed, so
+  # it validated locally. Replicating with "auto" would let an intermittently
+  # conforming endpoint take the structured path instead and skip that
+  # validation, making the two runs incomparable.
+  f(make(structured = "auto", backend = "json_mode", max_retries = 4L), name = "run2")
   expect_equal(seen$structured, "json")
   expect_equal(seen$max_retries, 4L)
 
-  # max_retries has no meaning on the purely structured path, and supplying it
-  # there is an error, so it is not carried
+  # Likewise the other way: a run that did take the structured path replicates
+  # as "structured", so a failure surfaces rather than being papered over by a
+  # fallback the original never used
   seen <- NULL
-  f(make("structured", backend = "structured", max_retries = 4L), name = "run3")
+  f(make(structured = "auto", backend = "structured"), name = "run3")
   expect_equal(seen$structured, "structured")
+  # max_retries has no meaning there, and supplying it is an error
   expect_false("max_retries" %in% names(seen))
 
   # An explicit override still wins
   seen <- NULL
-  f(make("json", backend = "json_mode"), structured = "structured", name = "run4")
-  expect_equal(seen$structured, "structured")
+  f(make(structured = "auto", backend = "json_mode"), structured = "auto", name = "run4")
+  expect_equal(seen$structured, "auto")
+})
+
+
+test_that("qlm_replicate leaves the mode alone for objects with no recorded backend", {
+  skip_if_not_installed("mockery")
+
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+
+  # Coded before `backend` was recorded at all
+  legacy <- new_qlm_coded(
+    results = data.frame(id = 1L, score = 0.5),
+    codebook = codebook, data = "a", input_type = "text",
+    chat_args = list(name = "openai/gpt-4o-mini"),
+    execution_args = list(), batch = FALSE,
+    metadata = list(n_units = 1), name = "run1", call = quote(qlm_code())
+  )
+
+  seen <- NULL
+  f <- qlm_replicate
+  mockery::stub(f, "qlm_code", function(...) {
+    seen <<- list(...)
+    legacy
+  })
+
+  f(legacy, name = "run2")
+  expect_false("structured" %in% names(seen))
 })
 
 

--- a/tests/testthat/test-qlm_replicate.R
+++ b/tests/testthat/test-qlm_replicate.R
@@ -575,9 +575,53 @@ test_that("qlm_replicate carries max_retries only where it applies", {
   f(make("deepseek/deepseek-chat"), name = "run2")
   expect_equal(seen$max_retries, 5L)
 
-  # Replicating onto a provider that cannot honour it drops it rather than
-  # aborting: changing the model is a legitimate thing to do.
+  # JSON mode is now reachable for any provider, so the setting still applies
+  # after a model change
   seen <- NULL
   f(make("deepseek/deepseek-chat"), model = "openai/gpt-4o-mini", name = "run3")
+  expect_equal(seen$max_retries, 5L)
+})
+
+
+test_that("qlm_replicate reproduces the coding path, not just the chat settings", {
+  skip_if_not_installed("mockery")
+
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+
+  make <- function(structured, ...) {
+    new_qlm_coded(
+      results = data.frame(id = 1L, score = 0.5),
+      codebook = codebook, data = "a", input_type = "text",
+      chat_args = list(name = "openai_compatible/kimi-k3"),
+      execution_args = list(), batch = FALSE,
+      metadata = c(list(n_units = 1, structured = structured), list(...)),
+      name = "run1", call = quote(qlm_code())
+    )
+  }
+
+  seen <- NULL
+  f <- qlm_replicate
+  mockery::stub(f, "qlm_code", function(...) {
+    seen <<- list(...)
+    make("json")
+  })
+
+  # A run that validated locally must replicate the same way, or the
+  # replication is not comparable to the run it claims to reproduce
+  f(make("json", backend = "json_mode", max_retries = 4L), name = "run2")
+  expect_equal(seen$structured, "json")
+  expect_equal(seen$max_retries, 4L)
+
+  # max_retries has no meaning on the purely structured path, and supplying it
+  # there is an error, so it is not carried
+  seen <- NULL
+  f(make("structured", backend = "structured", max_retries = 4L), name = "run3")
+  expect_equal(seen$structured, "structured")
   expect_false("max_retries" %in% names(seen))
+
+  # An explicit override still wins
+  seen <- NULL
+  f(make("json", backend = "json_mode"), structured = "structured", name = "run4")
+  expect_equal(seen$structured, "structured")
 })


### PR DESCRIPTION
## Summary

ellmer sends `response_format = {type: "json_schema", strict: true}` to every OpenAI-compatible
provider and takes the result on trust. Whether `strict` is honoured is entirely up to the
endpoint, and ellmer models no capability for it — so #128's local validation could only be
reached for DeepSeek, because the handler registry had exactly one entry.

Measured against ellmer 0.4.2 on 2026-09-01/02. An **adversarial probe** — a schema the endpoint
cannot satisfy plus instructions to violate it, so compliance proves there is no constrained
decoding, 3 trials each:

    openai / anthropic / google_gemini / mistral    no violation seen   0/3
    qwen-flash [dashscope] / glm-5.2 [dashscope]    no violation seen   0/3
    kimi-k3   [dashscope]                           NOT ENFORCED        2/3
    kimi-k2.6 [moonshot]                            NOT ENFORCED        1/3

And the **natural rate**, same question without the adversarial instruction, read with
`convert = FALSE` so violations stay visible rather than being coerced to `NA`:

    data_codebook_sentiment (1 enum, 1 integer), 25 texts
      kimi-k3 [dashscope]  0/25        kimi-k3 [moonshot]  0/25

    complex codebook (nested array, 4 enums, bounded numbers), 15 passages
      kimi-k3 [dashscope]  1/15  -> $ has unexpected properties: in_group, out_group
      kimi-k3 [moonshot]   0/15        qwen-flash [dashscope]  0/15

Low on a simple schema, non-zero on a complex one — and note *what* the one failure was. The
instructions asked for an in-group and out-group; the schema had no slot for either, so the
model invented two properties. `additionalProperties: false` makes that impossible on an
enforcing endpoint, and under the default `convert = TRUE` those keys are silently dropped and
the row looks perfect.

Fixes #134.

## Changes

`qlm_code()` gains `structured = c("auto", "structured", "json")`:

- **`"structured"`** — today's `parallel_chat_structured()` path; fails loudly if the call fails.
- **`"json"`** — ask for JSON, put the schema in the system prompt, validate each response
  against `codebook$schema` locally, re-prompt with the specific validation error. The reliable
  choice for an endpoint known not to enforce.
- **`"auto"`** (default) — attempt the structured call, fall back to `"json"` on failure.

Failure is detected two ways, because erroring is not sufficient: the call throwing, **and** a
result in which every required field is `NA` in every row — the signature of an endpoint that
accepted the schema and ignored it, as observed with `qwen3.5-397b-a17b` through Model Studio.
A partially incomplete result warns without triggering a fallback.

`code_handler_for()` becomes `default_structured_mode()`, returning `"json"` for DeepSeek —
whose API rejects the structured request outright, so `"auto"` would spend a guaranteed-wasted
round trip — and `"auto"` otherwise. It is only a default; an explicit `structured =` wins.

**The enforcement note.** `"auto"` catches wholesale non-enforcement, not the intermittent kind:
one bad row in fifteen leaves the all-`NA` check silent. Only `"json"` catches that, so
`qlm_code()` emits a one-time note when coding against an endpoint whose enforcement it cannot
verify, pointing at `structured = "json"`. Which endpoints those are is **derived from ellmer's
own request path** rather than a list of vendors: providers with their own enforced `chat_body()`
method (`ProviderOpenAI`, `ProviderAnthropic`, `ProviderGoogleGemini`, `ProviderAWSBedrock`,
`ProviderSnowflakeCortex`) enforce by construction; everything else falls through to
`ProviderOpenAICompatible`'s method. That cannot go stale in the dangerous direction — a
provider ellmer adds later defaults to "cannot vouch for this". Silenced with
`options(quallmer.quiet_schema_note = TRUE)`.

Two things beyond the original scope, both found while implementing:

- Under `batch = TRUE`, `"auto"` now aborts rather than falling back, since JSON mode has no
  batch path. Previously it would have failed later with a confusing message about `batch`.
- `qlm_replicate()` carries `structured` as well as `max_retries`. Reproducing a run means
  reproducing the coding path it took, not just its chat settings: a run that validated locally
  must replicate the same way, or it is not comparable to the run it claims to reproduce.

`max_retries` now errors only alongside `structured = "structured"`, where the JSON path is
unreachable, rather than for any non-DeepSeek provider.

## Tests

`[ FAIL 0 | WARN 2 | SKIP 3 | PASS 1048 ]` — the 2 warnings are pre-existing on `main`.

No network calls. The `parallel_chat_structured()` call moved into `try_structured_call()`, so
the four existing tests that stubbed it on `qlm_code()` now stub it on that function and hand
the prepared closure in — the seam moved, and the tests follow it.

New coverage: mode routing (`"structured"` never reaches the JSON path, `"json"` never attempts
the structured call); fallback on error and on all-`NA`; a partially incomplete result warning
without falling back; `"structured"` aborting instead; the batch guard; `required_scalar_fields()`
excluding list-columns; `all_required_missing()` not misreading a `convert = FALSE` result;
`provider_enforces_schema()` against real ellmer provider objects; and the note firing once,
being silenceable, and surviving a provider it cannot inspect.

Verified live against three endpoints:

| call | backend recorded | result |
|---|---|---|
| Kimi via Moonshot, `auto` | `structured` | correct; note fired once |
| Kimi via Moonshot, `structured = "json"` | `json_mode` | identical values and columns |
| qwen-flash via DashScope, `auto` | `structured` | correct |
| `openai/gpt-4o-mini` | `structured` | unchanged |

## Docs

- `@param structured`, a new **Schema enforcement** section on `qlm_code()`, and corrected
  `@param max_retries`.
- `dev/probe-schema-enforcement.R` gains `probe_natural()` and records both measurement sets.
- NEWS bullet.
- No roxygen churn this time — `DESCRIPTION` and `NAMESPACE` are untouched.

## Checklist

- [x] Linked issue — Fixes #134
- [x] Added/updated tests
- [x] Updated docs
- [x] Added NEWS bullet
- [x] `devtools::test()` passes locally
- [x] `devtools::check()` passes locally — 0 errors, 0 warnings, 0 notes

## Notes for Reviewers

**One branch is deliberately unreachable.** `is_json_word_error()` and its retry handle Alibaba
Model Studio rejecting `response_format` unless the prompt contains the word "json". That was
observed on 2026-08-12 with `response_format` of type `json_object`; ellmer sends `json_schema`,
which Model Studio accepted without complaint when checked live on 2026-09-02. It is kept as
defensive code and labelled as such in the roxygen block — *"Do not read its presence as evidence
that the quirk is live"* — and deliberately left out of NEWS, since a changelog entry for a
branch that never fires would misrepresent it.

**Deliberately not done: a provider-prefix registry.** `model = "openai_compatible/kimi-k3"` plus
`base_url =` already works and already distinguishes DashScope from Moonshot in `chat_args` — and
the probe shows that distinction matters, since the same `kimi-k3` behaves differently by route.
A prefix table would be a list of other vendors' endpoints and key names, could not replace
`openai_compatible/` anyway (self-hosted vLLM has no canonical name), and would reintroduce the
wrong-credential-to-wrong-vendor hazard that requiring explicit `credentials` prevents by
construction. Making that identity legible in the trail is #130's job, deriving it from
`base_url`, which also covers self-hosted endpoints. #129 stays free to decide the ergonomics
question separately.

**Caveat on the tables above:** the probe can prove non-enforcement but never prove enforcement.
The `0/3` and `0/15` rows are not clearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
