### PR TITLE
Generate a replication script that runs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,19 @@
 
 ## Bug fixes
 
+* `qlm_trail()` no longer advertises or generates a top-level `temperature`
+  argument. That form does not work -- it reaches `ellmer::chat()`, which has no
+  such argument -- so the replication script the audit trail generated could not
+  run, in the one document meant to show that a run can be reproduced. The
+  report now reads the sampling settings a run actually recorded, in
+  `chat_args$params`, and emits them as `params = ellmer::params()`. A legacy
+  `chat_args$temperature`, which older objects carry from the routing that was
+  never implemented, is folded into `params` on read, so an old trail file still
+  describes and reproduces itself in the form that works; `params$temperature`
+  is canonical and wins when both are present. Values are serialised one at a
+  time rather than through `unlist()`, so a vector-valued parameter such as
+  `stop = c("END", "STOP")` survives into the generated call (#127).
+
 * `qlm_code()` gains a `structured` argument controlling how the output schema
   is obtained, generalising the local-validation path added in #128 beyond
   DeepSeek. `"structured"` trusts the provider; `"json"` puts the schema in the

--- a/R/qlm_trail.R
+++ b/R/qlm_trail.R
@@ -468,8 +468,12 @@ generate_trail_report <- function(trail, file) {
       lines <- c(lines, paste("**Model:**", run$chat_args$name))
     }
 
-    if (!is.null(run$chat_args$temperature)) {
-      lines <- c(lines, paste("**Temperature:**", run$chat_args$temperature))
+    params <- run_params(run)
+    if (length(params) > 0) {
+      lines <- c(lines, paste(
+        "**Parameters:**",
+        paste(Map(format_param, names(params), params), collapse = ", ")
+      ))
     }
 
     # Codebook reference
@@ -701,15 +705,21 @@ generate_trail_report <- function(trail, file) {
 
       # Build qlm_code call
       model <- run$chat_args$name %||% "openai/gpt-4o"
-      temp <- run$chat_args$temperature
+      params <- run_params(run)
 
       code_call <- paste0("coded_", run$name, " <- qlm_code(")
       code_call <- paste0(code_call, "\n  texts,")
       code_call <- paste0(code_call, "\n  codebook_", run$name, ",")
       code_call <- paste0(code_call, "\n  model = \"", model, "\"")
 
-      if (!is.null(temp)) {
-        code_call <- paste0(code_call, ",\n  temperature = ", temp)
+      # Sampling settings belong in `params`, not at the top level, where they
+      # would reach ellmer::chat() and error. A generated script that cannot
+      # run is worse than one that omits the settings.
+      if (length(params) > 0) {
+        code_call <- paste0(
+          code_call, ",\n  params = ellmer::params(",
+          paste(Map(format_param, names(params), params), collapse = ", "), ")"
+        )
       }
 
       if (!is.null(run$batch) && run$batch) {
@@ -792,7 +802,7 @@ generate_trail_report <- function(trail, file) {
   lines <- c(lines, "")
   lines <- c(lines, "LLM outputs are inherently stochastic. To improve reproducibility:")
   lines <- c(lines, "")
-  lines <- c(lines, "- Use `temperature = 0` for more deterministic outputs")
+  lines <- c(lines, "- Use `params = ellmer::params(temperature = 0)` for more deterministic outputs")
   lines <- c(lines, "- Set a random seed where supported by the provider")
   lines <- c(lines, "- Document the exact model version (models are updated over time)")
   lines <- c(lines, "- Compare results across multiple runs using `qlm_replicate()`")
@@ -863,4 +873,65 @@ format_metric_rows <- function(df, label_fn, extra_label_col = NULL) {
     if (i < length(variables)) out <- c(out, "")
   }
   out
+}
+
+
+#' Sampling parameters recorded for a run
+#'
+#' `qlm_code()` takes sampling settings as `params = ellmer::params(...)` and
+#' stores them in `chat_args$params`. Older runs recorded a bare
+#' `chat_args$temperature` instead, from a routing that was never implemented:
+#' a top-level `temperature` reaches [ellmer::chat()], which has no such
+#' argument, so the call errored. That shape is read here and folded into
+#' `params` so an old trail still describes and reproduces itself in the form
+#' that works, but it is never displayed or emitted. `params$temperature` is
+#' canonical and wins when both are present.
+#'
+#' @param run One element of `trail$runs`.
+#'
+#' @return A named list of sampling parameters, possibly empty.
+#' @keywords internal
+#' @noRd
+run_params <- function(run) {
+  params <- run$chat_args$params %||% list()
+
+  if (is.null(params$temperature) && !is.null(run$chat_args$temperature)) {
+    params$temperature <- run$chat_args$temperature
+  }
+
+  params
+}
+
+
+#' Deparse one value onto a single line
+#'
+#' Values are serialised one at a time rather than through `unlist()`, which
+#' would flatten a vector-valued parameter such as `stop = c("END", "STOP")`
+#' into separate entries and lose the distinction between `0` and `"0"`. This
+#' is `deparse1()`, which cannot be used directly because the package supports
+#' R (>= 3.5.0) and `deparse1()` arrived in R 4.0.0.
+#'
+#' @param value Any value short enough to belong in a parameter list.
+#'
+#' @return A character scalar.
+#' @keywords internal
+#' @noRd
+deparse_value <- function(value) {
+  paste(deparse(value, width.cutoff = 500L), collapse = " ")
+}
+
+
+#' Format one named parameter as `name = value`
+#'
+#' Serves both the metadata readout and the generated replication call, so the
+#' report describes exactly what the script will run.
+#'
+#' @param name Parameter name.
+#' @param value Parameter value.
+#'
+#' @return A character scalar.
+#' @keywords internal
+#' @noRd
+format_param <- function(name, value) {
+  paste0(name, " = ", deparse_value(value))
 }

--- a/R/trail_settings.R
+++ b/R/trail_settings.R
@@ -2,9 +2,12 @@
 #'
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `trail_settings()` is deprecated. Use [qlm_code()] with the `model` and
-#' `temperature` parameters directly instead. For systematic comparisons across
-#' different models or settings, see [qlm_replicate()].
+#' `trail_settings()` is deprecated. Use [qlm_code()] instead, passing the
+#' model as `model` and sampling settings as
+#' `params = ellmer::params(temperature = )`. A top-level `temperature`
+#' argument does not work: it reaches [ellmer::chat()], which has no such
+#' argument. For systematic comparisons across different models or settings,
+#' see [qlm_replicate()].
 #'
 #' @param provider Character. Backend provider identifier supported by ellmer,
 #'   e.g. "openai", "ollama", "anthropic". See

--- a/man/trail_settings.Rd
+++ b/man/trail_settings.Rd
@@ -31,8 +31,11 @@ An object of class \code{"trail_setting"}.
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \details{
-\code{trail_settings()} is deprecated. Use \code{\link[=qlm_code]{qlm_code()}} with the \code{model} and
-\code{temperature} parameters directly instead. For systematic comparisons across
-different models or settings, see \code{\link[=qlm_replicate]{qlm_replicate()}}.
+\code{trail_settings()} is deprecated. Use \code{\link[=qlm_code]{qlm_code()}} instead, passing the
+model as \code{model} and sampling settings as
+\code{params = ellmer::params(temperature = )}. A top-level \code{temperature}
+argument does not work: it reaches \code{\link[ellmer:chat]{ellmer::chat()}}, which has no such
+argument. For systematic comparisons across different models or settings,
+see \code{\link[=qlm_replicate]{qlm_replicate()}}.
 }
 \keyword{internal}

--- a/tests/testthat/test-qlm_trail.R
+++ b/tests/testthat/test-qlm_trail.R
@@ -562,3 +562,136 @@ test_that("qlm_trail() report includes codebook information", {
   expect_true(any(grepl("Sentiment Codebook", content)))
   expect_true(any(grepl("positive or negative", content)))
 })
+
+
+# ---- sampling parameters in the trail (#127) --------------------------------
+
+# Minimum coded object for which generate_trail_report() emits both a metadata
+# block and a replication block for one run.
+trail_params_fixture <- function(chat_args, name = "run1") {
+  coded <- data.frame(.id = 1:3, polarity = c("pos", "neg", "pos"))
+  class(coded) <- c("qlm_coded", "data.frame")
+  attr(coded, "run") <- list(
+    name = name,
+    parent = NULL,
+    call = quote(qlm_code(data, codebook)),
+    metadata = list(
+      timestamp = as.POSIXct("2024-01-01 12:00:00"),
+      n_units = 3
+    ),
+    chat_args = chat_args,
+    codebook = list(name = "sentiment", instructions = "Code sentiment")
+  )
+  coded
+}
+
+trail_params_report <- function(chat_args, name = "run1") {
+  path <- file.path(tempdir(), "test_trail_params")
+  withr::defer_parent(unlink(paste0(path, c(".rds", ".qmd"))))
+  qlm_trail(trail_params_fixture(chat_args, name), path = path)
+  readLines(paste0(path, ".qmd"))
+}
+
+# The generated block is only useful if the sampling settings land where
+# qlm_code() actually reads them, so assert on the parsed call rather than on
+# the text: correct output contains "temperature =" too, nested inside
+# ellmer::params().
+qlm_code_call <- function(content, run_name = "run1") {
+  start <- grep(paste0("^#### Replicate: ", run_name, "$"), content)[1]
+  fences <- grep("^```", content[start:length(content)]) + start - 1L
+  block <- content[(fences[1] + 1L):(fences[2] - 1L)]
+  exprs <- as.list(parse(text = paste(block, collapse = "\n")))
+  hits <- Filter(function(e) {
+    is.call(e) && identical(e[[1]], as.name("<-")) &&
+      is.call(e[[3]]) && identical(e[[3]][[1]], as.name("qlm_code"))
+  }, exprs)
+  as.list(hits[[1]][[3]])[-1]
+}
+
+
+test_that("qlm_trail() report reads sampling settings from chat_args$params (#127)", {
+  content <- trail_params_report(list(
+    name = "openai/gpt-4o-mini",
+    params = list(temperature = 0, top_p = 0.95)
+  ))
+
+  expect_true(any(grepl(
+    "**Parameters:** temperature = 0, top_p = 0.95",
+    content, fixed = TRUE
+  )))
+
+  args <- qlm_code_call(content)
+  expect_false("temperature" %in% names(args))
+  expect_true("params" %in% names(args))
+  expect_equal(deparse(args$params[[1]]), "ellmer::params")
+
+  pargs <- as.list(args$params)[-1]
+  expect_equal(pargs$temperature, 0)
+  expect_equal(pargs$top_p, 0.95)
+})
+
+
+test_that("qlm_trail() normalises a legacy chat_args$temperature into params (#127)", {
+  content <- trail_params_report(list(
+    name = "openai/gpt-4o-mini",
+    temperature = 0.3
+  ))
+
+  # The obsolete form is read but never shown or emitted.
+  expect_false(any(grepl("**Temperature:**", content, fixed = TRUE)))
+  expect_true(any(grepl("**Parameters:** temperature = 0.3", content, fixed = TRUE)))
+
+  args <- qlm_code_call(content)
+  expect_false("temperature" %in% names(args))
+  pargs <- as.list(args$params)[-1]
+  expect_equal(pargs$temperature, 0.3)
+})
+
+
+test_that("qlm_trail() prefers params over a legacy temperature (#127)", {
+  content <- trail_params_report(list(
+    name = "openai/gpt-4o-mini",
+    params = list(temperature = 0),
+    temperature = 0.9
+  ))
+
+  pargs <- as.list(qlm_code_call(content)$params)[-1]
+  expect_equal(pargs$temperature, 0)
+})
+
+
+test_that("qlm_trail() serialises parameter values one at a time (#127)", {
+  content <- trail_params_report(list(
+    name = "openai/gpt-4o-mini",
+    params = list(
+      temperature = 0,
+      label = 'a "quoted" phrase',
+      stop = c("END", "STOP")
+    )
+  ))
+
+  # unlist() would flatten the vector into separate entries here.
+  expect_true(any(grepl('stop = c("END", "STOP")', content, fixed = TRUE)))
+
+  pargs <- as.list(qlm_code_call(content)$params)[-1]
+  expect_equal(eval(pargs$label), 'a "quoted" phrase')
+  expect_equal(eval(pargs$stop), c("END", "STOP"))
+})
+
+
+test_that("qlm_trail() omits parameters entirely when a run recorded none (#127)", {
+  content <- trail_params_report(list(name = "openai/gpt-4o-mini"))
+
+  expect_false(any(grepl("**Parameters:**", content, fixed = TRUE)))
+  expect_false("params" %in% names(qlm_code_call(content)))
+})
+
+
+test_that("qlm_trail() reproducibility advice uses the form that works (#127)", {
+  content <- trail_params_report(list(name = "openai/gpt-4o-mini"))
+
+  expect_true(any(grepl(
+    "Use `params = ellmer::params(temperature = 0)` for more deterministic",
+    content, fixed = TRUE
+  )))
+})


### PR DESCRIPTION
Closes #127.

`qlm_trail()` told the reader to pass `temperature = 0` to `qlm_code()` and wrote `temperature = <x>` into the replication script it generates. That argument reaches `ellmer::chat()`, which has no such parameter, so the call errors — the audit trail handed out code that cannot run, in the one document meant to show that a run can be reproduced.

This is the half of #127 that #138 left behind, having removed the dead `model_param_names` and documented the `params` / `api_args` split.

## What changed

`R/qlm_trail.R`, three sites in `generate_trail_report()` plus three internal helpers:

- the metadata block now renders `**Parameters:** temperature = 0, top_p = 0.95` from `chat_args$params`, replacing a `**Temperature:**` readout of a field no run has ever been able to record
- the generated replication call emits `params = ellmer::params(...)`
- the reproducibility advice shows that same working form

`run_params()` folds a legacy `chat_args$temperature` into `params` on read rather than dropping it, so an object carrying the older shape still describes and reproduces itself in the form that works. `params$temperature` is canonical and wins when both are present.

Values are deparsed one at a time rather than through `unlist()`, which would flatten `stop = c("END", "STOP")` into separate entries and lose the difference between `0` and `"0"`. `deparse1()` would be the obvious tool and is not used: it arrived in R 4.0.0 and `DESCRIPTION` declares `R (>= 3.5.0)`, which the package otherwise honours (no `|>`, no `\(x)`).

`trail_settings()`'s deprecation notice pointed at the same broken form and now points at `params`.

## Tests

The six new tests assert on the **parsed call tree**, not on the report text, because searching for `temperature =` cannot tell right from wrong — correct output contains that string too, nested inside `ellmer::params()`. They check that there is no top-level `temperature` argument, that `params` is present and calls `ellmer::params()`, and that the expected settings appear inside it.

Coverage: modern `params`, legacy `temperature` normalised, canonical winning over legacy, value serialisation round-tripping (a quoted string and a character vector), and no params meaning no output at all.

Run against the previous code in a scratch worktree, 14 of the new assertions fail — so they are wired to the behaviour rather than passing on both versions.

Full suite on this branch: `FAIL 0 | WARN 2 | SKIP 70 | PASS 908`. The 2 warnings are in `test-qlm_compare.R:336` and `test-qlm_validate.R:93`, untouched files where `expect_error()` tests surface intentional warnings; both pre-exist this branch.

## Note for review

`NAMESPACE` is deliberately not restaged. The roxygen2 installed locally is 8.0.0 against the 8.1.0 this package records in `Config/roxygen2/version`, and it reformats every `importFrom()` line. Only the intended `man/trail_settings.Rd` is committed.

## Out of scope

- **#139** — rejecting top-level model parameters with a pointer to `params` / `api_args`. That is the input side.
- **#130** — the generated script still omits `base_url` / `credentials` / `api_args`, so an `openai_compatible/` run will not replicate from the report alone.
- `annotate()` (`R/annotate.R:37`) passes `model_name` to `qlm_code()`, whose formal is `model`, so the deprecated `annotate()` / `trail_record()` path cannot run at all. Same family, different function; being filed separately.
