### PR TITLE
Fix the URL check note, ignore the repomix dump, drop the sign-commits rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -153,17 +153,16 @@ quallmer builds on the ellmer framework. Key points:
 - Use imperative mood: "Add feature" not "Added feature"
 - Keep subject line concise (50 chars or less)
 - Reference issues when applicable: "Fixes #21", "Closes #45"
-- Include Claude Code attribution when appropriate:
-  ```
-  Add trail comparison summary
-
-  Generated with Claude Code
-
-  Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
-  ```
+- Do not add a `Co-Authored-By: Claude ...` trailer or a "Generated with Claude
+  Code" line. No commit in this repository carries one and they are not wanted
+  here; end the message at the issue reference.
+- Explain *why* in the body, not just what changed. See the commits on #138 and
+  #142 for the house style.
 
 ### Pull Requests
-Use `.github/pull_request_template.md` to structure PRs. Include:
+`.github/pull_request_template.md` is a starting point, not a requirement --
+prefer a more direct structure when the change calls for one. Either way,
+cover:
 - **Clear summary**: What does this PR do?
 - **Motivation**: Why is this change needed?
 - **Scope**: What files/functions are affected?

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ batch_results.json
 .positai
 Kripp_Ch12.pdf
 sources
+repomix-output.xml

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -20,7 +20,7 @@ Our tutorials provide a brief introduction to the `quallmer` package, which is d
 
 ## Basic usage
 
-The `quallmer` package is developed for using it in R. Please make sure you have a recent version of [R and RStudio installed](https://posit.co/download/rstudio-desktop) on your computer. If you are new to R and RStudio, you can find [a great and free-of-charge 1.5h introduction to R and RStudio on instats](https://instats.org/seminar/introduction-to-r-with-rstudio-free-1-h3). 
+The `quallmer` package is developed for using it in R. Please make sure you have a recent version of [R and RStudio installed](https://docs.posit.co/ide/user/#rstudio-ide-oss-downloads) on your computer. If you are new to R and RStudio, you can find [a great and free-of-charge 1.5h introduction to R and RStudio on instats](https://instats.org/seminar/introduction-to-r-with-rstudio-free-1-h3). 
 
 To get started with `quallmer`, you first need to install the package from GitHub. 
 


### PR DESCRIPTION
Three unrelated bits of housekeeping, kept off #142 so that PR stays about #127.

## Fix the URL that R CMD check flags

```
Found the following (possibly) invalid URLs:
  URL: https://posit.co/download/rstudio-desktop
    From: inst/doc/getting-started.html
    Status: 301
```

`vignettes/getting-started.Rmd` now links to `https://docs.posit.co/ide/user/#rstudio-ide-oss-downloads`, which returns **200 on the first hop**.

Worth noting that check's own advice does not work here: adding a trailing slash still 301s (`https://posit.co/download/rstudio-desktop/` → same target). The new URL is the redirect destination minus its `?ref=rstudio-legacy` parameter, which is malformed anyway — a query string after a fragment.

Fixed in the vignette source; check reported it from `inst/doc/getting-started.html`, which is build output.

While in there I checked the other 33 URLs in `vignettes/`, `README.Rmd`, `DESCRIPTION`, `man/` and `NEWS.md` for first-hop status. No other permanent redirects, so this should be the last of these notes. `https://CRAN.R-project.org/package=quallmer` returns 303 but is the canonical form CRAN itself recommends, so it is left alone.

## Ignore the repomix dump

`repomix-output.xml` is generated output that has been sitting untracked across several commits. `.Rbuildignore` already excluded it from the build, so this only affects `git status`.

## Stop telling Claude to sign commits

`.claude/CLAUDE.md` asked for a `Co-Authored-By: Claude` trailer and a "Generated with Claude Code" line. Neither is wanted here and no commit in this repository carries one, so the guidance was actively producing trailers that then had to be amended off by hand.

Also softened the PR section: the template is now described as a starting point rather than a requirement, since a structure matched to the change is usually clearer than the generic sections.

## Verification

Nothing here touches package code, so the test suite is unaffected — but for the record, `FAIL 0 | WARN 2 | SKIP 70 | PASS 908` on this branch, with the 2 warnings pre-existing in `test-qlm_compare.R:336` and `test-qlm_validate.R:93`.
