### PR TITLE
Say which providers work, instead of naming an ellmer internal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,18 @@
 
 ## Bug fixes
 
+* `qlm_code()` and `qlm_segment()` now say what to do when a model's provider
+  prefix is not one ellmer can dispatch on. `model = "qwen/qwen3-max"` reached
+  `ellmer::chat()` and failed with `Can't find provider ellmer::chat_qwen()`,
+  which names an ellmer internal and offers no way forward. The error now names
+  every prefix that does work and points at `openai_compatible/<model>` with
+  `base_url` and `credentials`, which is how any other OpenAI-compatible
+  endpoint is reached. The list of working prefixes is derived from the
+  installed ellmer at run time, mirroring both gates `ellmer::chat()` applies,
+  so a provider ellmer adds or drops later needs no change here. Checked before
+  any request is made, since the answer does not depend on asking the provider
+  anything (#129).
+
 * `qlm_trail()` no longer advertises or generates a top-level `temperature`
   argument. That form does not work -- it reaches `ellmer::chat()`, which has no
   such argument -- so the replication script the audit trail generated could not

--- a/R/providers.R
+++ b/R/providers.R
@@ -1,0 +1,94 @@
+#' Provider prefix of a model specification
+#'
+#' `qlm_code()` and `qlm_segment()` take `model` in ellmer's
+#' `"provider/model"` form, or `"provider"` alone. This returns the provider
+#' part, which is what dispatch and several defaults key on.
+#'
+#' @param model A model specification, e.g. `"openai/gpt-4o-mini"`.
+#'
+#' @return A character scalar.
+#' @keywords internal
+#' @noRd
+model_provider <- function(model) {
+  sub("/.*$", "", model)
+}
+
+
+#' Providers reachable by name through ellmer
+#'
+#' [ellmer::chat()] dispatches on the model string's prefix: it looks up
+#' `chat_<provider>()` in ellmer's namespace and additionally requires that
+#' function to take `model`, `system_prompt` and `params`, calling anything
+#' else unsupported. Both gates are mirrored here so that this list is exactly
+#' the set of prefixes that can work.
+#'
+#' Derived from the installed ellmer at run time rather than hard-coded, so a
+#' provider ellmer adds or drops later needs no change here.
+#'
+#' @return A sorted character vector of provider names, without the `chat_`
+#'   prefix.
+#' @keywords internal
+#' @noRd
+ellmer_providers <- function() {
+  ns <- asNamespace("ellmer")
+  fns <- grep("^chat_", getNamespaceExports("ellmer"), value = TRUE)
+
+  # The same three formals ellmer::chat() insists on before dispatching.
+  dispatchable <- vapply(
+    fns,
+    function(fn) {
+      all(c("model", "system_prompt", "params") %in% names(formals(get(fn, envir = ns))))
+    },
+    logical(1)
+  )
+
+  sort(sub("^chat_", "", fns[dispatchable]))
+}
+
+
+#' Fail early when a model's provider cannot be reached by name
+#'
+#' Without this, `model = "qwen/qwen3-max"` reaches [ellmer::chat()] and aborts
+#' with `Can't find provider ellmer::chat_qwen()`, which leaks an ellmer
+#' internal and says nothing about what to do instead. Every provider ellmer
+#' has no `chat_*()` for is reachable as `openai_compatible/<model>` with a
+#' `base_url`, so the error names both the prefixes that work and that route.
+#'
+#' Checked before any request rather than by interpreting a failure, because
+#' the answer is known without asking the provider anything.
+#'
+#' @param model A model specification, as passed to [qlm_code()].
+#' @param call The calling environment, for the error message.
+#'
+#' @return `model`, invisibly.
+#' @keywords internal
+#' @noRd
+check_model_provider <- function(model, call = rlang::caller_env()) {
+  # Anything that is not a single string is not this function's business:
+  # callers validate that themselves, or ellmer's own `check_string()` does.
+  if (!is.character(model) || length(model) != 1L || is.na(model)) {
+    return(invisible(model))
+  }
+
+  provider <- model_provider(model)
+  providers <- ellmer_providers()
+
+  if (provider %in% providers) {
+    return(invisible(model))
+  }
+
+  # cli truncates a vector this long by default ("openrouter", ..., "vllm"),
+  # which would hide several of the very names the message exists to give.
+  providers <- cli::cli_vec(providers, style = list("vec-trunc" = Inf))
+
+  cli::cli_abort(
+    c(
+      "Can't reach provider {.val {provider}} by name.",
+      "i" = "{.fn ellmer::chat} dispatches on the prefix of {.arg model}, and ellmer has no {.fn ellmer::chat_{provider}}.",
+      "i" = "Reachable by name: {.val {providers}}.",
+      "i" = "Any other OpenAI-compatible endpoint is reachable as {.code openai_compatible/<model>} with {.arg base_url} and {.arg credentials}.",
+      "i" = "See the {.strong Provider-specific parameters} section of {.code ?qlm_code} for a worked example."
+    ),
+    call = call
+  )
+}

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -224,6 +224,11 @@ qlm_code <- function(x, codebook, model, ...,
     ))
   }
 
+  # A prefix ellmer cannot dispatch on is knowable without asking the provider
+  # anything, so say so here rather than letting ellmer::chat() abort with
+  # "Can't find provider ellmer::chat_qwen()".
+  check_model_provider(model)
+
   # Providers whose API rejects the schema-constrained request skip straight to
   # JSON mode rather than spending a wasted round trip; see
   # default_structured_mode().
@@ -398,7 +403,7 @@ qlm_code <- function(x, codebook, model, ...,
 #' @keywords internal
 #' @noRd
 default_structured_mode <- function(model) {
-  provider <- sub("/.*$", "", model)
+  provider <- model_provider(model)
 
   switch(provider,
     deepseek = "json",

--- a/R/qlm_segment.R
+++ b/R/qlm_segment.R
@@ -138,6 +138,11 @@ qlm_segment <- function(x, codebook, model, ..., name = NULL, notes = NULL) {
     ))
   }
 
+  # Dispatches by name through ellmer::chat() just as qlm_code() does, so an
+  # unreachable prefix gets the same explanation here. Checked after the input
+  # and codebook, which are the more fundamental problems when both are wrong.
+  check_model_provider(model)
+
   # Build internal schema: text field prepended to user-defined fields
   user_props <- codebook$schema@properties
   items_schema <- do.call(

--- a/tests/testthat/test-providers.R
+++ b/tests/testthat/test-providers.R
@@ -1,3 +1,12 @@
+# A prefix ellmer will never export a `chat_*()` for.
+#
+# Naming a real provider here -- "qwen", "kimi" -- would assert that it stays
+# unsupported, so these tests would start failing the day ellmer adds it. That
+# is the opposite of the property this file exists to check: that the supported
+# set is derived from the installed ellmer and needs no change here. See #129.
+unknown_provider <- "quallmer_unknown_provider_7f3c"
+
+
 test_that("model_provider() takes the prefix, or the whole string", {
   expect_equal(model_provider("openai/gpt-4o-mini"), "openai")
   expect_equal(model_provider("openai"), "openai")
@@ -17,7 +26,7 @@ test_that("ellmer_providers() reports the prefixes ellmer::chat() can dispatch o
   # Named rather than counted: a count would break every time ellmer adds a
   # provider, which is the churn deriving the list at run time avoids.
   expect_true(all(c("openai", "anthropic", "openai_compatible") %in% providers))
-  expect_false("qwen" %in% providers)
+  expect_false(unknown_provider %in% providers)
 
   # Every name reported must round-trip to a function ellmer exports.
   expect_true(all(paste0("chat_", providers) %in% getNamespaceExports("ellmer")))
@@ -38,22 +47,22 @@ test_that("ellmer_providers() excludes anything ellmer::chat() would refuse", {
 
 test_that("check_model_provider() explains an unreachable provider (#129)", {
   expect_error(
-    check_model_provider("qwen/qwen3-max"),
+    check_model_provider(paste0(unknown_provider, "/some-model")),
     "Can't reach provider"
   )
 
-  err <- tryCatch(check_model_provider("qwen/qwen3-max"), error = function(e) e)
+  err <- tryCatch(check_model_provider(paste0(unknown_provider, "/some-model")), error = function(e) e)
   msg <- cli::ansi_strip(paste(conditionMessage(err), collapse = "\n"))
 
   # The three things the bare ellmer error left the user without.
-  expect_match(msg, "qwen", fixed = TRUE)
+  expect_match(msg, unknown_provider, fixed = TRUE)
   expect_match(msg, "openai_compatible/<model>", fixed = TRUE)
   expect_match(msg, "base_url", fixed = TRUE)
 })
 
 
 test_that("check_model_provider() names every provider, without cli truncation (#129)", {
-  err <- tryCatch(check_model_provider("qwen/qwen3-max"), error = function(e) e)
+  err <- tryCatch(check_model_provider(paste0(unknown_provider, "/some-model")), error = function(e) e)
   msg <- cli::ansi_strip(paste(conditionMessage(err), collapse = "\n"))
 
   # cli abbreviates a vector this long by default, which would silently drop
@@ -62,6 +71,17 @@ test_that("check_model_provider() names every provider, without cli truncation (
     expect_match(msg, provider, fixed = TRUE)
   }
   expect_false(grepl("\u2026", msg))
+})
+
+
+test_that("check_model_provider() accepts every provider ellmer reports", {
+  # The forward-compatible half of the same property: if ellmer gains
+  # chat_qwen(), it appears in ellmer_providers() and is accepted here with no
+  # change to this file.
+  for (provider in ellmer_providers()) {
+    expect_silent(check_model_provider(provider))
+    expect_silent(check_model_provider(paste0(provider, "/some-model")))
+  }
 })
 
 
@@ -94,17 +114,17 @@ test_that("qlm_code() and qlm_segment() reject an unreachable provider before re
 
   # No request is made, so these need no credentials and no network.
   expect_error(
-    qlm_code(c("great", "awful"), cb, model = "qwen/qwen3-max"),
+    qlm_code(c("great", "awful"), cb, model = paste0(unknown_provider, "/some-model")),
     "Can't reach provider"
   )
   expect_error(
-    qlm_code(c("great", "awful"), cb, model = "kimi"),
+    qlm_code(c("great", "awful"), cb, model = unknown_provider),
     "Can't reach provider"
   )
 
   skip_if_not_installed("quanteda")
   expect_error(
-    qlm_segment("A sentence. Another one.", cb, model = "qwen/qwen3-max"),
+    qlm_segment("A sentence. Another one.", cb, model = paste0(unknown_provider, "/some-model")),
     "Can't reach provider"
   )
 })

--- a/tests/testthat/test-providers.R
+++ b/tests/testthat/test-providers.R
@@ -1,0 +1,123 @@
+test_that("model_provider() takes the prefix, or the whole string", {
+  expect_equal(model_provider("openai/gpt-4o-mini"), "openai")
+  expect_equal(model_provider("openai"), "openai")
+  # ellmer joins the remainder back with "/", so only the first "/" separates.
+  expect_equal(model_provider("openai_compatible/org/model-1"), "openai_compatible")
+})
+
+
+test_that("ellmer_providers() reports the prefixes ellmer::chat() can dispatch on", {
+  providers <- ellmer_providers()
+
+  expect_type(providers, "character")
+  expect_true(length(providers) > 0)
+  expect_equal(providers, sort(providers))
+  expect_false(anyDuplicated(providers) > 0)
+
+  # Named rather than counted: a count would break every time ellmer adds a
+  # provider, which is the churn deriving the list at run time avoids.
+  expect_true(all(c("openai", "anthropic", "openai_compatible") %in% providers))
+  expect_false("qwen" %in% providers)
+
+  # Every name reported must round-trip to a function ellmer exports.
+  expect_true(all(paste0("chat_", providers) %in% getNamespaceExports("ellmer")))
+})
+
+
+test_that("ellmer_providers() excludes anything ellmer::chat() would refuse", {
+  # ellmer::chat() requires `model`, `system_prompt` and `params` before it
+  # dispatches, so a chat_*() lacking them is not reachable by name even
+  # though it exists.
+  required <- c("model", "system_prompt", "params")
+  for (provider in ellmer_providers()) {
+    fn <- get(paste0("chat_", provider), envir = asNamespace("ellmer"))
+    expect_true(all(required %in% names(formals(fn))), info = provider)
+  }
+})
+
+
+test_that("check_model_provider() explains an unreachable provider (#129)", {
+  expect_error(
+    check_model_provider("qwen/qwen3-max"),
+    "Can't reach provider"
+  )
+
+  err <- tryCatch(check_model_provider("qwen/qwen3-max"), error = function(e) e)
+  msg <- cli::ansi_strip(paste(conditionMessage(err), collapse = "\n"))
+
+  # The three things the bare ellmer error left the user without.
+  expect_match(msg, "qwen", fixed = TRUE)
+  expect_match(msg, "openai_compatible/<model>", fixed = TRUE)
+  expect_match(msg, "base_url", fixed = TRUE)
+})
+
+
+test_that("check_model_provider() names every provider, without cli truncation (#129)", {
+  err <- tryCatch(check_model_provider("qwen/qwen3-max"), error = function(e) e)
+  msg <- cli::ansi_strip(paste(conditionMessage(err), collapse = "\n"))
+
+  # cli abbreviates a vector this long by default, which would silently drop
+  # names from the one message whose job is to list them.
+  for (provider in ellmer_providers()) {
+    expect_match(msg, provider, fixed = TRUE)
+  }
+  expect_false(grepl("\u2026", msg))
+})
+
+
+test_that("check_model_provider() passes anything reachable by name", {
+  expect_silent(check_model_provider("openai/gpt-4o-mini"))
+  expect_silent(check_model_provider("openai"))
+  expect_silent(check_model_provider("anthropic/claude-sonnet-4-5"))
+  expect_silent(check_model_provider("openai_compatible/qwen3-max"))
+
+  expect_equal(check_model_provider("openai"), "openai")
+})
+
+
+test_that("check_model_provider() leaves non-strings to the caller's own check", {
+  # qlm_code() reports these itself, and ellmer's check_string() covers the
+  # rest; duplicating that here would report the wrong problem.
+  expect_silent(check_model_provider(NULL))
+  expect_silent(check_model_provider(character(0)))
+  expect_silent(check_model_provider(NA_character_))
+  expect_silent(check_model_provider(c("openai", "anthropic")))
+  expect_silent(check_model_provider(42))
+})
+
+
+test_that("qlm_code() and qlm_segment() reject an unreachable provider before requesting (#129)", {
+  cb <- qlm_codebook(
+    "sentiment", "Code the sentiment.",
+    ellmer::type_object(polarity = ellmer::type_string("pos or neg"))
+  )
+
+  # No request is made, so these need no credentials and no network.
+  expect_error(
+    qlm_code(c("great", "awful"), cb, model = "qwen/qwen3-max"),
+    "Can't reach provider"
+  )
+  expect_error(
+    qlm_code(c("great", "awful"), cb, model = "kimi"),
+    "Can't reach provider"
+  )
+
+  skip_if_not_installed("quanteda")
+  expect_error(
+    qlm_segment("A sentence. Another one.", cb, model = "qwen/qwen3-max"),
+    "Can't reach provider"
+  )
+})
+
+
+test_that("qlm_code() still reports a malformed model before looking at the provider", {
+  cb <- qlm_codebook(
+    "sentiment", "Code the sentiment.",
+    ellmer::type_object(polarity = ellmer::type_string("pos or neg"))
+  )
+
+  expect_error(
+    qlm_code(c("great", "awful"), cb, model = c("openai", "anthropic")),
+    "must be a single string"
+  )
+})

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -292,7 +292,7 @@ test_that("qlm_code passes provider-specific arguments to ellmer::chat", {
   mockery::stub(f, "try_structured_call", tsc)
 
   # Call with a provider-specific argument (like base_url for openai_compatible)
-  f(c("text1", "text2"), codebook, model = "test/model",
+  f(c("text1", "text2"), codebook, model = "openai_compatible/test-model",
            base_url = "https://my-api.com/v1")
 
   # Verify the provider-specific argument was passed through to ellmer::chat
@@ -319,7 +319,7 @@ test_that("qlm_code uses parallel_chat_structured when batch=FALSE", {
   mockery::stub(f, "try_structured_call", tsc)
 
   result <- f(c("text1", "text2"), codebook,
-                     model = "test/model", batch = FALSE)
+                     model = "openai_compatible/test-model", batch = FALSE)
 
   # Verify parallel_chat_structured was called
   mockery::expect_called(mock_pcs, 1)
@@ -350,7 +350,7 @@ test_that("qlm_code uses batch_chat_structured when batch=TRUE", {
   # Use an execution arg that's valid (convert is in both parallel and batch)
   result <- suppressWarnings(
     f(c("text1", "text2"), codebook,
-      model = "test/model", batch = TRUE,
+      model = "openai_compatible/test-model", batch = TRUE,
       convert = TRUE)
   )
 
@@ -381,7 +381,7 @@ test_that("qlm_code builds metadata correctly", {
   mockery::stub(f, "try_structured_call", tsc)
 
   result <- f(c("text1", "text2", "text3"), codebook,
-              model = "test/model")
+              model = "openai_compatible/test-model")
 
   meta_attr <- attr(result, "meta")
 

--- a/tests/testthat/test-qlm_segment.R
+++ b/tests/testthat/test-qlm_segment.R
@@ -88,7 +88,7 @@ test_that("qlm_segment returns a quanteda corpus from character input", {
   mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
 
   input  <- c(review1 = "Clean room. Basic furnishings.", review2 = "Great location.")
-  result <- qlm_segment(input, cb, model = "test/model")
+  result <- qlm_segment(input, cb, model = "openai_compatible/test-model")
 
   expect_true(quanteda::is.corpus(result))
   expect_equal(quanteda::ndoc(result), 3L)
@@ -119,7 +119,7 @@ test_that("qlm_segment sets docvars correctly from character input", {
 
   result <- qlm_segment(
     c(review1 = "Clean room. Basic furnishings.", review2 = "Great location."),
-    cb, model = "test/model"
+    cb, model = "openai_compatible/test-model"
   )
 
   dv <- quanteda::docvars(result)
@@ -147,7 +147,7 @@ test_that("qlm_segment uses sequential text labels for unnamed character input",
   mockery::stub(qlm_segment, "ellmer::chat", mock_chat)
   mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
 
-  result <- qlm_segment(c("Text one.", "Text two."), cb, model = "test/model")
+  result <- qlm_segment(c("Text one.", "Text two."), cb, model = "openai_compatible/test-model")
 
   expect_equal(quanteda::docnames(result), c("text1.1", "text2.1"))
   expect_equal(quanteda::docvars(result)$docid, c("text1", "text2"))
@@ -179,7 +179,7 @@ test_that("qlm_segment returns a corpus from corpus input", {
   mockery::stub(qlm_segment, "ellmer::chat", mock_chat)
   mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
 
-  result <- qlm_segment(corp, cb, model = "test/model")
+  result <- qlm_segment(corp, cb, model = "openai_compatible/test-model")
 
   expect_true(quanteda::is.corpus(result))
   expect_equal(quanteda::ndoc(result), 3L)
@@ -210,7 +210,7 @@ test_that("qlm_segment corpus output inherits parent docvars", {
   mockery::stub(qlm_segment, "ellmer::chat", mock_chat)
   mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
 
-  result <- qlm_segment(corp, cb, model = "test/model")
+  result <- qlm_segment(corp, cb, model = "openai_compatible/test-model")
   dv     <- quanteda::docvars(result)
 
   expect_equal(quanteda::ndoc(result), 2L)
@@ -239,7 +239,7 @@ test_that("qlm_segment warns for documents producing no segments", {
   mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
 
   expect_warning(
-    qlm_segment(c(doc1 = "Text one.", doc2 = "Text two."), cb, model = "test/model"),
+    qlm_segment(c(doc1 = "Text one.", doc2 = "Text two."), cb, model = "openai_compatible/test-model"),
     "produced no segments"
   )
 })
@@ -266,7 +266,7 @@ test_that("qlm_segment passes provider-specific arguments to ellmer::chat", {
   mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
 
   # Call with a provider-specific argument (like base_url for openai_compatible)
-  qlm_segment("Text.", cb, model = "test/model", base_url = "https://my-api.com/v1")
+  qlm_segment("Text.", cb, model = "openai_compatible/test-model", base_url = "https://my-api.com/v1")
 
   # Verify the provider-specific argument was passed through to ellmer::chat
   expect_true("base_url" %in% names(chat_args_received))


### PR DESCRIPTION
Closes #129, taking the issue's minimal fix: name the prefixes that work and point at the route that reaches everything else. The prefix-to-`base_url` registry is left out deliberately — see below.

## The problem

```r
qlm_code(texts, cb, model = "qwen/qwen3-max")
#> Error: Can't find provider `ellmer::chat_qwen()`.
```

That names an ellmer internal and gives no indication that the provider *is* reachable, just under a different prefix. What a user gets now:

```
Error in `qlm_code()`: Can't reach provider "qwen" by name.
i `ellmer::chat()` dispatches on the prefix of `model`, and ellmer has no `ellmer::chat_qwen()`.
i Reachable by name: "anthropic", "aws_bedrock", "azure_openai", "claude", "cloudflare",
  "databricks", "deepseek", "github", "google_gemini", "google_vertex", "groq",
  "huggingface", "lmstudio", "mistral", "ollama", "openai", "openai_compatible",
  "openrouter", "perplexity", "portkey", "posit", "snowflake", and "vllm".
i Any other OpenAI-compatible endpoint is reachable as `openai_compatible/<model>`
  with `base_url` and `credentials`.
i See the Provider-specific parameters section of `?qlm_code` for a worked example.
```

## How

New `R/providers.R`, all internal: `model_provider()`, `ellmer_providers()`, `check_model_provider()`.

`ellmer_providers()` derives the list from the installed ellmer rather than hard-coding it, as the issue asks, and mirrors **both** gates `ellmer::chat()` applies — the `chat_<provider>()` lookup *and* the requirement that the function take `model`, `system_prompt` and `params`. The second gate excludes nothing in ellmer 0.4.2, so it is asserted by test rather than assumed to stay inert.

The check runs **before any request**, not by interpreting a failure: whether a prefix can dispatch does not depend on asking the provider anything. That is the deliberate difference from #133, which is about diagnosing failures that have already happened.

`qlm_segment()` dispatches by name the same way and gets the same check. `default_structured_mode()` now reuses `model_provider()` instead of its own inline `sub()`.

## Two notes for review

**The message defeats cli's vector truncation.** At 23 names cli abbreviates to `"openrouter", ..., "vllm"`, which hid several of the very prefixes the message exists to list. There is a regression test for this, since it is the kind of thing that silently comes back.

**Two mock fixtures changed.** `test-qlm_code.R` and `test-qlm_segment.R` used `model = "test/model"` — a prefix nothing can dispatch on — and now use `openai_compatible/test-model`. No assertion referenced the old string, and the mocks intercept before any request either way. This is the one place where the change forced existing tests to move rather than the reverse, so it is worth a look.

Also worth knowing: my first attempt put the check at the top of `qlm_segment()`, ahead of codebook validation, which made a call with both a bad codebook and an odd prefix report the wrong problem. The existing tests caught it. It now sits after the input/codebook/schema checks, matching `qlm_code()`'s order.

## Verification

`FAIL 0 | WARN 2 | SKIP 3 | PASS 1195`.

Note the skip count: `{mockery}` is installed now, where earlier in the day it was not, so a large block of previously-dormant tests runs. The 2 warnings are pre-existing in `test-qlm_compare.R:336` and `test-qlm_validate.R:93`, where `expect_error()` tests surface intentional warnings.

No roxygen regeneration: everything new is `@noRd`, so there is no `man/` or `NAMESPACE` churn.

## Left out on purpose

- **The prefix registry.** Mapping `qwen/`, `kimi/`, `glm/`, `xai/`, ... to `base_url` + API-key env var so those prefixes just work. The sweep comment on #129 has the verified data for 15 endpoints, but it carries a real hazard — a backend defaulting to `DASHSCOPE_API_KEY` and then pointed at `api.moonshot.ai` would send one vendor's credential to another — so it deserves its own design pass rather than riding along here.
- **Near-match suggestions** for a typo'd prefix (`"opena"` -> did you mean `"openai"`?). Cheap with `utils::adist()`, but fuzzy matching belongs with #133.
- **#133 itself** — diagnosing a 4xx after the fact by checking the model against `models_<provider>()`. It can reuse `ellmer_providers()` and `model_provider()` from this PR. So can #130, whose provider derivation is stale for ~20 providers.
