### PR TITLE
Bound CI jobs so a hung step fails fast

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,6 +9,9 @@ permissions: read-all
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
+    # Without this a hung step inherits GitHub's 6h default; healthy runs
+    # take ~4m20s. See #126.
+    timeout-minutes: 30
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     strategy:
       fail-fast: false

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,7 +27,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,6 +15,8 @@ permissions: read-all
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
+    # Healthy runs take ~2m30s. See #126.
+    timeout-minutes: 20
     # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -18,7 +18,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   render-readme:
     runs-on: ubuntu-latest
+    # Same setup-r apt exposure as the others. See #126.
+    timeout-minutes: 20
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -18,7 +18,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -12,6 +12,8 @@ permissions: read-all
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
+    # Healthy runs take ~2m10s. See #126.
+    timeout-minutes: 20
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Closes #126.

## Timeouts (052df7a)

No job set `timeout-minutes`, so every one inherited GitHub's 6h default. On #123 an `apt-get` stall against the Azure Ubuntu mirror hung three jobs for six hours each — ~18 runner-hours — and surfaced as three red checks indistinguishable from a genuine test failure until someone read the raw logs.

| workflow | job | ceiling | healthy |
|---|---|---|---|
| `R-CMD-check.yaml` | matrix job | 30 | ~4m20s |
| `test-coverage.yaml` | `test-coverage` | 20 | ~2m10s |
| `pkgdown.yaml` | `pkgdown` | 20 | ~2m30s |
| `render-readme.yaml` | `render-readme` | 20 | — |

Generous against healthy durations, so they fire on a hang rather than on a slow runner.

**`render-readme.yaml` is not in the issue's list.** It runs `setup-r` on ubuntu exactly like the other three, so it carries the same apt exposure — and it is the one workflow that pushes a commit, so a silent six-hour hang there is worse than in the others. Included here.

## checkout v7 (718727a)

`actions/checkout@v4` targets Node 20, deprecated and currently force-run on Node 24, which warns in every job. v7 targets Node 24 and clears it, and brings the dependency and security updates from v5-v7.

Note that #126 suggests `@v5`; the current release is v7.0.1, so the issue's suggestion is two majors behind. The intervening changes:

- **v5.0.0** (Aug 2025) - Node 24. Needs runner >= v2.327.1, which GitHub-hosted runners exceed.
- **v6.0.0** (Nov 2025) - `persist-credentials` moves into `$RUNNER_TEMP` instead of `.git/config`. The v6 README states directly: "No workflow changes required - `git fetch`, `git push`, etc. continue to work automatically", and v7 documents the same built-in-token push pattern `render-readme.yaml:45` uses.
- **v7.0.0** (Jun 2026) - refuses to check out fork PR code under `pull_request_target` and `workflow_run`. Inert here: this repository's triggers are `push`, `pull_request`, `release` and `workflow_dispatch` only.

Following the repository's existing convention of moving major tags.

## Verification

Config only — no package code, so the test suite is untouched.

Each workflow was parsed with `yaml::read_yaml()` to confirm it is still valid and that `timeout-minutes` attaches to the **job** rather than to a step, which a grep would not have distinguished.

The timeouts cannot be proven to work short of a real hang. The failure mode they convert is a six-hour silent stall into a ~20-30 minute legible one; the ceilings are ~7x the observed healthy durations, so a false positive would need a genuinely pathological runner.

