### PR TITLE
Name both destinations for a top-level model parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,21 @@
 
 ## Bug fixes
 
+* `qlm_code()` and `qlm_segment()` now reject a model parameter passed at the
+  top level. `max_tokens = 100` used to fall through to `chat_args` and reach
+  `ellmer::chat()`, failing with `unused argument (max_tokens = 100)` raised
+  from inside ellmer -- naming the argument but neither of the two places it
+  could have gone. The error now names both: `params` for the settings ellmer
+  standardises, `api_args` for a provider's raw request fields. It deliberately
+  does not prescribe one, because the choice is not a property of the name:
+  `top_k` is a real `ellmer::params()` field, but ellmer maps it onto
+  `top_logprobs` for OpenAI-compatible providers, so a caller wanting a
+  provider's raw `top_k` needs `api_args`. `stop` and `response_format` are
+  unambiguous and do get a specific destination. The rejected set is read from
+  `ellmer::params()` at run time, minus whatever the request path currently
+  accepts, so a name a later ellmer gives a real meaning stops being rejected
+  without an update here (#139).
+
 * `qlm_code()` and `qlm_segment()` now say what to do when a model's provider
   prefix is not one ellmer can dispatch on. `model = "qwen/qwen3-max"` reached
   `ellmer::chat()` and failed with `Can't find provider ellmer::chat_qwen()`,

--- a/R/model_params.R
+++ b/R/model_params.R
@@ -1,0 +1,119 @@
+#' Sampling parameters ellmer standardises
+#'
+#' The fields of [ellmer::params()], read from the installed ellmer rather than
+#' listed here, so a parameter ellmer adds or drops later needs no change.
+#'
+#' @return A character vector of parameter names.
+#' @keywords internal
+#' @noRd
+model_param_names <- function() {
+  setdiff(names(formals(ellmer::params)), "...")
+}
+
+
+#' Names that are not `params()` fields but get typed as though they were
+#'
+#' Kept separate from [model_param_names()] so that nothing here implies
+#' [ellmer::params()] accepts them:
+#'
+#' * `stop` is OpenAI's body field; ellmer spells the standardised form
+#'   `stop_sequences`.
+#' * `response_format` is a raw body field. The JSON-mode path sets it itself,
+#'   so passing it at the top level is always wrong, while `api_args` remains
+#'   the way to set it deliberately.
+#'
+#' @keywords internal
+#' @noRd
+model_param_aliases <- c("stop", "response_format")
+
+
+#' Argument names something in the request path legitimately accepts
+#'
+#' A name is only worth rejecting if nothing would have taken it. Subtracting
+#' this set at run time, rather than trusting a list fixed when quallmer was
+#' built, means an installed quallmer running against a newer ellmer that gives
+#' one of these names a real meaning stops rejecting it -- without an update
+#' here. A test asserts the set is currently disjoint from the candidates, so
+#' the reverse change fails loudly during package testing.
+#'
+#' @param model A model specification, as passed to [qlm_code()].
+#'
+#' @return A character vector of argument names.
+#' @keywords internal
+#' @noRd
+top_level_arg_names <- function(model) {
+  provider_fn <- get0(
+    paste0("chat_", model_provider(model)),
+    envir = asNamespace("ellmer")
+  )
+
+  unique(c(
+    names(formals(ellmer::chat)),
+    if (!is.null(provider_fn)) names(formals(provider_fn)),
+    names(formals(ellmer::parallel_chat_structured)),
+    names(formals(ellmer::batch_chat_structured))
+  ))
+}
+
+
+#' Reject a model parameter passed at the top level
+#'
+#' A top-level `temperature` or `max_tokens` falls through to `chat_args` and
+#' reaches [ellmer::chat()], which has no such argument, so the call died with
+#' `unused argument (max_tokens = 100)` raised from inside ellmer -- naming the
+#' argument but neither of the two places it could have gone.
+#'
+#' Deliberately does not say which of the two to use. The choice is not a
+#' property of the name: `top_k` is a real [ellmer::params()] field, but ellmer
+#' maps it onto `top_logprobs` for OpenAI-compatible providers, so a caller who
+#' wants a provider's raw `top_k` needs `api_args` and one who wants ellmer's
+#' standardised form needs `params`. Naming both and letting the caller pick is
+#' the honest message. The two aliases are unambiguous and do get a specific
+#' note.
+#'
+#' Values are not quoted back. The name is enough to locate the mistake, and a
+#' value may be large or hold a credential.
+#'
+#' @param dot_names Names of the arguments in `...`.
+#' @param model A model specification, as passed to [qlm_code()].
+#' @param call The calling environment, for the error message.
+#'
+#' @return `dot_names`, invisibly.
+#' @keywords internal
+#' @noRd
+check_model_params <- function(dot_names, model, call = rlang::caller_env()) {
+  if (length(dot_names) == 0) {
+    return(invisible(dot_names))
+  }
+
+  candidates <- setdiff(
+    c(model_param_names(), model_param_aliases),
+    top_level_arg_names(model)
+  )
+  offenders <- intersect(dot_names, candidates)
+
+  if (length(offenders) == 0) {
+    return(invisible(dot_names))
+  }
+
+  msg <- c(
+    paste0(
+      "{cli::qty(length(offenders))}Model parameter{?s} {.arg {offenders}} ",
+      "cannot be passed at the top level."
+    ),
+    "i" = "Standard model parameters go in {.code params = ellmer::params()}.",
+    "i" = "Provider-specific request fields go in {.code api_args = list()}."
+  )
+
+  if ("stop" %in% offenders) {
+    msg <- c(msg, "i" = "ellmer spells {.arg stop} as {.arg stop_sequences} in {.arg params}.")
+  }
+  if ("response_format" %in% offenders) {
+    msg <- c(msg, "i" = paste0(
+      "{.arg response_format} belongs in {.arg api_args}; ",
+      "JSON-mode coding sets it itself."
+    ))
+  }
+
+  cli::cli_abort(msg, call = call)
+}

--- a/R/model_params.R
+++ b/R/model_params.R
@@ -13,7 +13,7 @@ model_param_names <- function() {
 
 #' Names that are not `params()` fields but get typed as though they were
 #'
-#' Kept separate from [model_param_names()] so that nothing here implies
+#' Kept separate from `model_param_names()` so that nothing here implies
 #' [ellmer::params()] accepts them:
 #'
 #' * `stop` is OpenAI's body field; ellmer spells the standardised form

--- a/R/model_params.R
+++ b/R/model_params.R
@@ -86,6 +86,16 @@ check_model_params <- function(dot_names, model, call = rlang::caller_env()) {
     return(invisible(dot_names))
   }
 
+  # Same contract as check_model_provider(): a malformed `model` is the
+  # caller's to report, or ellmer's. Without this, `qlm_segment()` -- which has
+  # no model validation of its own -- reached get0() with a length-2 prefix and
+  # died with "first argument has length > 1", and an `NA` model resolved to no
+  # provider and reported the parameter instead of the model. Either way the
+  # error depended on whether `...` happened to be empty.
+  if (!is.character(model) || length(model) != 1L || is.na(model)) {
+    return(invisible(dot_names))
+  }
+
   candidates <- setdiff(
     c(model_param_names(), model_param_aliases),
     top_level_arg_names(model)

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -229,6 +229,10 @@ qlm_code <- function(x, codebook, model, ...,
   # "Can't find provider ellmer::chat_qwen()".
   check_model_provider(model)
 
+  # Checked after the model itself, so a bad model and a stray parameter report
+  # the model first. `dot_names` is already in hand from the capture above.
+  check_model_params(dot_names, model)
+
   # Providers whose API rejects the schema-constrained request skip straight to
   # JSON mode rather than spending a wasted round trip; see
   # default_structured_mode().

--- a/R/qlm_segment.R
+++ b/R/qlm_segment.R
@@ -143,6 +143,12 @@ qlm_segment <- function(x, codebook, model, ..., name = NULL, notes = NULL) {
   # and codebook, which are the more fundamental problems when both are wrong.
   check_model_provider(model)
 
+  # Same routing contract as qlm_code(), so the same rejection. Captured once
+  # here and reused by the routing below, rather than forcing `...` twice.
+  dots      <- list(...)
+  dot_names <- names(dots)
+  check_model_params(dot_names, model)
+
   # Build internal schema: text field prepended to user-defined fields
   user_props <- codebook$schema@properties
   items_schema <- do.call(
@@ -167,8 +173,6 @@ qlm_segment <- function(x, codebook, model, ..., name = NULL, notes = NULL) {
   # execution_args go to parallel_chat_structured
   # Everything else (including provider-specific args like base_url) goes to chat()
   pcs_arg_names  <- names(formals(ellmer::parallel_chat_structured))
-  dots       <- list(...)
-  dot_names  <- names(dots)
   execution_args <- dots[dot_names %in% pcs_arg_names]
   # chat_args gets everything NOT destined for execution functions
   # This allows provider-specific args (base_url, credentials, api_args, etc.)

--- a/tests/testthat/test-model_params.R
+++ b/tests/testthat/test-model_params.R
@@ -1,0 +1,188 @@
+test_codebook <- function() {
+  qlm_codebook(
+    "sentiment", "Code the sentiment.",
+    ellmer::type_object(polarity = ellmer::type_string("pos or neg"))
+  )
+}
+
+all_candidates <- function() c(model_param_names(), model_param_aliases)
+
+
+test_that("model_param_names() comes from ellmer::params(), not a fixed list", {
+  expect_equal(model_param_names(), setdiff(names(formals(ellmer::params)), "..."))
+  expect_false("..." %in% model_param_names())
+  expect_true(all(c("temperature", "max_tokens", "top_p") %in% model_param_names()))
+})
+
+
+test_that("the aliases are deliberately not params() fields", {
+  # The whole point of keeping them separate: listing them alongside
+  # model_param_names() would imply ellmer::params() accepts them.
+  expect_false(any(model_param_aliases %in% model_param_names()))
+  expect_true("stop_sequences" %in% model_param_names())
+  expect_false("stop" %in% model_param_names())
+})
+
+
+test_that("qlm_code() rejects every model parameter passed at the top level (#139)", {
+  cb <- test_codebook()
+
+  for (nm in all_candidates()) {
+    args <- list("great", cb, model = "openai/gpt-4o-mini")
+    args[[nm]] <- 1
+    expect_error(
+      do.call(qlm_code, args),
+      "cannot be passed at the top level",
+      info = nm
+    )
+  }
+})
+
+
+test_that("qlm_segment() rejects them too, sharing the routing contract (#139)", {
+  skip_if_not_installed("quanteda")
+  cb <- test_codebook()
+
+  for (nm in all_candidates()) {
+    args <- list("A sentence. Another one.", cb, model = "openai/gpt-4o-mini")
+    args[[nm]] <- 1
+    expect_error(
+      do.call(qlm_segment, args),
+      "cannot be passed at the top level",
+      info = nm
+    )
+  }
+})
+
+
+test_that("the message names both destinations and never the value (#139)", {
+  cb <- test_codebook()
+  err <- tryCatch(
+    qlm_code("great", cb, model = "openai/gpt-4o-mini", max_tokens = 4242),
+    error = function(e) e
+  )
+  msg <- cli::ansi_strip(paste(conditionMessage(err), collapse = "\n"))
+
+  expect_match(msg, "max_tokens", fixed = TRUE)
+  expect_match(msg, "params = ellmer::params()", fixed = TRUE)
+  expect_match(msg, "api_args = list()", fixed = TRUE)
+
+  # Values are not quoted back: one may be large, or hold a credential.
+  expect_false(grepl("4242", msg, fixed = TRUE))
+
+  # Deliberately does not prescribe one destination. `top_k` is a real params
+  # field that ellmer maps onto `top_logprobs` for OpenAI-compatible
+  # providers, so "use params" would be wrong advice for a raw `top_k`.
+  expect_false(grepl("must go in", msg, fixed = TRUE))
+})
+
+
+test_that("every offending name is listed, not just the first (#139)", {
+  cb <- test_codebook()
+  err <- tryCatch(
+    qlm_code("great", cb, model = "openai/gpt-4o-mini", max_tokens = 1, temperature = 0),
+    error = function(e) e
+  )
+  msg <- cli::ansi_strip(paste(conditionMessage(err), collapse = "\n"))
+
+  expect_match(msg, "max_tokens", fixed = TRUE)
+  expect_match(msg, "temperature", fixed = TRUE)
+  expect_match(msg, "parameters", fixed = TRUE)  # pluralised
+})
+
+
+test_that("the two unambiguous aliases get a specific destination (#139)", {
+  cb <- test_codebook()
+
+  stop_msg <- cli::ansi_strip(paste(conditionMessage(tryCatch(
+    qlm_code("great", cb, model = "openai/gpt-4o-mini", stop = c("END")),
+    error = function(e) e
+  )), collapse = "\n"))
+  expect_match(stop_msg, "stop_sequences", fixed = TRUE)
+
+  rf_msg <- cli::ansi_strip(paste(conditionMessage(tryCatch(
+    qlm_code("great", cb, model = "openai/gpt-4o-mini", response_format = "json"),
+    error = function(e) e
+  )), collapse = "\n"))
+  expect_match(rf_msg, "api_args", fixed = TRUE)
+  expect_match(rf_msg, "JSON-mode coding sets it itself", fixed = TRUE)
+})
+
+
+test_that("provider and credential arguments still pass through (#139)", {
+  # The regression that would matter most: rejecting one of these would break
+  # every OpenAI-compatible endpoint, and `api_key` is how a key held in a
+  # keyring reaches the provider.
+  expect_silent(check_model_params(
+    c("params", "api_args", "base_url", "credentials", "api_key",
+      "api_headers", "echo"),
+    "openai/gpt-4o-mini"
+  ))
+})
+
+
+test_that("execution arguments still pass through, including batch-only ones (#139)", {
+  # `path` and `wait` belong to batch_chat_structured() rather than the
+  # parallel path. Checked here rather than through a real `batch = TRUE`
+  # call, which would issue a request.
+  expect_silent(check_model_params(
+    c("max_active", "rpm", "on_error", "convert", "include_tokens"),
+    "openai/gpt-4o-mini"
+  ))
+  expect_silent(check_model_params(c("path", "wait", "ignore_hash"), "openai/gpt-4o-mini"))
+})
+
+
+test_that("check_model_params() is a no-op with no dots", {
+  expect_silent(check_model_params(NULL, "openai/gpt-4o-mini"))
+  expect_silent(check_model_params(character(0), "openai/gpt-4o-mini"))
+  expect_equal(check_model_params(NULL, "openai/gpt-4o-mini"), NULL)
+})
+
+
+test_that("a name ellmer starts accepting stops being rejected, with no change here (#139)", {
+  # The installed-quallmer-against-newer-ellmer case, which the collision test
+  # below cannot reach: if a future ellmer gives `max_tokens` a real meaning at
+  # the top level, the runtime subtraction picks that up.
+  local_mocked_bindings(
+    top_level_arg_names = function(model) {
+      c(names(formals(ellmer::chat)), "max_tokens")
+    }
+  )
+
+  expect_silent(check_model_params("max_tokens", "openai/gpt-4o-mini"))
+  # Everything else still rejected.
+  expect_error(
+    check_model_params("temperature", "openai/gpt-4o-mini"),
+    "cannot be passed at the top level"
+  )
+})
+
+
+test_that("no candidate is currently accepted anywhere in the request path (#139)", {
+  # The canary. Rejecting these is only safe while nothing in the request path
+  # takes them; if an ellmer update changes that, this fails during package
+  # testing rather than in a user's session.
+  candidates <- all_candidates()
+
+  for (provider in ellmer_providers()) {
+    clash <- intersect(candidates, top_level_arg_names(paste0(provider, "/m")))
+    expect_equal(clash, character(0), info = provider)
+  }
+})
+
+
+test_that("a malformed model is still reported before a stray parameter (#139)", {
+  cb <- test_codebook()
+
+  # Validation precedence from #144: the model is the more fundamental problem
+  # when both are wrong.
+  expect_error(
+    qlm_code("great", cb, model = c("openai", "anthropic"), max_tokens = 1),
+    "must be a single string"
+  )
+  expect_error(
+    qlm_code("great", cb, model = "quallmer_unknown_provider_7f3c/m", max_tokens = 1),
+    "Can't reach provider"
+  )
+})

--- a/tests/testthat/test-model_params.R
+++ b/tests/testthat/test-model_params.R
@@ -186,3 +186,52 @@ test_that("a malformed model is still reported before a stray parameter (#139)",
     "Can't reach provider"
   )
 })
+
+
+test_that("check_model_params() leaves a malformed model to the caller (#139)", {
+  # Same contract as check_model_provider(). Without it, a length > 1 model
+  # reached get0() and died with "first argument has length > 1", and an NA
+  # model resolved to no provider and reported the parameter instead.
+  expect_silent(check_model_params("max_tokens", c("openai", "anthropic")))
+  expect_silent(check_model_params("max_tokens", NA_character_))
+  expect_silent(check_model_params("max_tokens", 42))
+  expect_silent(check_model_params("max_tokens", NULL))
+  expect_silent(check_model_params("max_tokens", character(0)))
+})
+
+
+test_that("qlm_segment() reports a malformed model before a stray parameter (#139)", {
+  skip_if_not_installed("quanteda")
+  cb <- test_codebook()
+
+  # qlm_segment() has no model validation of its own and defers to ellmer's
+  # check_string(), so the message here is ellmer's rather than qlm_code()'s.
+  expect_error(
+    qlm_segment("A sentence.", cb, model = c("openai", "anthropic"), max_tokens = 1),
+    "must be a single string"
+  )
+  expect_error(
+    qlm_segment("A sentence.", cb, model = "quallmer_unknown_provider_7f3c/m", max_tokens = 1),
+    "Can't reach provider"
+  )
+})
+
+
+test_that("a malformed model reports the same way whether or not ... is passed (#139)", {
+  skip_if_not_installed("quanteda")
+  cb <- test_codebook()
+
+  # The actual defect: the reported error depended on whether `...` happened to
+  # be empty, so the crash only appeared for callers who passed something.
+  bare <- tryCatch(
+    qlm_segment("A sentence.", cb, model = c("openai", "anthropic")),
+    error = conditionMessage
+  )
+  with_dots <- tryCatch(
+    qlm_segment("A sentence.", cb, model = c("openai", "anthropic"), max_tokens = 1),
+    error = conditionMessage
+  )
+
+  expect_equal(with_dots, bare)
+  expect_false(grepl("length > 1", with_dots, fixed = TRUE))
+})


### PR DESCRIPTION
Closes #139. Input side of the pair #127 closed on the output side: #127 stopped `qlm_trail()` advertising a top-level `temperature`, but typing one still died inside ellmer.

## Before / after

```r
qlm_code(x, cb, model = "openai/gpt-4o-mini", max_tokens = 100)
#> Error: unused argument (max_tokens = 100)
#>   in chat_fun(model = model, ..., system_prompt = system_prompt, params = params, ...)
```

```
Error in `qlm_code()`: Model parameter `max_tokens` cannot be passed at the top level.
i Standard model parameters go in `params = ellmer::params()`.
i Provider-specific request fields go in `api_args = list()`.
```

## Three design decisions worth reviewing

**The list is derived, not restored.** #127's deleted `model_param_names` vector was both wrong and incomplete — it listed `stop` and `response_format`, which are not `ellmer::params()` fields, and omitted `log_probs`, `stop_sequences`, `reasoning_effort`, `reasoning_tokens`. The set now comes from `formals(ellmer::params)` at run time. `stop` and `response_format` live in a separate `model_param_aliases` so nothing implies `params()` takes them; both have an unambiguous destination and get a specific note.

**The message names both destinations without choosing.** `top_k` is why: it is a real `params()` field, but ellmer maps it onto `top_logprobs` for OpenAI-compatible providers (raised upstream as tidyverse/ellmer#1113), so "use `params`" is wrong advice for a caller who wants a provider's raw `top_k`. Naming both and letting the caller pick is the honest message.

**Values are not quoted back.** `check_model_params()` only sees names, and a value may be large or hold a credential. A test asserts the value is absent from the message.

## Future-proofing

Candidates have the arguments the request path *currently* accepts subtracted at run time — `ellmer::chat()`, the resolved `chat_<provider>()`, and both execution functions. A set fixed at build time would make an already-installed quallmer reject a name that a newer ellmer had given a real meaning.

Verified behaviour-neutral today: the subtraction removes nothing for any of the 23 providers, so all 13 candidates are still rejected. A test asserts the sets stay disjoint, so a change in that direction fails loudly during package testing rather than in someone's session — and a second test mocks `top_level_arg_names()` to confirm a newly-legitimate name really does stop being rejected.

## Placement

After the model and provider checks, preserving the precedence #144 established: when both the model and a parameter are wrong, the model is reported. Two tests pin that.

`qlm_segment()` shares the routing contract and gets the same check. Its `...` capture is hoisted above the check so `...` is forced once rather than twice.

## Verification

`FAIL 0 | WARN 2 | SKIP 3 | PASS 1317`, up 76 from 1241.

Run with `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY`, which is what proves the rejection is pre-request rather than something the provider reports back.

The 2 warnings pre-exist in `test-qlm_compare.R:336` and `test-qlm_validate.R:93`.

## One coverage limit

`path` and `wait` are `batch_chat_structured()` arguments, tested at the checker level rather than through a real `batch = TRUE` call, which would issue a request. The routing treats them as execution arguments regardless of `batch` (`execution_arg_names` unions both functions' formals), so the checker-level test covers the actual risk — but it is not end-to-end.

## Not done

No automatic routing of top-level parameters into `params` — #127 considered and rejected that. No inspecting or rewriting `params`/`api_args` contents. No fuzzy matching for near-misses like `temp`, which stays with #133.
