### PR TITLE
Stop binary rounding deciding agreement at the tolerance boundary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,22 @@
 
 ## Bug fixes
 
+* `qlm_compare(level = "interval", tolerance = )` counted a pair differing by
+  exactly `tolerance` as disagreement or agreement depending on how the
+  subtraction happened to round in binary. `1.1 - 1.0` is
+  `0.10000000000000009` and failed at `tolerance = 0.1`, while `1.2 - 1.1` is
+  `0.09999999999999987` and passed -- the same nominal difference, opposite
+  answers. On decimal-increment scales this is common rather than exotic; one
+  reported analysis understated agreement by 23 percentage points, and the
+  result stayed plausible enough that nothing looked wrong. The comparison now
+  allows a few units in the last place, scaled to the magnitudes being
+  compared. Percent agreement can therefore only stay the same or rise: no pair
+  that previously agreed becomes a disagreement. Anyone who has reported a
+  percent agreement computed on a non-integer scale should recompute it.
+  `tolerance = 0` now means numerical equality rather than bit identity, so
+  `0.1 + 0.2` counts as equal to `0.3`, while a genuine difference of `1e-9` is
+  still a difference (#121).
+
 * `qlm_code()` and `qlm_segment()` now reject a model parameter passed at the
   top level. `max_tokens = 100` used to fall through to `chat_args` and reach
   `ellmer::chat()`, failing with `unused argument (max_tokens = 100)` raised

--- a/R/qlm_compare.R
+++ b/R/qlm_compare.R
@@ -24,8 +24,14 @@
 #'     \item Named list: Specify level for each variable
 #'   }
 #'   Valid levels are `"nominal"`, `"ordinal"`, `"interval"`, or `"ratio"`.
-#' @param tolerance Numeric. Tolerance for agreement with numeric data.
-#'   Default is 0 (exact agreement required). Used for percent agreement calculation.
+#' @param tolerance Numeric. Ratings agree when they differ by no more than
+#'   `tolerance`. Default is 0, meaning numerical equality. The comparison
+#'   allows a few units of floating-point rounding error scaled to the values
+#'   being compared, so a difference of exactly `tolerance` counts as agreement
+#'   and `0.1 + 0.2` equals `0.3`; it is numerical equality rather than bit
+#'   identity. The allowance is far smaller than any meaningful rating
+#'   difference, so a genuinely different pair is never counted as agreeing.
+#'   Used for percent agreement calculation.
 #' @param ci Confidence interval method:
 #'   \describe{
 #'     \item{`"none"`}{No confidence intervals (default)}
@@ -667,6 +673,42 @@ bootstrap_reliability_ci <- function(ratings, n_raters, level, tolerance, bootst
 #' @param tolerance Tolerance for agreement
 #' @param use_ci CI method: FALSE, "analytic", or "bootstrap"
 #'
+#' Do a unit's ratings agree, within tolerance?
+#'
+#' A raw `max(row) - min(row) <= tolerance` decides an exactly-at-tolerance
+#' pair on how the subtraction happens to round in binary. `1.1 - 1.0` is
+#' `0.10000000000000009` and fails at `tolerance = 0.1`, while `1.2 - 1.1` is
+#' `0.09999999999999987` and passes -- the same nominal difference, opposite
+#' answers. On decimal-increment scales that is common rather than exotic, and
+#' the reported agreement was understated as a result (#121).
+#'
+#' The allowance is a few units in the last place, scaled to the magnitudes
+#' involved, so it tracks the representational error actually available at that
+#' scale. Deliberately not `sqrt(.Machine$double.eps)`, which at ordinary
+#' magnitudes is around `1.5e-8` and would count a real `1e-9` difference as
+#' exact agreement at `tolerance = 0` -- over-reporting agreement, the more
+#' damaging direction for a reliability statistic. Deliberately not
+#' [all.equal()] either, whose approximate-equality semantics are far broader
+#' than rounding error.
+#'
+#' @param row Numeric ratings for one unit, one per rater.
+#' @param tolerance Numeric scalar. Largest difference still counted as
+#'   agreement.
+#'
+#' @return `TRUE` if the ratings agree within `tolerance`.
+#' @keywords internal
+#' @noRd
+agrees_within_tolerance <- function(row, tolerance) {
+  lower <- min(row)
+  upper <- max(row)
+
+  scale <- max(1, abs(lower), abs(upper), abs(tolerance))
+  epsilon <- 4 * .Machine$double.eps * scale
+
+  upper - lower <= tolerance + epsilon
+}
+
+
 #' @return List with all computed measures (and optionally CIs)
 #' @keywords internal
 #' @noRd
@@ -680,7 +722,7 @@ compute_reliability_by_level <- function(ratings, n_raters, level, tolerance, us
   # For ordinal/interval/ratio: agreement within tolerance
   agrees <- apply(ratings, 1, function(row) {
     if (is.numeric(row)) {
-      max(row) - min(row) <= tolerance
+      agrees_within_tolerance(row, tolerance)
     } else {
       length(unique(as.character(row))) == 1
     }

--- a/man/qlm_compare.Rd
+++ b/man/qlm_compare.Rd
@@ -37,8 +37,14 @@ compared. Can be a single variable (\code{by = sentiment}), a character vector
 }
 Valid levels are \code{"nominal"}, \code{"ordinal"}, \code{"interval"}, or \code{"ratio"}.}
 
-\item{tolerance}{Numeric. Tolerance for agreement with numeric data.
-Default is 0 (exact agreement required). Used for percent agreement calculation.}
+\item{tolerance}{Numeric. Ratings agree when they differ by no more than
+\code{tolerance}. Default is 0, meaning numerical equality. The comparison
+allows a few units of floating-point rounding error scaled to the values
+being compared, so a difference of exactly \code{tolerance} counts as agreement
+and \code{0.1 + 0.2} equals \code{0.3}; it is numerical equality rather than bit
+identity. The allowance is far smaller than any meaningful rating
+difference, so a genuinely different pair is never counted as agreeing.
+Used for percent agreement calculation.}
 
 \item{ci}{Confidence interval method:
 \describe{

--- a/tests/testthat/test-qlm_compare.R
+++ b/tests/testthat/test-qlm_compare.R
@@ -551,3 +551,93 @@ test_that("qlm_compare validates by_category argument", {
     "by_category"
   )
 })
+
+
+# ---- agreement at exactly the tolerance boundary (#121) ---------------------
+
+# Cases about the predicate itself are tested directly: routing them through
+# qlm_compare() would need >= 2 units purely to keep ICC quiet, which would
+# obscure what each case is actually pinning.
+
+compare_pair <- function(a, b, tolerance, level = "interval") {
+  x <- as_qlm_coded(data.frame(.id = seq_along(a), g = a), id = .id, name = "A")
+  y <- as_qlm_coded(data.frame(.id = seq_along(b), g = b), id = .id, name = "B")
+  res <- as.data.frame(
+    qlm_compare(x, y, by = "g", level = level, tolerance = tolerance)
+  )
+  res$value[res$measure == "percent_agreement"]
+}
+
+
+test_that("a difference of exactly the tolerance counts as agreement (#121)", {
+  # The reported case, end to end. Correct agreement is 4/4; a raw `<=` on the
+  # subtraction gave 0.5.
+  a <- c(1.1, 1.2, 1.3, 0.9)
+  b <- c(1.0, 1.1, 1.2, 0.9)
+
+  expect_equal(compare_pair(a, b, tolerance = 0.1), 1)
+})
+
+
+test_that("each at-tolerance pair agrees individually (#121)", {
+  # Pairwise, because only two of the three failed: a test built solely on
+  # 1.2/1.1 would have passed against the broken comparison.
+  expect_true(agrees_within_tolerance(c(1.1, 1.0), 0.1))
+  expect_true(agrees_within_tolerance(c(1.2, 1.1), 0.1))
+  expect_true(agrees_within_tolerance(c(1.3, 1.2), 0.1))
+})
+
+
+test_that("a difference beyond the tolerance still disagrees (#121)", {
+  # The guard that the comparison was corrected rather than loosened.
+  expect_false(agrees_within_tolerance(c(1.0 + 0.1 + 1e-6, 1.0), 0.1))
+  expect_false(agrees_within_tolerance(c(1.2, 1.0), 0.1))
+  expect_equal(compare_pair(c(1.2, 1.1), c(1.0, 1.2), tolerance = 0.1), 0.5)
+})
+
+
+test_that("other decimal grids work at their own increment (#121)", {
+  expect_equal(compare_pair(c(0.25, 0.75), c(0.5, 1.0), tolerance = 0.25), 1)
+  expect_equal(compare_pair(c(1.5, 2.5), c(1.0, 2.0), tolerance = 0.5), 1)
+  expect_equal(compare_pair(c(0.3, 0.6), c(0.2, 0.5), tolerance = 0.1), 1)
+})
+
+
+test_that("tolerance = 0 means numerical equality, not bit identity (#121)", {
+  # 0.1 + 0.2 is 0.30000000000000004, the same number for any measurement
+  # purpose.
+  expect_true(agrees_within_tolerance(c(0.1 + 0.2, 0.3), 0))
+  expect_equal(compare_pair(c(0.1 + 0.2, 1), c(0.3, 1), tolerance = 0), 1)
+
+  # A real difference is still a difference. This is what rules out
+  # sqrt(.Machine$double.eps): at about 1.5e-8 it would call this agreement,
+  # over-reporting, which is the more damaging direction for a reliability
+  # statistic.
+  expect_false(agrees_within_tolerance(c(0, 1e-9), 0))
+  expect_equal(compare_pair(c(1, 2), c(1, 3), tolerance = 0), 0.5)
+})
+
+
+test_that("the boundary holds at large magnitudes too (#121)", {
+  # The epsilon scales with the values, so it tracks the precision actually
+  # available there rather than assuming ratings are of order 1.
+  expect_true(agrees_within_tolerance(c(1e6 + 0.1, 1e6), 0.1))
+  expect_false(agrees_within_tolerance(c(1e6 + 0.2, 1e6), 0.1))
+  expect_true(agrees_within_tolerance(c(1e8 + 0.1, 1e8), 0.1))
+  expect_false(agrees_within_tolerance(c(1e8 + 0.2, 1e8), 0.1))
+})
+
+
+test_that("agrees_within_tolerance() handles more than two raters (#121)", {
+  # The comparison is on max - min, so a third rater inside the band must not
+  # change the verdict.
+  expect_true(agrees_within_tolerance(c(1.0, 1.05, 1.1), 0.1))
+  expect_false(agrees_within_tolerance(c(1.0, 1.05, 1.2), 0.1))
+  expect_true(agrees_within_tolerance(1.0, 0))
+})
+
+
+test_that("nominal comparison is unaffected by the tolerance change (#121)", {
+  expect_equal(compare_pair(c("a", "b"), c("a", "b"), tolerance = 0, level = "nominal"), 1)
+  expect_equal(compare_pair(c("a", "b"), c("a", "c"), tolerance = 0, level = "nominal"), 0.5)
+})


### PR DESCRIPTION
Closes #121.

Reproduced on `main` before touching anything: the issue's example returns `percent_agreement = 0.5` where the correct answer is `1.0`.

## The defect

`compute_reliability_by_level()` tested the subtraction directly:

```r
max(row) - min(row) <= tolerance
```

so a pair differing by exactly `tolerance` was counted or not according to how that subtraction happened to round in binary:

| pair | difference in double | `<= 0.1` |
|---|---|---|
| `1.1 - 1.0` | `0.10000000000000009` | FALSE |
| `1.2 - 1.1` | `0.09999999999999987` | TRUE |
| `1.3 - 1.2` | `0.10000000000000009` | FALSE |

Same nominal difference, opposite answers. On any decimal-increment scale this is common rather than exotic, and the output stays plausible — the reporter's analysis was understated by 23 percentage points before anyone checked the arithmetic. `example_illiberalism.Rmd:191` uses `tolerance = 1` on z-scores, which is exactly the exposed case.

## The fix

```r
agrees_within_tolerance <- function(row, tolerance) {
  lower <- min(row)
  upper <- max(row)

  scale   <- max(1, abs(lower), abs(upper), abs(tolerance))
  epsilon <- 4 * .Machine$double.eps * scale

  upper - lower <= tolerance + epsilon
}
```

**Why scaled by magnitude rather than fixed.** My first draft used a fixed `sqrt(.Machine$double.eps)`, on the reasoning that scaling by magnitude would be too permissive. That was wrong — it conflated `sqrt(eps) * magnitude` with `eps * magnitude`, which differ by eight orders of magnitude. The scaled form with plain `eps` is both tighter at ordinary scales and correct at large ones.

The concrete case that settles it, now a test:

```r
agrees_within_tolerance(c(0, 1e-9), 0)
```

Under `sqrt(eps)` (~1.5e-8 at ordinary magnitudes) this returns `TRUE` — a real `1e-9` difference reported as exact agreement. That is over-reporting agreement, the more damaging direction for a reliability statistic. Under the scaled form it is `FALSE`.

Not `all.equal()`: its approximate-equality semantics are far broader than rounding error.

## Effect on results

Bounded in one direction: percent agreement can stay the same or rise, and no pair that previously agreed becomes a disagreement. Anyone who has reported a percent agreement computed on a non-integer scale should recompute it — that is called out in NEWS rather than left for people to discover.

To be precise about the mechanism: floating-point rounding itself goes both ways, as the table above shows. What is one-directional is this patch's effect on the statistic.

## `tolerance = 0`

Gets the same treatment, so it now means numerical equality rather than bit identity: `0.1 + 0.2` counts as equal to `0.3`, while a genuine `1e-9` difference is still a difference. This is a behaviour change on non-integer data at the default tolerance, and is documented in `@param tolerance` and NEWS.

## Tests

Boundary cases are tested against the predicate directly rather than through `qlm_compare()`. Routing them through the full path would need >= 2 units purely to keep ICC from warning, which would obscure what each case pins.

- the issue's example end to end, as the regression anchor
- each of the three at-tolerance pairs separately, because only two of three failed — a test built solely on `1.2/1.1` would have passed against the broken code
- beyond-tolerance still disagrees, the guard that this corrected the comparison rather than loosening it
- 0.25 and 0.5 grids
- `tolerance = 0`: `0.1 + 0.2` agrees, `1e-9` does not
- large magnitudes: `1e6` and `1e8`, agreeing at `+0.1` and not at `+0.2`
- three raters, exercising `max - min` rather than a pair
- nominal comparison unaffected

## Verification

`FAIL 0 | WARN 2 | SKIP 3 | PASS 1349`, up 23. Both warnings pre-exist in `test-qlm_compare.R:336` and `test-qlm_validate.R:93`.

`bootstrap_reliability_ci()` routes through the same function, so the CI path inherits the fix with no separate change.

## Worth knowing

`irr::agree(tolerance = )` has the same defect and returns the same wrong number, so cross-checking against irr confirms the wrong answer rather than catching it. Not stated in user docs — it is someone else's package — but reviewers should know.
