### PR TITLE
Do not let an infinite rating scale the allowance to infinity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,9 @@
   percent agreement computed on a non-integer scale should recompute it.
   `tolerance = 0` now means numerical equality rather than bit identity, so
   `0.1 + 0.2` counts as equal to `0.3`, while a genuine difference of `1e-9` is
-  still a difference (#121).
+  still a difference. A non-finite rating takes the plain comparison, since an
+  infinite magnitude would otherwise scale the allowance to infinity and report
+  a finite rating as agreeing with an infinite one (#121).
 
 * `qlm_code()` and `qlm_segment()` now reject a model parameter passed at the
   top level. `max_tokens = 100` used to fall through to `chat_args` and reach

--- a/R/qlm_compare.R
+++ b/R/qlm_compare.R
@@ -665,14 +665,6 @@ bootstrap_reliability_ci <- function(ratings, n_raters, level, tolerance, bootst
 }
 
 
-#' Compute all reliability statistics for a given level
-#'
-#' @param ratings Matrix where rows are subjects and columns are raters
-#' @param n_raters Number of raters
-#' @param level Measurement level
-#' @param tolerance Tolerance for agreement
-#' @param use_ci CI method: FALSE, "analytic", or "bootstrap"
-#'
 #' Do a unit's ratings agree, within tolerance?
 #'
 #' A raw `max(row) - min(row) <= tolerance` decides an exactly-at-tolerance
@@ -691,6 +683,11 @@ bootstrap_reliability_ci <- function(ratings, n_raters, level, tolerance, bootst
 #' [all.equal()] either, whose approximate-equality semantics are far broader
 #' than rounding error.
 #'
+#' A non-finite rating gets the plain comparison. Scaling to the magnitudes
+#' involved is meaningless once one of them is infinite, and an infinite scale
+#' makes an infinite epsilon, under which `Inf <= Inf` reports agreement
+#' between a finite rating and an infinite one.
+#'
 #' @param row Numeric ratings for one unit, one per rater.
 #' @param tolerance Numeric scalar. Largest difference still counted as
 #'   agreement.
@@ -702,6 +699,10 @@ agrees_within_tolerance <- function(row, tolerance) {
   lower <- min(row)
   upper <- max(row)
 
+  if (!is.finite(lower) || !is.finite(upper)) {
+    return(upper - lower <= tolerance)
+  }
+
   scale <- max(1, abs(lower), abs(upper), abs(tolerance))
   epsilon <- 4 * .Machine$double.eps * scale
 
@@ -709,6 +710,14 @@ agrees_within_tolerance <- function(row, tolerance) {
 }
 
 
+#' Compute all reliability statistics for a given level
+#'
+#' @param ratings Matrix where rows are subjects and columns are raters
+#' @param n_raters Number of raters
+#' @param level Measurement level
+#' @param tolerance Tolerance for agreement
+#' @param use_ci CI method: FALSE, "analytic", or "bootstrap"
+#'
 #' @return List with all computed measures (and optionally CIs)
 #' @keywords internal
 #' @noRd

--- a/tests/testthat/test-qlm_compare.R
+++ b/tests/testthat/test-qlm_compare.R
@@ -619,12 +619,37 @@ test_that("tolerance = 0 means numerical equality, not bit identity (#121)", {
 
 
 test_that("the boundary holds at large magnitudes too (#121)", {
-  # The epsilon scales with the values, so it tracks the precision actually
-  # available there rather than assuming ratings are of order 1.
+  # 2^28 is where this actually bites: (2^28 + 0.1) - 2^28 is
+  # 0.10000002384185791, so a raw comparison and a fixed small epsilon both
+  # reject it, and only an epsilon scaled to the magnitude accepts it. The 1e6
+  # and 1e8 cases below round the other way and pass even the broken
+  # comparison, so they are sanity checks rather than discriminating ones.
+  expect_true(agrees_within_tolerance(c(2^28 + 0.1, 2^28), 0.1))
+  expect_false(agrees_within_tolerance(c(2^28 + 0.3, 2^28), 0.1))
+
   expect_true(agrees_within_tolerance(c(1e6 + 0.1, 1e6), 0.1))
   expect_false(agrees_within_tolerance(c(1e6 + 0.2, 1e6), 0.1))
   expect_true(agrees_within_tolerance(c(1e8 + 0.1, 1e8), 0.1))
-  expect_false(agrees_within_tolerance(c(1e8 + 0.2, 1e8), 0.1))
+})
+
+
+test_that("a non-finite rating is not counted as agreement (#121)", {
+  # Scaling to the magnitudes involved is meaningless once one is infinite: the
+  # scale becomes Inf, so does the epsilon, and `Inf <= Inf` reported a finite
+  # rating as agreeing with an infinite one. Non-finite rows take the plain
+  # comparison, which is what they did before the tolerance fix.
+  expect_false(agrees_within_tolerance(c(1, Inf), 0))
+  expect_false(agrees_within_tolerance(c(1, -Inf), 0))
+  expect_false(agrees_within_tolerance(c(-Inf, Inf), 0))
+  expect_false(agrees_within_tolerance(c(1, Inf), 1e6))
+
+  # Inf - Inf and anything with NaN are NA, unchanged from before.
+  expect_true(is.na(agrees_within_tolerance(c(Inf, Inf), 0)))
+  expect_true(is.na(agrees_within_tolerance(c(1, NaN), 0)))
+
+  # Finite comparisons are untouched by the guard.
+  expect_true(agrees_within_tolerance(c(1.1, 1.0), 0.1))
+  expect_false(agrees_within_tolerance(c(0, 1e-9), 0))
 })
 
 


### PR DESCRIPTION
Follow-up to #149, which is merged so cannot be reopened. Fixes a regression that PR introduced, plus the two minor points from its post-merge review.

## The regression

#121 scaled the agreement epsilon to the magnitudes being compared. With a non-finite rating the scale becomes `Inf`, so the epsilon does too, and `Inf <= Inf` is `TRUE`:

| row | before #121 | after #121 (on `main` now) | this PR |
|---|---|---|---|
| `c(1, Inf)` | `FALSE` | **`TRUE`** | `FALSE` |
| `c(1, -Inf)` | `FALSE` | **`TRUE`** | `FALSE` |
| `c(-Inf, Inf)` | `FALSE` | **`TRUE`** | `FALSE` |
| `c(Inf, Inf)` | `NA` | `NA` | `NA` |
| `c(1, NaN)` | `NA` | `NA` | `NA` |

So a finite rating was reported as agreeing with an infinite one. Reachable, as the review notes: `qlm_compare()` drops incomplete cases but does not exclude infinities.

The fix takes the plain comparison for non-finite rows, restoring the pre-#121 answers exactly. Verified case by case against the old implementation rather than reasoned about.

I did not take the "reject non-finite quantitative ratings" option. It is arguably the better end state, but it is a behaviour change beyond repairing this regression — someone currently getting `NA` from an `Inf - Inf` row would start getting an error. Worth its own decision; happy to file it.

## `2^28`: the test that actually discriminates

The review is right that the existing large-magnitude tests were vacuous. Measured:

| case | difference in double | raw `<=` | fixed small eps | scaled eps |
|---|---|---|---|---|
| `1e6 + 0.1` | `0.09999999997671694` | pass | pass | pass |
| `1e8 + 0.1` | `0.09999999403953552` | pass | pass | pass |
| `2^28 + 0.1` | `0.10000002384185791` | **fail** | **fail** | pass |

Only `2^28` separates the scaled epsilon from both alternatives, so it is added along with `2^28 + 0.3` as the negative case. The `1e6`/`1e8` cases are kept but relabelled as sanity checks, with a comment saying why they do not discriminate — otherwise someone will read them as proof of something they do not prove.

## Roxygen header

Inserting `agrees_within_tolerance()` split the "Compute all reliability statistics" block, leaving its title and five `@param` tags attached to the wrong function. Both are `@noRd` so nothing was generated wrongly, but it misleads anyone reading the source. Headers are now contiguous with their own functions.

## NEWS

Amended the existing #121 bullet rather than adding a new one: the regression never shipped — both changes are in the same unreleased `0.4.0.9000` — so a bullet describing a bug no user could have hit would be noise. The amendment documents the non-finite behaviour, which is worth stating.

## Verification

`FAIL 0 | WARN 2 | SKIP 3 | PASS 1358`, up 9 from 1349. Both warnings pre-exist in `test-qlm_compare.R:336` and `test-qlm_validate.R:93`.
