### PR TITLE
Name the endpoint each run used, not a stale guess at its provider

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,26 @@
 
 ## Bug fixes
 
+* `qlm_trail()` reports which endpoint each run actually used, and points at
+  the right ellmer help page for setting it up. The report derived a provider
+  by splitting the model string and mapped it through a four-name `if/else`
+  chain, which had gone stale three ways. The `google` branch could never fire,
+  because ellmer's providers are `google_gemini` and `google_vertex` and a
+  `google/` prefix does not resolve at all. Every OpenAI-compatible endpoint --
+  Qwen through Alibaba, Kimi through Moonshot, a vLLM box, a laptop -- reported
+  the same provider and the same instruction to configure credentials for
+  "openai_compatible", which for an audit trail whose purpose is telling runs
+  apart was the worst of the three. And roughly twenty providers ellmer ships
+  fell through to "configure credentials as needed". Runs are now identified by
+  provider *and* `base_url`, the rule `qlm_replicate()` already applies, so
+  endpoints differing only by port, path or scheme stay distinct. Credentials
+  embedded in a URL, as userinfo or as a query parameter, are stripped before
+  anything is printed. Ollama is told it needs no key only where the endpoint
+  is local, since ellmer reads `OLLAMA_API_KEY` for one served behind a proxy.
+  The section is now "Provider and endpoint setup" rather than "Configure API
+  credentials", because several providers use IAM, OAuth or platform
+  credentials rather than a key (#130).
+
 * `qlm_compare(level = "interval", tolerance = )` counted a pair differing by
   exactly `tolerance` as disagreement or agreement depending on how the
   subtraction happened to round in binary. `1.1 - 1.0` is

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,9 +15,12 @@
   fell through to "configure credentials as needed". Runs are now identified by
   provider *and* `base_url`, the rule `qlm_replicate()` already applies, so
   endpoints differing only by port, path or scheme stay distinct. Credentials
-  embedded in a URL, as userinfo or as a query parameter, are stripped before
-  anything is printed. Ollama is told it needs no key only where the endpoint
-  is local, since ellmer reads `OLLAMA_API_KEY` for one served behind a proxy.
+  embedded in a URL, as userinfo or as a query parameter, are stripped from the
+  endpoint labels this section prints; note that the Call section still shows
+  the call as written and the `.rds` still preserves `chat_args` whole. Ollama
+  is told it needs no key only where a loopback endpoint was recorded, since
+  ellmer reads `OLLAMA_API_KEY` for one served behind a proxy and resolves an
+  unset `base_url` through `OLLAMA_BASE_URL`, which may be remote.
   The section is now "Provider and endpoint setup" rather than "Configure API
   credentials", because several providers use IAM, OAuth or platform
   credentials rather than a key (#130).

--- a/R/qlm_trail.R
+++ b/R/qlm_trail.R
@@ -631,35 +631,64 @@ generate_trail_report <- function(trail, file) {
   lines <- c(lines, "```")
   lines <- c(lines, "")
 
-  # Collect unique providers from runs
-  providers <- unique(unlist(lapply(trail$runs, function(r) {
-    if (!is.null(r$chat_args$name)) {
-      strsplit(r$chat_args$name, "/")[[1]][1]
+  # One entry per distinct endpoint actually used. Identity is the provider
+  # prefix *and* the base_url, matching qlm_replicate(): everything ellmer has
+  # no chat_*() for arrives as `openai_compatible`, so the prefix alone would
+  # collapse unrelated services into one line.
+  endpoints <- lapply(trail$runs, function(r) {
+    if (is.null(r$chat_args$name)) {
+      return(NULL)
     }
-  })))
-  providers <- providers[!is.na(providers)]
+    identity <- endpoint_identity(r$chat_args$base_url)
+    list(
+      provider = model_provider(r$chat_args$name),
+      identity = identity,
+      key = paste0(model_provider(r$chat_args$name), "\r", identity)
+    )
+  })
+  endpoints <- endpoints[!vapply(endpoints, is.null, logical(1))]
+  endpoints <- endpoints[!duplicated(vapply(endpoints, function(e) e$key, character(1)))]
 
-  if (length(providers) > 0) {
-    lines <- c(lines, "Configure API credentials for the models used:")
+  if (length(endpoints) > 0) {
+    known <- ellmer_providers()
+
+    lines <- c(lines, "### Provider and endpoint setup")
+    lines <- c(lines, "")
+    lines <- c(lines, paste(
+      "Credentials are not recorded in the trail. Set up each provider below as",
+      "its ellmer help page describes -- the requirements differ, from an API key",
+      "to platform IAM to none at all."
+    ))
     lines <- c(lines, "")
     lines <- c(lines, "```r")
-    for (provider in providers) {
-      if (provider == "openai") {
-        lines <- c(lines, "# OpenAI: Set OPENAI_API_KEY environment variable")
-        lines <- c(lines, "# Sys.setenv(OPENAI_API_KEY = \"your-api-key\")")
-      } else if (provider == "anthropic") {
-        lines <- c(lines, "# Anthropic: Set ANTHROPIC_API_KEY environment variable")
-        lines <- c(lines, "# Sys.setenv(ANTHROPIC_API_KEY = \"your-api-key\")")
-      } else if (provider == "google") {
-        lines <- c(lines, "# Google: Set GOOGLE_API_KEY environment variable")
-        lines <- c(lines, "# Sys.setenv(GOOGLE_API_KEY = \"your-api-key\")")
-      } else if (provider == "ollama") {
-        lines <- c(lines, "# Ollama: Ensure Ollama is running locally")
-        lines <- c(lines, "# See: https://ollama.ai/")
+
+    for (endpoint in endpoints) {
+      label <- endpoint_label(endpoint$identity)
+      heading <- if (is.na(label)) {
+        paste0("# ", endpoint$provider)
       } else {
-        lines <- c(lines, paste0("# ", provider, ": Configure API credentials as needed"))
+        paste0("# ", endpoint$provider, " at ", label)
+      }
+      lines <- c(lines, heading)
+
+      if (endpoint$provider %in% known) {
+        lines <- c(lines, paste0("#   see ?ellmer::chat_", endpoint$provider))
+      } else {
+        # Recorded before qlm_code() began rejecting prefixes ellmer cannot
+        # dispatch on, so there is no help topic to send the reader to.
+        lines <- c(lines, "#   this provider is not one the installed ellmer offers")
+        lines <- c(lines, "#   see https://ellmer.tidyverse.org/reference/index.html")
+      }
+
+      # Ollama needs no key on a local endpoint, but ellmer reads
+      # OLLAMA_API_KEY when one is served behind a proxy, so this is said only
+      # where it is true.
+      if (identical(endpoint$provider, "ollama") && is_local_endpoint(endpoint$identity)) {
+        lines <- c(lines, "#   no API key for a local endpoint; ensure Ollama is running")
+        lines <- c(lines, "#   https://ollama.com")
       }
     }
+
     lines <- c(lines, "```")
     lines <- c(lines, "")
   }
@@ -934,4 +963,84 @@ deparse_value <- function(value) {
 #' @noRd
 format_param <- function(name, value) {
   paste0(name, " = ", deparse_value(value))
+}
+
+
+#' Normalised endpoint identity for a run
+#'
+#' Two runs are against the same endpoint when the provider prefix *and* the
+#' `base_url` match, which is the rule [qlm_replicate()] already applies: every
+#' provider ellmer has no `chat_*()` for is reached as
+#' `openai_compatible/<model>`, so the prefix alone cannot tell Qwen through
+#' Alibaba from Kimi through Moonshot, nor one local server from another.
+#'
+#' The host alone is not enough either. `localhost:8000` and `localhost:1234`
+#' are different servers, `/team-a/v1` and `/team-b/v1` on one gateway are
+#' different deployments, and `http` and `https` are different endpoints. So
+#' the whole URL is kept, minus any userinfo -- a credential embedded as
+#' `https://user:token@host` is not part of the endpoint's identity and must
+#' never be recorded as though it were.
+#'
+#' @param base_url A recorded `chat_args$base_url`, possibly `NULL` or `NA`.
+#'
+#' @return A single string, or `NA_character_` when no usable URL was recorded.
+#' @keywords internal
+#' @noRd
+endpoint_identity <- function(base_url) {
+  if (length(base_url) != 1L || !is.character(base_url) || is.na(base_url) ||
+      !nzchar(base_url)) {
+    return(NA_character_)
+  }
+
+  url <- sub("^(\\w+://)[^/@]*@", "\\1", base_url)  # drop userinfo
+  sub("/+$", "", url)
+}
+
+
+#' Endpoint label safe to print in a shared report
+#'
+#' The identity minus query and fragment. A credential is as likely to arrive
+#' as `?api_key=` as in userinfo, and an audit trail is written to be handed to
+#' someone else.
+#'
+#' Known limitation: an endpoint distinguished only by a query parameter --
+#' Azure's `api-version=`, say -- prints the same label as its sibling, though
+#' the two remain distinct identities and so appear as separate entries.
+#'
+#' @param identity A value from `endpoint_identity()`.
+#'
+#' @return A single string, or `NA_character_`.
+#' @keywords internal
+#' @noRd
+endpoint_label <- function(identity) {
+  if (is.na(identity)) {
+    return(NA_character_)
+  }
+
+  sub("[?#].*$", "", identity)
+}
+
+
+#' Is this endpoint on the machine running the report?
+#'
+#' Used only to decide whether "no API key needed" is safe to say. An absent
+#' `base_url` means the provider's own default, which for Ollama is
+#' `http://localhost:11434`.
+#'
+#' @param identity A value from `endpoint_identity()`.
+#'
+#' @return `TRUE` when the endpoint is local or defaulted.
+#' @keywords internal
+#' @noRd
+is_local_endpoint <- function(identity) {
+  if (is.na(identity)) {
+    return(TRUE)
+  }
+
+  host <- sub("^\\w+://", "", identity)
+  host <- sub("[/?#].*$", "", host)
+  host <- sub("^\\[(.*)\\]$", "\\1", host)  # bracketed IPv6
+  host <- sub(":\\d+$", "", host)
+
+  host %in% c("localhost", "127.0.0.1", "::1", "0.0.0.0")
 }

--- a/R/qlm_trail.R
+++ b/R/qlm_trail.R
@@ -655,9 +655,9 @@ generate_trail_report <- function(trail, file) {
     lines <- c(lines, "### Provider and endpoint setup")
     lines <- c(lines, "")
     lines <- c(lines, paste(
-      "Credentials are not recorded in the trail. Set up each provider below as",
-      "its ellmer help page describes -- the requirements differ, from an API key",
-      "to platform IAM to none at all."
+      "Credential requirements differ by provider, from an API key to platform",
+      "IAM to none at all. Follow the corresponding ellmer help page to",
+      "configure access."
     ))
     lines <- c(lines, "")
     lines <- c(lines, "```r")
@@ -997,11 +997,16 @@ endpoint_identity <- function(base_url) {
 }
 
 
-#' Endpoint label safe to print in a shared report
+#' Endpoint label for the setup section
 #'
 #' The identity minus query and fragment. A credential is as likely to arrive
-#' as `?api_key=` as in userinfo, and an audit trail is written to be handed to
-#' someone else.
+#' as `?api_key=` as in userinfo, and a trail is written to be handed to
+#' someone else, so neither is printed here.
+#'
+#' This narrows one exposure; it does not make the report credential-free. The
+#' Call section prints `deparse(run$call)`, so a `base_url` written as a
+#' literal at the call site still appears there, and the `.rds` preserves
+#' `chat_args` whole by design. Redacting those is a separate problem.
 #'
 #' Known limitation: an endpoint distinguished only by a query parameter --
 #' Azure's `api-version=`, say -- prints the same label as its sibling, though
@@ -1023,24 +1028,34 @@ endpoint_label <- function(identity) {
 
 #' Is this endpoint on the machine running the report?
 #'
-#' Used only to decide whether "no API key needed" is safe to say. An absent
-#' `base_url` means the provider's own default, which for Ollama is
-#' `http://localhost:11434`.
+#' Used only to decide whether "no API key needed" is safe to say, so an
+#' unknown endpoint must not count as local. An absent `base_url` is unknown
+#' rather than default: ellmer resolves Ollama's to
+#' `Sys.getenv("OLLAMA_BASE_URL", "http://localhost:11434")`, so a run made
+#' against a remote `OLLAMA_BASE_URL` records no URL, and calling that local
+#' would reproduce the stale guidance this replaced.
 #'
 #' @param identity A value from `endpoint_identity()`.
 #'
-#' @return `TRUE` when the endpoint is local or defaulted.
+#' @return `TRUE` only when the endpoint is recorded and loopback.
 #' @keywords internal
 #' @noRd
 is_local_endpoint <- function(identity) {
   if (is.na(identity)) {
-    return(TRUE)
+    return(FALSE)
   }
 
   host <- sub("^\\w+://", "", identity)
   host <- sub("[/?#].*$", "", host)
-  host <- sub("^\\[(.*)\\]$", "\\1", host)  # bracketed IPv6
-  host <- sub(":\\d+$", "", host)
+
+  # Brackets and port together: `[::1]` and `[::1]:11434` both have to reduce
+  # to `::1`. Unbracketing first and stripping the port after would take the
+  # trailing `:1` off `::1` and leave a bare colon.
+  host <- if (grepl("^\\[", host)) {
+    sub("^\\[([^]]*)\\].*$", "\\1", host)
+  } else {
+    sub(":\\d+$", "", host)
+  }
 
   host %in% c("localhost", "127.0.0.1", "::1", "0.0.0.0")
 }

--- a/tests/testthat/test-qlm_trail.R
+++ b/tests/testthat/test-qlm_trail.R
@@ -763,9 +763,11 @@ test_that("OpenAI-compatible endpoints are no longer collapsed into one (#130)",
 })
 
 
-test_that("a credential in the URL never reaches the report (#130)", {
-  # A trail is written to be handed to someone else. Credentials arrive both as
-  # userinfo and as a query parameter.
+test_that("a credential in the URL does not appear in the endpoint label (#130)", {
+  # Scoped deliberately to the label. The report is not credential-free: the
+  # Call section prints deparse(run$call), so a base_url written as a literal
+  # at the call site still appears there, and the .rds keeps chat_args whole.
+  # That is a separate problem; this asserts only what this section controls.
   section <- setup_section(endpoint_fixture(
     "openai_compatible/m", "https://user:tok3n@api.example.com/v1?api_key=abc#frag"
   ))
@@ -781,7 +783,9 @@ test_that("a credential in the URL never reaches the report (#130)", {
 test_that("Ollama is only told it needs no key when the endpoint is local (#130)", {
   # ellmer reads OLLAMA_API_KEY through ollama_credentials() and takes
   # OLLAMA_BASE_URL, so a blanket "running locally" is wrong behind a proxy.
-  local_section <- setup_section(endpoint_fixture("ollama/llama3.2"))
+  local_section <- setup_section(
+    endpoint_fixture("ollama/llama3.2", "http://localhost:11434")
+  )
   expect_true(any(grepl("no API key for a local endpoint", local_section, fixed = TRUE)))
   expect_true(any(grepl("?ellmer::chat_ollama", local_section, fixed = TRUE)))
 
@@ -790,6 +794,36 @@ test_that("Ollama is only told it needs no key when the endpoint is local (#130)
   )
   expect_false(any(grepl("no API key", remote_section, fixed = TRUE)))
   expect_true(any(grepl("?ellmer::chat_ollama", remote_section, fixed = TRUE)))
+})
+
+
+test_that("an unrecorded endpoint is not claimed to be local (#130)", {
+  # ellmer resolves Ollama's default to Sys.getenv("OLLAMA_BASE_URL",
+  # "http://localhost:11434"), so an absent base_url may well have been a
+  # remote server. Claiming no key is needed there would reproduce exactly the
+  # stale guidance this replaced.
+  absent_section <- setup_section(endpoint_fixture("ollama/llama3.2"))
+
+  expect_false(any(grepl("no API key", absent_section, fixed = TRUE)))
+  expect_true(any(grepl("?ellmer::chat_ollama", absent_section, fixed = TRUE)))
+  expect_false(is_local_endpoint(NA_character_))
+})
+
+
+test_that("IPv6 loopback counts as local, with or without a port (#130)", {
+  # Unbracketing before stripping the port turned `::1` into `:`, so neither
+  # form was recognised.
+  expect_true(is_local_endpoint("http://[::1]:11434"))
+  expect_true(is_local_endpoint("http://[::1]"))
+  expect_true(is_local_endpoint("http://[::1]/v1"))
+
+  # Link-local is not loopback.
+  expect_false(is_local_endpoint("http://[fe80::1]:11434"))
+
+  # And the IPv4 forms still work.
+  expect_true(is_local_endpoint("http://localhost:11434"))
+  expect_true(is_local_endpoint("http://127.0.0.1"))
+  expect_false(is_local_endpoint("http://localhost.evil.com"))
 })
 
 

--- a/tests/testthat/test-qlm_trail.R
+++ b/tests/testthat/test-qlm_trail.R
@@ -695,3 +695,151 @@ test_that("qlm_trail() reproducibility advice uses the form that works (#127)", 
     content, fixed = TRUE
   )))
 })
+
+
+# ---- provider and endpoint setup section (#130) -----------------------------
+
+endpoint_fixture <- function(name, base_url = NULL, run = "run1") {
+  coded <- data.frame(.id = 1:2, polarity = c("pos", "neg"))
+  class(coded) <- c("qlm_coded", "data.frame")
+  chat_args <- list(name = name)
+  if (!is.null(base_url)) chat_args$base_url <- base_url
+  attr(coded, "run") <- list(
+    name = run, parent = NULL, call = quote(qlm_code(x, cb)),
+    metadata = list(timestamp = as.POSIXct("2024-01-01 12:00:00"), n_units = 2),
+    chat_args = chat_args,
+    codebook = list(name = "sentiment", instructions = "Code sentiment")
+  )
+  coded
+}
+
+setup_section <- function(...) {
+  path <- file.path(tempdir(), "test_trail_endpoints")
+  withr::defer_parent(unlink(paste0(path, c(".rds", ".qmd"))))
+  qlm_trail(..., path = path)
+  content <- readLines(paste0(path, ".qmd"))
+  start <- grep("^### Provider and endpoint setup$", content)
+  if (length(start) == 0) return(character(0))
+  rest <- content[start:length(content)]
+  rest[seq_len(grep("^### ", rest)[2] - 1L)]
+}
+
+
+test_that("endpoints on the same host but different ports stay distinct (#130)", {
+  section <- setup_section(
+    endpoint_fixture("vllm/a", "http://localhost:8000/v1", "one"),
+    endpoint_fixture("vllm/b", "http://localhost:1234/v1", "two")
+  )
+
+  expect_true(any(grepl("localhost:8000/v1", section, fixed = TRUE)))
+  expect_true(any(grepl("localhost:1234/v1", section, fixed = TRUE)))
+  expect_equal(sum(grepl("^# vllm at", section)), 2)
+})
+
+
+test_that("endpoints on the same host but different paths stay distinct (#130)", {
+  section <- setup_section(
+    endpoint_fixture("openai_compatible/a", "https://gw.example.com/team-a/v1", "one"),
+    endpoint_fixture("openai_compatible/b", "https://gw.example.com/team-b/v1", "two")
+  )
+
+  expect_true(any(grepl("gw.example.com/team-a/v1", section, fixed = TRUE)))
+  expect_true(any(grepl("gw.example.com/team-b/v1", section, fixed = TRUE)))
+  expect_equal(sum(grepl("^# openai_compatible at", section)), 2)
+})
+
+
+test_that("OpenAI-compatible endpoints are no longer collapsed into one (#130)", {
+  # The worst of the three symptoms: Qwen and Kimi both arrive as
+  # `openai_compatible`, and the report used to name only that prefix.
+  section <- setup_section(
+    endpoint_fixture("openai_compatible/qwen3-max",
+                     "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "one"),
+    endpoint_fixture("openai_compatible/kimi-k3", "https://api.moonshot.ai/v1", "two")
+  )
+
+  expect_true(any(grepl("dashscope-intl.aliyuncs.com", section, fixed = TRUE)))
+  expect_true(any(grepl("api.moonshot.ai", section, fixed = TRUE)))
+})
+
+
+test_that("a credential in the URL never reaches the report (#130)", {
+  # A trail is written to be handed to someone else. Credentials arrive both as
+  # userinfo and as a query parameter.
+  section <- setup_section(endpoint_fixture(
+    "openai_compatible/m", "https://user:tok3n@api.example.com/v1?api_key=abc#frag"
+  ))
+
+  expect_false(any(grepl("tok3n", section, fixed = TRUE)))
+  expect_false(any(grepl("api_key=abc", section, fixed = TRUE)))
+  expect_false(any(grepl("user:", section, fixed = TRUE)))
+  expect_false(any(grepl("#frag", section, fixed = TRUE)))
+  expect_true(any(grepl("api.example.com/v1", section, fixed = TRUE)))
+})
+
+
+test_that("Ollama is only told it needs no key when the endpoint is local (#130)", {
+  # ellmer reads OLLAMA_API_KEY through ollama_credentials() and takes
+  # OLLAMA_BASE_URL, so a blanket "running locally" is wrong behind a proxy.
+  local_section <- setup_section(endpoint_fixture("ollama/llama3.2"))
+  expect_true(any(grepl("no API key for a local endpoint", local_section, fixed = TRUE)))
+  expect_true(any(grepl("?ellmer::chat_ollama", local_section, fixed = TRUE)))
+
+  remote_section <- setup_section(
+    endpoint_fixture("ollama/llama3.2", "https://ollama.corp.example.com")
+  )
+  expect_false(any(grepl("no API key", remote_section, fixed = TRUE)))
+  expect_true(any(grepl("?ellmer::chat_ollama", remote_section, fixed = TRUE)))
+})
+
+
+test_that("every ellmer provider gets a real pointer, not a generic non-answer (#130)", {
+  section <- setup_section(
+    endpoint_fixture("google_gemini/gemini-2.5-flash", run = "one"),
+    endpoint_fixture("deepseek/deepseek-chat", run = "two"),
+    endpoint_fixture("aws_bedrock/claude", run = "three")
+  )
+
+  expect_true(any(grepl("?ellmer::chat_google_gemini", section, fixed = TRUE)))
+  expect_true(any(grepl("?ellmer::chat_deepseek", section, fixed = TRUE)))
+  expect_true(any(grepl("?ellmer::chat_aws_bedrock", section, fixed = TRUE)))
+  expect_false(any(grepl("Configure API credentials as needed", section, fixed = TRUE)))
+})
+
+
+test_that("a provider the installed ellmer lacks gets no broken help link (#130)", {
+  # `google` is the shape of a trail recorded before qlm_code() began
+  # rejecting prefixes ellmer cannot dispatch on. `?ellmer::chat_google` does
+  # not exist, so it must not be offered.
+  section <- setup_section(endpoint_fixture("google/gemini-2.5-flash"))
+
+  expect_false(any(grepl("?ellmer::chat_google", section, fixed = TRUE)))
+  expect_true(any(grepl("not one the installed ellmer offers", section, fixed = TRUE)))
+  expect_true(any(grepl("ellmer.tidyverse.org/reference/index.html", section, fixed = TRUE)))
+})
+
+
+test_that("a missing or unusable base_url degrades to the provider alone (#130)", {
+  for (value in list(NULL, NA_character_, "", 42, c("a", "b"))) {
+    section <- setup_section(endpoint_fixture("openai/gpt-4o-mini", base_url = value))
+    expect_true(any(grepl("^# openai$", section)), info = paste(class(value), length(value)))
+    expect_false(any(grepl(" at NA", section, fixed = TRUE)))
+    expect_true(any(grepl("?ellmer::chat_openai", section, fixed = TRUE)))
+  }
+})
+
+
+test_that("a run with no recorded model name does not break the section (#130)", {
+  coded <- data.frame(.id = 1:2, polarity = c("pos", "neg"))
+  class(coded) <- c("qlm_coded", "data.frame")
+  attr(coded, "run") <- list(
+    name = "nameless", parent = NULL, call = quote(qlm_code(x, cb)),
+    metadata = list(timestamp = as.POSIXct("2024-01-01 12:00:00"), n_units = 2),
+    chat_args = list(),
+    codebook = list(name = "sentiment", instructions = "Code sentiment")
+  )
+
+  # qlm_trail() reports where it saved, so silence is not the assertion here.
+  expect_no_error(section <- setup_section(coded))
+  expect_length(section, 0)
+})


### PR DESCRIPTION
Closes #130. All three adjustments from the plan review are in.

## Before / after

Old output, for a trail spanning Qwen, Kimi, two local vLLM servers and Gemini:

```r
# openai: Set OPENAI_API_KEY environment variable
# openai_compatible: Configure API credentials as needed
# vllm: Configure API credentials as needed
# google_gemini: Configure API credentials as needed
```

Four runs against four different services collapsed to one `openai_compatible` line, and Gemini got the generic non-answer because the `google` branch keys on a prefix that cannot resolve.

New:

```r
# openai
#   see ?ellmer::chat_openai
# openai_compatible at https://dashscope-intl.aliyuncs.com/compatible-mode/v1
#   see ?ellmer::chat_openai_compatible
# openai_compatible at https://api.moonshot.ai/v1
#   see ?ellmer::chat_openai_compatible
# vllm at http://localhost:8000/v1
#   see ?ellmer::chat_vllm
# vllm at http://localhost:1234/v1
#   see ?ellmer::chat_vllm
# ollama
#   see ?ellmer::chat_ollama
#   no API key for a local endpoint; ensure Ollama is running
#   https://ollama.com
# google
#   this provider is not one the installed ellmer offers
#   see https://ellmer.tidyverse.org/reference/index.html
```

## Identity is the whole `base_url`, not the host

Matching `qlm_replicate()`, which already treats prefix + `base_url` as the run's identity. Host-only would have collapsed `localhost:8000` against `localhost:1234`, `/team-a/v1` against `/team-b/v1`, and http against https — all tested.

The label shown is the identity minus query and fragment, and userinfo is stripped from both. A credential arrives as `https://user:token@host` or as `?api_key=`, and a trail is written to be handed to someone else. Tested with `https://user:tok3n@api.example.com/v1?api_key=abc#frag`, asserting the secret is absent **from the endpoint label** while `api.example.com/v1` is present.

**This does not make the report credential-free, and no longer claims to.** The Call section prints `deparse(run$call)`, so a `base_url` written as a literal at the call site appears there verbatim, and the `.rds` preserves `chat_args` whole by design — both confirmed by building a trail from a run whose call embeds `user:s3cret@`. An earlier revision of this PR told the reader "Credentials are not recorded in the trail", which was false; the section now says only that requirements differ by provider. The remaining exposure is filed as #154, where the three routes (`base_url` userinfo/query, a direct `api_key`, `api_headers` literals) are separated because they need different fixes.

Applied wherever `base_url` is recorded, not only to OpenAI-compatible and local providers.

**Known limitation, documented in the helper:** an endpoint distinguished only by a query parameter — Azure's `api-version=` — prints the same label as its sibling. The two remain distinct identities and appear as separate entries, so nothing is collapsed; the labels just read alike.

## Guidance is delegated, not enumerated

quallmer cannot derive credential requirements. I confirmed ellmer's `deepseek_key()`, `openai_key()` and `key_get()` are all internal — `getNamespaceExports("ellmer")` has none of them — and `:::` would trade a stale table for a CRAN-check problem. Convention does not substitute either: `google_gemini` uses `GEMINI_API_KEY`, and `hf_key()` does not follow the pattern.

So each entry points at `?ellmer::chat_<provider>`, guarded by `ellmer_providers()` from #144. A prefix the installed ellmer lacks — which is exactly what a trail recorded before #129 can carry — is named without offering a help topic that does not exist, and gets the ellmer provider index instead.

## Ollama

Not an unconditional exception. Verified against installed ellmer 0.4.2: `ollama_credentials()` reads `OLLAMA_API_KEY`, and `base_url` defaults to `Sys.getenv("OLLAMA_BASE_URL", "http://localhost:11434")`. So the "running locally" wording was already wrong for a proxied endpoint. It is now emitted only when a loopback endpoint was **recorded** — `localhost`, `127.0.0.1`, `::1` or `0.0.0.0`.

An absent `base_url` counts as unknown, not local. An earlier revision treated it as the provider default, but ellmer resolves that through `OLLAMA_BASE_URL`, so a run against a remote Ollama records no URL and would have been told it needed no key — reproducing the exact stale guidance this PR set out to remove.

IPv6 loopback also needed fixing: unbracketing before stripping the port turned `[::1]` into `::1` and then a bare colon, so `http://[::1]` and `http://[::1]:11434` both came back `FALSE`. Brackets and port are handled together now, with `[fe80::1]` kept as a negative case since link-local is not loopback.

Its link also moves from `https://ollama.ai/`, which 301s, to `https://ollama.com/`, which does not.

## Heading

"Provider and endpoint setup", not "Configure API credentials" — several supported providers use IAM, OAuth or platform credentials, and local Ollama uses none. The intro says as much and sends readers to the ellmer help pages.

## Tests

All from the review list, plus three of mine:

- same host, different ports; same host, different paths
- Qwen and Kimi no longer collapsing into one entry
- userinfo, query and fragment absent from the endpoint label
- local versus remote Ollama, and an unrecorded endpoint getting no no-key claim
- IPv6 loopback with and without a port and path, and link-local staying non-local
- `base_url` as `NULL`, `NA_character_`, `""`, `42`, and `c("a", "b")` — each degrading to the provider alone with no `at NA`
- `google_gemini`, `deepseek` and `aws_bedrock` each getting a real pointer, and no "configure credentials as needed" anywhere
- a legacy `google` prefix getting no `?ellmer::chat_google`
- a run with no recorded model name not breaking the section

`FAIL 0 | WARN 2 | SKIP 3 | PASS 1409`, up 51. Both warnings pre-exist in `test-qlm_compare.R:336` and `test-qlm_validate.R:93`.

## Upstream

Still worth asking tidyverse/ellmer for stable provider metadata — but for authentication metadata or a public help-topic accessor generally, not a `provider_key_env()`, since ellmer's auth methods are too varied for a single environment-variable accessor. Happy to draft it as a separate issue.

