### PR TITLE
Let qlm_codebook(levels=) name variables nested inside the schema

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 ## Bug fixes
 
+* `qlm_codebook(levels = )` accepts variables nested inside a `type_array()`
+  or a nested `type_object()`. The check matched names against top-level
+  schema properties only, so a codebook whose schema returns one array entry
+  per rated item could not declare measurement levels for the very variables
+  `qlm_compare()` and `qlm_validate()` need them for, and the only workaround
+  was to drop `levels` from the codebook and re-attach them by hand after
+  unnesting. Property names are now collected at every depth. A name that
+  occurs at more than one place in the schema is an error rather than being
+  resolved silently to the first match, since a flat `levels` list cannot say
+  which one it means (#131).
+
 * `qlm_trail()` reports which endpoint each run actually used, and points at
   the right ellmer help page for setting it up. The report derived a provider
   by splitting the model string and mapped it through a four-name `if/else`

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,10 +8,12 @@
   per rated item could not declare measurement levels for the very variables
   `qlm_compare()` and `qlm_validate()` need them for, and the only workaround
   was to drop `levels` from the codebook and re-attach them by hand after
-  unnesting. Property names are now collected at every depth. A name that
-  occurs at more than one place in the schema is an error rather than being
-  resolved silently to the first match, since a flat `levels` list cannot say
-  which one it means (#131).
+  unnesting. Property names are now collected at every depth, and for a
+  schema whose root is a `type_array()` rather than a `type_object()`, which
+  previously skipped the check altogether. A name that occurs at more than
+  one place in the schema is an error rather than being resolved silently to
+  the first match, since a flat `levels` list cannot say which one it means
+  (#131).
 
 * `qlm_trail()` reports which endpoint each run actually used, and points at
   the right ellmer help page for setting it up. The report derived a provider

--- a/R/qlm_codebook.R
+++ b/R/qlm_codebook.R
@@ -25,11 +25,14 @@
 #'
 #'   Names may refer to properties at any depth of the schema, including those
 #'   inside a nested [type_object()] or the items of a [type_array()]. A level
-#'   declared for a nested variable describes that variable once the coded
-#'   output has been unnested to one row per item, which is the form
-#'   [qlm_compare()] and [qlm_validate()] consume. Because `levels` is a flat
-#'   list, a name that occurs at more than one place in the schema cannot be
-#'   declared and is an error; rename the properties to make them distinct.
+#'   declared for a nested variable describes that variable in a table
+#'   unnested to one row per item. [qlm_compare()] and [qlm_validate()] merge
+#'   on `.id`, so such a table needs an identifier that is unique per item
+#'   (a document-item key, not the document's `.id` alone) and must be
+#'   re-wrapped with [as_qlm_coded()], passing this codebook as `codebook`,
+#'   for the declared levels to be found. Because `levels` is a flat list, a
+#'   name that occurs at more than one place in the schema cannot be declared
+#'   and is an error; rename the properties to make them distinct.
 #'
 #' @return A codebook object (a list with class `c("qlm_codebook", "task")`)
 #'   containing the codebook definition. Use with [qlm_code()] to apply the
@@ -278,16 +281,23 @@ validate_levels <- function(levels, schema) {
   # If schema is provided, check that variable names match schema properties.
   # Properties are collected at every depth, so a variable inside a nested
   # type_object() or the items of a type_array() can be declared too (#131).
-  if (!is.null(schema) && inherits(schema, "ellmer::TypeObject")) {
+  # The root need not be a type_object(): a root type_array() is a documented
+  # schema shape, and its items' properties are resolved the same way.
+  if (!is.null(schema)) {
     all_props <- schema_prop_names(schema)
     schema_props <- unique(all_props)
     unknown <- !names(levels) %in% schema_props
 
     if (any(unknown)) {
       unknown_names <- names(levels)[unknown]
+      hint <- if (length(schema_props) == 0) {
+        "The schema declares no named properties."
+      } else {
+        "Schema properties are: {.val {schema_props}}"
+      }
       cli::cli_abort(c(
         "Variable{?s} not found in schema: {.var {unknown_names}}",
-        "i" = "Schema properties are: {.val {schema_props}}"
+        "i" = hint
       ))
     }
 

--- a/R/qlm_codebook.R
+++ b/R/qlm_codebook.R
@@ -23,6 +23,14 @@
 #'   following mapping: `type_boolean` and `type_enum` = nominal, `type_string`
 #'   = nominal, `type_integer` = ordinal, `type_number` = interval.
 #'
+#'   Names may refer to properties at any depth of the schema, including those
+#'   inside a nested [type_object()] or the items of a [type_array()]. A level
+#'   declared for a nested variable describes that variable once the coded
+#'   output has been unnested to one row per item, which is the form
+#'   [qlm_compare()] and [qlm_validate()] consume. Because `levels` is a flat
+#'   list, a name that occurs at more than one place in the schema cannot be
+#'   declared and is an error; rename the properties to make them distinct.
+#'
 #' @return A codebook object (a list with class `c("qlm_codebook", "task")`)
 #'   containing the codebook definition. Use with [qlm_code()] to apply the
 #'   codebook to data.
@@ -267,9 +275,12 @@ validate_levels <- function(levels, schema) {
     ))
   }
 
-  # If schema is provided, check that variable names match schema properties
+  # If schema is provided, check that variable names match schema properties.
+  # Properties are collected at every depth, so a variable inside a nested
+  # type_object() or the items of a type_array() can be declared too (#131).
   if (!is.null(schema) && inherits(schema, "ellmer::TypeObject")) {
-    schema_props <- names(schema@properties)
+    all_props <- schema_prop_names(schema)
+    schema_props <- unique(all_props)
     unknown <- !names(levels) %in% schema_props
 
     if (any(unknown)) {
@@ -279,9 +290,46 @@ validate_levels <- function(levels, schema) {
         "i" = "Schema properties are: {.val {schema_props}}"
       ))
     }
+
+    # A flat levels list cannot say which of two same-named properties at
+    # different depths it means, so refuse rather than pick one silently.
+    duplicated_props <- unique(all_props[duplicated(all_props)])
+    ambiguous <- names(levels) %in% duplicated_props
+
+    if (any(ambiguous)) {
+      ambiguous_names <- names(levels)[ambiguous]
+      cli::cli_abort(c(
+        "Variable{?s} {.var {ambiguous_names}} occur{?s/} more than once in the schema.",
+        "i" = "{.arg levels} cannot tell same-named properties at different depths apart.",
+        "i" = "Rename the properties so that each declared variable is unique."
+      ))
+    }
   }
 
   invisible(TRUE)
+}
+
+
+#' Collect property names at every depth of a schema
+#'
+#' Descends through nested `type_object()` properties and the items of a
+#' `type_array()`. Names are returned in document order and are not
+#' deduplicated, so a name occurring at two depths appears twice; callers
+#' use that to detect ambiguity.
+#'
+#' @param x An ellmer type object
+#' @return Character vector of property names (possibly with duplicates)
+#' @keywords internal
+#' @noRd
+schema_prop_names <- function(x) {
+  if (inherits(x, "ellmer::TypeObject")) {
+    props <- x@properties
+    c(names(props), unlist(lapply(unname(props), schema_prop_names)))
+  } else if (inherits(x, "ellmer::TypeArray")) {
+    schema_prop_names(x@items)
+  } else {
+    character()
+  }
 }
 
 

--- a/man/qlm_codebook.Rd
+++ b/man/qlm_codebook.Rd
@@ -36,11 +36,14 @@ following mapping: \code{type_boolean} and \code{type_enum} = nominal, \code{typ
 
 Names may refer to properties at any depth of the schema, including those
 inside a nested \code{\link[ellmer:type_object]{type_object()}} or the items of a \code{\link[ellmer:type_array]{type_array()}}. A level
-declared for a nested variable describes that variable once the coded
-output has been unnested to one row per item, which is the form
-\code{\link[=qlm_compare]{qlm_compare()}} and \code{\link[=qlm_validate]{qlm_validate()}} consume. Because \code{levels} is a flat
-list, a name that occurs at more than one place in the schema cannot be
-declared and is an error; rename the properties to make them distinct.}
+declared for a nested variable describes that variable in a table
+unnested to one row per item. \code{\link[=qlm_compare]{qlm_compare()}} and \code{\link[=qlm_validate]{qlm_validate()}} merge
+on \code{.id}, so such a table needs an identifier that is unique per item
+(a document-item key, not the document's \code{.id} alone) and must be
+re-wrapped with \code{\link[=as_qlm_coded]{as_qlm_coded()}}, passing this codebook as \code{codebook},
+for the declared levels to be found. Because \code{levels} is a flat list, a
+name that occurs at more than one place in the schema cannot be declared
+and is an error; rename the properties to make them distinct.}
 }
 \value{
 A codebook object (a list with class \code{c("qlm_codebook", "task")})

--- a/man/qlm_codebook.Rd
+++ b/man/qlm_codebook.Rd
@@ -32,7 +32,15 @@ variable in the schema. Names should match schema property names. Values
 should be one of \code{"nominal"}, \code{"ordinal"}, \code{"interval"}, or \code{"ratio"}.
 If \code{NULL} (default), levels are auto-detected from schema types using the
 following mapping: \code{type_boolean} and \code{type_enum} = nominal, \code{type_string}
-= nominal, \code{type_integer} = ordinal, \code{type_number} = interval.}
+= nominal, \code{type_integer} = ordinal, \code{type_number} = interval.
+
+Names may refer to properties at any depth of the schema, including those
+inside a nested \code{\link[ellmer:type_object]{type_object()}} or the items of a \code{\link[ellmer:type_array]{type_array()}}. A level
+declared for a nested variable describes that variable once the coded
+output has been unnested to one row per item, which is the form
+\code{\link[=qlm_compare]{qlm_compare()}} and \code{\link[=qlm_validate]{qlm_validate()}} consume. Because \code{levels} is a flat
+list, a name that occurs at more than one place in the schema cannot be
+declared and is an error; rename the properties to make them distinct.}
 }
 \value{
 A codebook object (a list with class \code{c("qlm_codebook", "task")})

--- a/tests/testthat/test-qlm_codebook.R
+++ b/tests/testthat/test-qlm_codebook.R
@@ -289,3 +289,63 @@ test_that("qlm_codebook levels refuse a name that occurs at more than one depth"
   )
   expect_equal(cb$levels, list(label = "nominal"))
 })
+
+test_that("qlm_codebook levels are checked when the schema root is a type_array", {
+  schema <- type_array(
+    items = type_object(score = type_integer("1-5."), label = type_string("Label."))
+  )
+
+  # Previously the check was skipped for any root that was not a type_object
+  expect_error(
+    qlm_codebook("x", "x", schema, levels = list(typo = "ordinal")),
+    "not found in schema.*typo"
+  )
+
+  cb <- qlm_codebook("x", "x", schema, levels = list(score = "ordinal"))
+  expect_equal(cb$levels, list(score = "ordinal"))
+
+  # A root with no named properties at all says so rather than listing nothing
+  expect_error(
+    qlm_codebook("x", "x", type_array(items = type_string()),
+                 levels = list(score = "ordinal")),
+    "declares no named properties"
+  )
+})
+
+test_that("nested levels reach qlm_compare through an unnested, re-wrapped table", {
+  # End to end for #131: the codebook declares levels for variables one array
+  # deep; the coded output is unnested to one row per document-item, given an
+  # identifier unique per item, and re-wrapped with the codebook. qlm_compare()
+  # must then pick up "ordinal" for `importance` without a `level` argument.
+  cb <- qlm_codebook(
+    name = "nested_levels",
+    instructions = "Score each item.",
+    schema = type_object(
+      assessments = type_array(
+        items = type_object(
+          item_id = type_string("Identifier."),
+          importance = type_integer("0-2.")
+        )
+      )
+    ),
+    levels = list(importance = "ordinal")
+  )
+
+  # Two documents; d1 has two items, d2 has one. The unit id is document-item.
+  unnested_a <- data.frame(
+    unit = c("d1.econ", "d1.env", "d2.econ"),
+    importance = c(2L, 1L, 0L)
+  )
+  unnested_b <- data.frame(
+    unit = c("d1.econ", "d1.env", "d2.econ"),
+    importance = c(2L, 0L, 0L)
+  )
+
+  coder_a <- as_qlm_coded(unnested_a, id = "unit", name = "A", codebook = cb)
+  coder_b <- as_qlm_coded(unnested_b, id = "unit", name = "B", codebook = cb)
+
+  res <- as.data.frame(qlm_compare(coder_a, coder_b, by = "importance"))
+
+  expect_true(all(res$level == "ordinal"))
+  expect_equal(res$value[res$measure == "percent_agreement"], 2 / 3)
+})

--- a/tests/testthat/test-qlm_codebook.R
+++ b/tests/testthat/test-qlm_codebook.R
@@ -164,3 +164,128 @@ test_that("predefined codebooks are qlm_codebook objects", {
   # Predefined codebook should be qlm_codebook object
   expect_true(inherits(data_codebook_sentiment, "qlm_codebook"))
 })
+
+test_that("qlm_codebook levels accept variables nested inside a type_array", {
+  # The case from #131: one document yields many rated items, so the schema
+  # is an array of per-item objects and the variables that carry levels sit
+  # one array deep.
+  schema <- type_object(
+    assessments = type_array(
+      description = "One entry per item.",
+      items = type_object(
+        item_id = type_string("Identifier."),
+        importance = type_integer("0 = absent, 1 = mild, 2 = high."),
+        position = type_integer("1-7.")
+      )
+    )
+  )
+
+  cb <- qlm_codebook(
+    name = "nested_levels",
+    instructions = "Score each item.",
+    schema = schema,
+    levels = list(importance = "ordinal", position = "ordinal")
+  )
+
+  expect_equal(cb$levels, list(importance = "ordinal", position = "ordinal"))
+  expect_equal(qlm_levels(cb), list(importance = "ordinal", position = "ordinal"))
+
+  # The array itself and a mix of depths are both declarable
+  cb2 <- qlm_codebook(
+    name = "mixed",
+    instructions = "Score each item.",
+    schema = schema,
+    levels = list(assessments = "nominal", item_id = "nominal", importance = "ordinal")
+  )
+  expect_equal(names(cb2$levels), c("assessments", "item_id", "importance"))
+})
+
+test_that("qlm_codebook levels accept variables inside a nested type_object", {
+  schema <- type_object(
+    summary = type_string("Summary."),
+    scores = type_object(
+      tone = type_number("Tone from -1 to 1."),
+      confidence = type_integer("1-5.")
+    )
+  )
+
+  cb <- qlm_codebook(
+    name = "nested_object",
+    instructions = "Rate.",
+    schema = schema,
+    levels = list(summary = "nominal", tone = "interval", confidence = "ordinal")
+  )
+  expect_equal(cb$levels[["tone"]], "interval")
+})
+
+test_that("qlm_codebook levels resolve through arrays nested in arrays", {
+  schema <- type_object(
+    documents = type_array(
+      items = type_object(
+        sentences = type_array(
+          items = type_object(polarity = type_integer("-1, 0, 1."))
+        )
+      )
+    )
+  )
+
+  cb <- qlm_codebook(
+    name = "deep",
+    instructions = "Rate.",
+    schema = schema,
+    levels = list(polarity = "ordinal")
+  )
+  expect_equal(cb$levels[["polarity"]], "ordinal")
+})
+
+test_that("qlm_codebook levels still reject names absent at every depth", {
+  schema <- type_object(
+    assessments = type_array(
+      items = type_object(importance = type_integer("0-2."))
+    )
+  )
+
+  expect_error(
+    qlm_codebook(
+      name = "x", instructions = "x", schema = schema,
+      levels = list(importance = "ordinal", salience = "ordinal")
+    ),
+    "not found in schema.*salience"
+  )
+
+  # The listing of available names now includes nested ones
+  expect_error(
+    qlm_codebook(
+      name = "x", instructions = "x", schema = schema,
+      levels = list(salience = "ordinal")
+    ),
+    "importance"
+  )
+})
+
+test_that("qlm_codebook levels refuse a name that occurs at more than one depth", {
+  schema <- type_object(
+    score = type_number("Overall score."),
+    items = type_array(
+      items = type_object(
+        score = type_integer("Per-item score."),
+        label = type_string("Label.")
+      )
+    )
+  )
+
+  expect_error(
+    qlm_codebook(
+      name = "x", instructions = "x", schema = schema,
+      levels = list(score = "interval")
+    ),
+    "more than once in the schema"
+  )
+
+  # Declaring only the unambiguous names is fine
+  cb <- qlm_codebook(
+    name = "x", instructions = "x", schema = schema,
+    levels = list(label = "nominal")
+  )
+  expect_equal(cb$levels, list(label = "nominal"))
+})


### PR DESCRIPTION
Fixes #131.

## What

`validate_levels()` matched `names(levels)` against `names(schema@properties)`, the top level only. A codebook whose schema returns one `type_array()` entry per rated item could not declare measurement levels for the variables inside that array, which are exactly the ones `qlm_compare()` and `qlm_validate()` need levels for. The only workaround was to drop `levels` from the codebook and re-attach them after unnesting, so the codebook silently lost part of its specification and `qlm_meta()` stopped reporting it.

A new internal `schema_prop_names()` collects property names at every depth, descending through nested `type_object()` properties and `type_array()` items. `validate_levels()` checks against that set, and the "not found in schema" hint lists the full set.

## The two follow-on decisions from the issue

**Name collisions.** The collector keeps duplicates. A flat `levels` list cannot say which of two same-named properties at different depths it means, so declaring such a name is an error, not a silent resolution to the first match:

```
Error in `validate_levels()`:
! Variable `score` occurs more than once in the schema.
ℹ `levels` cannot tell same-named properties at different depths apart.
ℹ Rename the properties so that each declared variable is unique.
```

Only names actually declared are checked, so a schema may still contain duplicates that `levels` does not mention. I did not add a `"parent$child"` path form; nothing downstream would know how to consume one, since the consumers work on flat unnested columns.

**What the level applies to.** The `@param levels` docs now say that a level for a nested variable describes it once the output has been unnested to one row per item, which is the form `qlm_compare()` and `qlm_validate()` consume.

## Not changed

`auto_detect_levels()` still reads the top level only, so a nested schema with `levels = NULL` yields a level for the array rather than its items. Recursing there raises the same collision problem without a user present to resolve it, so it is left as a separate question.

## Scope

- `R/qlm_codebook.R`: `validate_levels()`, new `schema_prop_names()`, `@param levels` docs
- `man/qlm_codebook.Rd` regenerated (roxygen2 8.1.0)
- `tests/testthat/test-qlm_codebook.R`: five new tests (array items, nested object, array-in-array, unknown nested name, ambiguous name)
- `NEWS.md` bullet under Bug fixes

## Checks

- `devtools::test()`: 1418 passing, 0 failures; the 2 warnings are the pre-existing deliberate one in `test-qlm_validate.R:93`
- `R CMD check --as-cran`: 0 errors, 0 warnings, 1 NOTE (dev version number / no prebuilt vignette index)
