### PR TITLE
Report a response cut off at max_tokens as failed

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -29,3 +29,4 @@
 ^quallmer-context\.xml$
 ^sources$
 ^dev$
+^\.git$

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,25 @@
 
 ## Bug fixes
 
+* `qlm_code()` no longer returns a response cut off at the provider's
+  `max_tokens` limit as a successful empty result. Such a response is billed
+  in full, and arrived as a row of `NA` scalars and zero-length arrays with no
+  `.error`, indistinguishable from a unit to which nothing applied, so a
+  document that overran the limit read as "nothing here", and the documents
+  that do so are systematically the longest and richest ones. On the JSON
+  path the finish reason that ellmer 0.4.2 attaches to each turn is now read:
+  the unit is recorded in `.error` with the token count, listed by
+  `qlm_failures()`, and not retried, since the same limit reproduces the cut
+  and the retry is billed again. On the structured path ellmer's parallel
+  call discards the turns, so the finish reason is out of reach; there, when
+  `params(max_tokens = )` is set, a row that used the whole budget and
+  returned nothing is recorded in `.error` as cut off. Without a declared
+  limit the cap is not known and such a row stays silent, which needs an
+  ellmer change to close. Rows carrying an `.error` are also no longer read as
+  evidence that an endpoint ignored the schema, so a run whose every unit
+  failed for a recorded reason is reported as failed rather than re-coded in
+  JSON mode (#153).
+
 * `qlm_codebook(levels = )` accepts variables nested inside a `type_array()`
   or a nested `type_object()`. The check matched names against top-level
   schema properties only, so a codebook whose schema returns one array entry

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,10 +16,12 @@
   `params(max_tokens = )` is set, a row that used the whole budget and
   returned nothing is recorded in `.error` as cut off. Without a declared
   limit the cap is not known and such a row stays silent, which needs an
-  ellmer change to close. Rows carrying an `.error` are also no longer read as
-  evidence that an endpoint ignored the schema, so a run whose every unit
-  failed for a recorded reason is reported as failed rather than re-coded in
-  JSON mode (#153).
+  ellmer change to close. Rows whose request failed, or whose response was
+  cut off, are also no longer read as evidence that an endpoint ignored the
+  schema, so a run whose every unit failed that way is reported as failed
+  rather than re-coded in JSON mode; a response ellmer could extract nothing
+  from still counts, so `"auto"` still falls back for an endpoint that
+  answers in prose (#153).
 
 * `qlm_codebook(levels = )` accepts variables nested inside a `type_array()`
   or a nested `type_object()`. The check matched names against top-level

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -120,7 +120,9 @@
 #'   \item{`"auto"`}{Attempt the structured call; fall back to `"json"` if it
 #'     errors, or if it returns a result in which every required field is `NA`
 #'     in every row, which is what an endpoint that ignored the schema
-#'     produces.}
+#'     produces. Rows carrying an `.error` are left out of that judgement:
+#'     they failed for a recorded reason, which says nothing about the
+#'     schema.}
 #' }
 #'
 #' `"auto"` catches wholesale non-enforcement, not the intermittent kind: a
@@ -147,6 +149,36 @@
 #' are not supported there, so `"auto"` will not fall back under
 #' `batch = TRUE`. The path actually taken is recorded in the run metadata as
 #' `backend`.
+#'
+#' @section Truncated responses:
+#'
+#' A response that runs into the provider's output limit (`max_tokens`) is cut
+#' off mid-JSON, and the request is billed in full. The affected units are
+#' systematically the longest and richest ones, and for a codebook where an
+#' empty answer is a legitimate outcome, a cut-off answer that reads as empty
+#' is the worst kind of silent failure. What arrives depends on the path.
+#'
+#' On the JSON path the finish reason travels with the response, so a unit cut
+#' off this way is recorded in `.error` with the token count, is listed by
+#' [qlm_failures()], and is not retried: a repair prompt cannot supply what the
+#' limit withheld, and would only press the model into a shorter answer.
+#'
+#' On the structured path, [ellmer::parallel_chat_structured()] returns the
+#' converted table and discards the turns, and the finish reason with them. A
+#' truncated response therefore arrives as a row of `NA` scalars and
+#' zero-length arrays. Where the cut leaves unparsable JSON behind, ellmer
+#' warns that it could extract no data, and that warning becomes an `.error`
+#' naming a parse error rather than the cut. Where it leaves nothing behind,
+#' as on Anthropic's forced-tool path, there is no warning, and nothing in the
+#' table distinguishes the row from a unit to which nothing applied. What the
+#' table can carry is the output token count, so when `params(max_tokens = )`
+#' is set, a row that used the whole budget and has nothing in it is recorded
+#' in `.error` as cut off, with that as the reason in either case. Without a
+#' declared limit the cap is not known here (ellmer supplies a provider
+#' default, 4096 for Anthropic, inside its request builder), and the silent
+#' case stays silent. So set `max_tokens` explicitly, high enough for the
+#' longest answer the codebook can produce: the limit is then both less likely
+#' to be hit and detectable when it is.
 #'
 #' When `batch = TRUE`, the function uses [ellmer::batch_chat_structured()]
 #' which submits jobs to the provider's batch API. This is typically more
@@ -483,6 +515,16 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
 
   warn_unenforced_schema(chat, model)
 
+  # Whether a response ran into a declared output limit is knowable only from
+  # the token counts, which ellmer attaches on request; the finish reason
+  # itself does not survive parallel_chat_structured(). See
+  # mark_truncated_rows() for what is inferred from them, and why.
+  cap <- declared_max_tokens(chat_args)
+  keep_tokens <- isTRUE(execution_args$include_tokens)
+  if (!is.null(cap)) {
+    execution_args$include_tokens <- TRUE
+  }
+
   run <- function(chat) {
     if (batch) {
       with_extraction_errors(do.call(ellmer::batch_chat_structured, c(
@@ -520,6 +562,12 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
     attempt <- tryCatch(
       list(ok = TRUE, value = run(build_chat(retry_prompt))),
       error = function(e) list(ok = FALSE, error = strip_ansi(conditionMessage(e)))
+    )
+  }
+
+  if (isTRUE(attempt$ok)) {
+    attempt$value <- mark_truncated_rows(
+      attempt$value, codebook$schema, cap, keep_tokens = keep_tokens
     )
   }
 
@@ -650,6 +698,166 @@ attach_extraction_errors <- function(results, failures) {
     results <- results[, c(others, ".error", usage)]
   }
   results
+}
+
+
+#' The output limit the caller declared, if any
+#'
+#' Read from `params(max_tokens = )` and nowhere else. ellmer fills in a
+#' provider default when none is set (4096 for Anthropic, at the time of
+#' writing), but that default lives in its request builder and is not visible
+#' from here, so an undeclared limit is treated as unknown rather than guessed
+#' at. `api_args` is not consulted either: quallmer forwards it unchanged and
+#' does not inspect it.
+#'
+#' @param chat_args List of arguments destined for [ellmer::chat()].
+#'
+#' @return A positive number, or `NULL`.
+#' @keywords internal
+#' @noRd
+declared_max_tokens <- function(chat_args) {
+  params <- chat_args$params
+  if (!is.list(params)) {
+    return(NULL)
+  }
+  cap <- params$max_tokens
+  if (is.numeric(cap) && length(cap) == 1L && is.finite(cap) && cap > 0) {
+    as.numeric(cap)
+  } else {
+    NULL
+  }
+}
+
+
+#' Flag structured rows that used the whole output budget and returned nothing
+#'
+#' [ellmer::parallel_chat_structured()] returns the converted table and
+#' discards the turns, and with them the finish reason. A response the provider
+#' cut off at `max_tokens` therefore arrives as an ordinary row with nothing in
+#' it -- `NA` scalars, zero-length arrays -- at full cost. When the cut leaves
+#' unparsable JSON, ellmer warns and `with_extraction_errors()` records the
+#' parse error; when it leaves nothing, as on Anthropic's forced-tool path,
+#' there is no `.error` at all and the row is indistinguishable from a unit to
+#' which nothing applied. ellmer's sequential `chat_structured()` raises an
+#' error for the very same response.
+#'
+#' What the table does carry, when asked, is the output token count. A row
+#' that spent every token of a declared limit *and* has nothing in it was, to
+#' a near certainty, cut off: a complete answer that happened to end exactly at
+#' the limit would carry data, and an empty answer does not need the whole
+#' budget. Both conditions are required, so "empty is not missing" still
+#' holds: an empty row below the limit is left alone, since a required array
+#' may validly be `[]`.
+#'
+#' Only a limit the caller declared is known here (see `declared_max_tokens()`).
+#' The finish reason is the right signal and is read directly on the JSON
+#' path; using it here too needs ellmer to return it from the parallel call.
+#'
+#' @param results The result of [ellmer::parallel_chat_structured()], with
+#'   token columns when `cap` is not `NULL`.
+#' @param schema The codebook schema.
+#' @param cap The declared output limit, or `NULL` when none is known.
+#' @param keep_tokens Whether the caller asked for the token columns. If not,
+#'   they were requested only for this check and are removed again.
+#'
+#' @return `results`, with `.error` set for the flagged rows.
+#' @keywords internal
+#' @noRd
+mark_truncated_rows <- function(results, schema, cap, keep_tokens = TRUE) {
+  if (is.null(cap) || !is.data.frame(results) || !nrow(results) ||
+      !"output_tokens" %in% names(results)) {
+    return(results)
+  }
+  spent <- results$output_tokens
+  # A request that failed outright spent no output tokens, so it can never
+  # land here and keeps ellmer's reason. A row that did spend the whole limit
+  # may already carry an extraction error from with_extraction_errors()
+  # ("premature EOF"): that is the symptom, and the cut is the cause, so the
+  # reason recorded here replaces it.
+  hit <- !is.na(spent) & spent >= cap & blank_rows(results, schema)
+
+  if (!keep_tokens) {
+    token_columns <- c("input_tokens", "output_tokens", "cached_input_tokens")
+    results[intersect(token_columns, names(results))] <- NULL
+  }
+  if (!any(hit)) {
+    return(results)
+  }
+
+  errors <- recorded_errors(results)
+  for (i in which(hit)) {
+    errors[i] <- list(simpleError(paste0(
+      "The response used the whole max_tokens limit of ",
+      format(cap, big.mark = ","), " and returned nothing, so it was most ",
+      "likely cut off; raise the limit with params(max_tokens = )."
+    )))
+  }
+  results$.error <- errors
+
+  # ellmer's column order: coded values, then .error, then usage
+  trailing <- intersect(
+    c("input_tokens", "output_tokens", "cached_input_tokens", "cost"),
+    names(results)
+  )
+  results <- results[c(setdiff(names(results), c(".error", trailing)), ".error", trailing)]
+
+  n <- sum(hit)
+  cli::cli_warn(c(
+    "{n} response{?s} from the structured call used the whole {.code max_tokens} limit of {cap} and returned nothing.",
+    "i" = "{cli::qty(n)}{?It was/They were} most likely cut off; raise the limit with {.code params(max_tokens = )}.",
+    "i" = "{.fn qlm_failures} lists the affected units."
+  ))
+  results
+}
+
+
+#' Which rows of a converted result carry no coded value at all?
+#'
+#' Reads the columns the schema defines, ignoring `.error` and the usage
+#' columns. A scalar is blank when `NA`; an array, which converts to a
+#' list-column, when its cell is empty; a nested object, which converts to a
+#' data-frame column, when every one of its columns is blank.
+#'
+#' @param results A data frame as returned by ellmer's converter.
+#' @param schema The codebook schema.
+#'
+#' @return A logical vector, one element per row.
+#' @keywords internal
+#' @noRd
+blank_rows <- function(results, schema) {
+  meta <- c(".error", "input_tokens", "output_tokens", "cached_input_tokens", "cost")
+  cols <- if (inherits(schema, "ellmer::TypeObject")) {
+    intersect(names(schema@properties), names(results))
+  } else {
+    setdiff(names(results), meta)
+  }
+  if (!length(cols)) {
+    return(rep(FALSE, nrow(results)))
+  }
+  Reduce(`&`, lapply(results[cols], blank_column))
+}
+
+blank_column <- function(v) {
+  if (is.data.frame(v)) {
+    if (!ncol(v)) {
+      return(rep(TRUE, nrow(v)))
+    }
+    return(Reduce(`&`, lapply(v, blank_column)))
+  }
+  if (is.list(v)) {
+    return(vapply(v, blank_cell, logical(1)))
+  }
+  is.na(v)
+}
+
+blank_cell <- function(x) {
+  if (is.null(x)) {
+    return(TRUE)
+  }
+  if (is.data.frame(x)) {
+    return(nrow(x) == 0L)
+  }
+  length(x) == 0L
 }
 
 

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -120,9 +120,11 @@
 #'   \item{`"auto"`}{Attempt the structured call; fall back to `"json"` if it
 #'     errors, or if it returns a result in which every required field is `NA`
 #'     in every row, which is what an endpoint that ignored the schema
-#'     produces. Rows carrying an `.error` are left out of that judgement:
-#'     they failed for a recorded reason, which says nothing about the
-#'     schema.}
+#'     produces. Rows whose request failed, or whose response was cut off
+#'     at `max_tokens`, are left out of that judgement, since neither says
+#'     anything about the schema; a row from which ellmer could extract no
+#'     structured data counts, since that is what an endpoint that ignored
+#'     the schema produces.}
 #' }
 #'
 #' `"auto"` catches wholesale non-enforcement, not the intermittent kind: a
@@ -684,7 +686,7 @@ attach_extraction_errors <- function(results, failures) {
   for (k in seq_len(nrow(failures))) {
     i <- failures$index[k]
     if (is.null(errors[[i]])) {
-      errors[[i]] <- simpleError(failures$message[k])
+      errors[[i]] <- extraction_error(failures$message[k])
     }
   }
   results$.error <- errors
@@ -858,6 +860,32 @@ blank_cell <- function(x) {
     return(nrow(x) == 0L)
   }
   length(x) == 0L
+}
+
+
+#' An error recorded for a response ellmer could extract nothing from
+#'
+#' Carries a class of its own so that the schema-enforcement check in
+#' `all_required_missing()` can tell it from a request failure or a cut-off
+#' response. The distinction matters: here the endpoint did answer, and the
+#' answer was not the schema, which is precisely the evidence that check
+#' looks for; a request that never got an answer, or an answer the provider
+#' cut short, is not.
+#'
+#' @param message The message ellmer gave for the row.
+#'
+#' @return A condition inheriting from `simpleError`.
+#' @keywords internal
+#' @noRd
+extraction_error <- function(message) {
+  structure(
+    simpleError(message),
+    class = c("quallmer_extraction_error", "simpleError", "error", "condition")
+  )
+}
+
+is_extraction_error <- function(e) {
+  inherits(e, "quallmer_extraction_error")
 }
 
 

--- a/R/qlm_code_json.R
+++ b/R/qlm_code_json.R
@@ -131,19 +131,20 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
         checked$error <- paste0("API request failed: ", turns$error[[j]])
       }
       # A response the provider itself reports as incomplete -- cut off at
-      # max_tokens, withheld by a content filter -- fails validation for that
-      # reason, not for anything the model chose to write, so record the
-      # provider's reason rather than "Invalid JSON". `turns$finish` is NA for
-      # a request that failed outright, so the two cannot collide.
+      # max_tokens, withheld by a content filter -- is a failure whatever the
+      # text looks like. Cut-off JSON usually fails to parse, and then the
+      # provider's reason is the one to record rather than "Invalid JSON"; an
+      # object that happened to close just before the limit parses cleanly,
+      # and the provider's word still wins, as it does in ellmer's own
+      # check_finish_reason(). `turns$finish` is NA for a request that failed
+      # outright, so this can never override a transport error.
       truncated <- FALSE
-      if (!isTRUE(checked$ok)) {
-        reason <- incomplete_response_reason(
-          turns$finish[[j]], turns$usage[j, "output_tokens"]
-        )
-        if (!is.null(reason)) {
-          checked$error <- reason
-          truncated <- is_truncation(turns$finish[[j]])
-        }
+      reason <- incomplete_response_reason(
+        turns$finish[[j]], turns$usage[j, "output_tokens"]
+      )
+      if (!is.null(reason)) {
+        checked <- list(ok = FALSE, error = reason)
+        truncated <- is_truncation(turns$finish[[j]])
       }
       if (isTRUE(checked$ok)) {
         parsed[[i]] <- checked$value
@@ -966,11 +967,18 @@ all_required_missing <- function(results, schema) {
   if (!length(fields)) {
     return(FALSE)
   }
-  # A row with a recorded error failed for that reason -- a rejected request,
-  # a response cut off at max_tokens -- and says nothing about whether the
-  # endpoint honours the schema. Enforcement is judged from the rows that
-  # came back intact; if there are none, there is nothing to judge.
-  judged <- !errored_rows(results)
+  # A row with a recorded error is evidence only if the endpoint answered. A
+  # rejected request, or a response cut off at max_tokens, says nothing about
+  # whether the endpoint honours the schema, so those rows are set aside. A
+  # response ellmer could extract nothing from -- prose where JSON was asked
+  # for -- is exactly what an endpoint that ignored the schema produces, so
+  # those rows are judged alongside the intact ones. If nothing is left to
+  # judge, there is nothing to conclude.
+  judged <- vapply(
+    recorded_errors(results),
+    function(e) is.null(e) || is_extraction_error(e),
+    logical(1)
+  )
   if (!any(judged)) {
     return(FALSE)
   }

--- a/R/qlm_code_json.R
+++ b/R/qlm_code_json.R
@@ -130,6 +130,21 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
       if (!isTRUE(checked$ok) && !is.na(turns$error[[j]])) {
         checked$error <- paste0("API request failed: ", turns$error[[j]])
       }
+      # A response the provider itself reports as incomplete -- cut off at
+      # max_tokens, withheld by a content filter -- fails validation for that
+      # reason, not for anything the model chose to write, so record the
+      # provider's reason rather than "Invalid JSON". `turns$finish` is NA for
+      # a request that failed outright, so the two cannot collide.
+      truncated <- FALSE
+      if (!isTRUE(checked$ok)) {
+        reason <- incomplete_response_reason(
+          turns$finish[[j]], turns$usage[j, "output_tokens"]
+        )
+        if (!is.null(reason)) {
+          checked$error <- reason
+          truncated <- is_truncation(turns$finish[[j]])
+        }
+      }
       if (isTRUE(checked$ok)) {
         parsed[[i]] <- checked$value
         # NB: `problems[[i]] <- NULL` would DELETE the element and shift every
@@ -153,7 +168,14 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
         # generation and billed at zero tokens, so a wasted attempt is free,
         # whereas dropping the unit discards a coding a retry would have got.
         # Only a context-length rejection is provably unrecoverable.
-        if (!length_rejection && !fatal[[i]]) {
+        #
+        # A response cut off at the output limit is not retried either. The
+        # same limit reproduces the cut, the retry is billed in full, and a
+        # repair prompt cannot supply what the limit withheld: it can only
+        # press the model into a shorter answer, which changes the coding
+        # rather than repairing it. The fix is the caller's, in
+        # params(max_tokens = ), so say so and move on.
+        if (!length_rejection && !truncated && !fatal[[i]]) {
           next_pending <- c(next_pending, i)
         }
       }
@@ -236,14 +258,19 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
 #' so it is captured here. Without it every failure reads as a bare "empty
 #' response", which is useless when triaging a large run.
 #'
+#' The turn also carries ellmer's normalised finish reason (`"success"`,
+#' `"max_tokens"`, `"content_filter"`, ...), which is what distinguishes a
+#' response the model completed from one the provider cut off. It is `NA` for
+#' a request that failed outright and for providers that do not report one.
+#'
 #' @param chat An [ellmer::Chat] object.
 #' @param prompts List of prompts.
 #' @param pc_args List of arguments for [ellmer::parallel_chat()].
 #'
 #' @return A list with `text` (character), `usage` (numeric matrix of input,
-#'   output, and cached input tokens and cost), `error` (character), and
-#'   `status` (integer HTTP status, `NA` when the failure was not an HTTP
-#'   error).
+#'   output, and cached input tokens and cost), `error` (character), `status`
+#'   (integer HTTP status, `NA` when the failure was not an HTTP error), and
+#'   `finish` (character finish reason, `NA` when there is none).
 #' @keywords internal
 #' @noRd
 json_chat_turns <- function(chat, prompts, pc_args) {
@@ -256,6 +283,7 @@ json_chat_turns <- function(chat, prompts, pc_args) {
   text <- rep(NA_character_, n)
   error <- rep(NA_character_, n)
   status <- rep(NA_integer_, n)
+  finish <- rep(NA_character_, n)
   usage <- matrix(
     0,
     nrow = n, ncol = 4,
@@ -276,6 +304,7 @@ json_chat_turns <- function(chat, prompts, pc_args) {
       next
     }
     text[[i]] <- turn@text
+    finish[[i]] <- turn_finish_reason(turn)
     tokens <- turn@tokens
     if (length(tokens) >= 3L) {
       usage[i, 1:3] <- as.numeric(tokens[1:3])
@@ -283,7 +312,31 @@ json_chat_turns <- function(chat, prompts, pc_args) {
     usage[i, 4] <- as.numeric(turn@cost)
   }
 
-  list(text = text, usage = usage, error = error, status = status)
+  list(text = text, usage = usage, error = error, status = status,
+       finish = finish)
+}
+
+
+#' The finish reason recorded on a turn
+#'
+#' ellmer (>= 0.4.2) normalises the provider's stop reason onto an
+#' [ellmer::AssistantTurn] as `finish_reason`: `"success"`, `"tool_use"`,
+#' `"max_tokens"`, `"context_window"`, `"content_filter"`, or, wrapped in
+#' `I()`, a value it did not recognise. Turns from an older ellmer have no such
+#' property, and a provider that reports nothing leaves it `NA`; both read as
+#' "unknown" here rather than as a failure.
+#'
+#' @param turn An [ellmer::Turn].
+#'
+#' @return A single string, or `NA_character_`.
+#' @keywords internal
+#' @noRd
+turn_finish_reason <- function(turn) {
+  reason <- tryCatch(turn@finish_reason, error = function(e) NULL)
+  if (!is.character(reason) || length(reason) != 1L || is.na(reason)) {
+    return(NA_character_)
+  }
+  as.character(unclass(reason))
 }
 
 
@@ -747,6 +800,65 @@ is_length_rejection <- function(msg) {
 }
 
 
+#' Why an intact response is nonetheless unusable
+#'
+#' A response can arrive with HTTP 200 and still not be the model's answer:
+#' the provider cut it off at the output limit, or withheld it. The finish
+#' reason says which, and is the right thing to record, because the parse
+#' error it produces ("premature EOF") describes the symptom and points at the
+#' wrong remedy. Wording follows ellmer's own `check_finish_reason()`, which
+#' raises the same conditions for a sequential `chat_structured()` call.
+#'
+#' @param finish A finish reason, as returned by `json_chat_turns()`.
+#' @param output_tokens Output tokens spent on the response, for the message.
+#'
+#' @return A single string, or `NULL` when the finish reason does not explain
+#'   a failure (the response completed, or no reason was reported).
+#' @keywords internal
+#' @noRd
+incomplete_response_reason <- function(finish, output_tokens = NA_real_) {
+  if (!length(finish) || is.na(finish) ||
+      finish %in% c("success", "tool_use", "stop_sequence")) {
+    return(NULL)
+  }
+  spent <- if (length(output_tokens) == 1L && is.finite(output_tokens) &&
+               output_tokens > 0) {
+    paste0(" after ", format(output_tokens, big.mark = ","), " output tokens")
+  } else {
+    ""
+  }
+  switch(finish,
+    max_tokens = paste0(
+      "The response was cut off at the max_tokens limit", spent,
+      "; raise the limit with params(max_tokens = ) to let the model finish."
+    ),
+    context_window = paste0(
+      "The response was cut off because the input and output together ",
+      "exceeded the model's context window."
+    ),
+    content_filter = "The response was withheld by the provider's content filter.",
+    paste0(
+      "The response may be incomplete: the provider reported finish reason \"",
+      finish, "\"."
+    )
+  )
+}
+
+
+#' Was the response cut short by a limit that a retry cannot lift?
+#'
+#' @param finish A finish reason, as returned by `json_chat_turns()`.
+#'
+#' @return `TRUE` for a response cut off at `max_tokens` or at the context
+#'   window.
+#' @keywords internal
+#' @noRd
+is_truncation <- function(finish) {
+  length(finish) == 1L && !is.na(finish) &&
+    finish %in% c("max_tokens", "context_window")
+}
+
+
 #' Remove ANSI escape sequences
 #'
 #' cli formats API errors with ANSI colour codes, which would otherwise travel
@@ -854,14 +966,23 @@ all_required_missing <- function(results, schema) {
   if (!length(fields)) {
     return(FALSE)
   }
-  all(vapply(fields, function(f) all(is.na(results[[f]])), logical(1)))
+  # A row with a recorded error failed for that reason -- a rejected request,
+  # a response cut off at max_tokens -- and says nothing about whether the
+  # endpoint honours the schema. Enforcement is judged from the rows that
+  # came back intact; if there are none, there is nothing to judge.
+  judged <- !errored_rows(results)
+  if (!any(judged)) {
+    return(FALSE)
+  }
+  all(vapply(fields, function(f) all(is.na(results[[f]][judged])), logical(1)))
 }
 
 
 #' How many rows are missing at least one required field?
 #'
 #' Partial failure, which is worth reporting but is not grounds for discarding
-#' the whole attempt and re-coding in JSON mode.
+#' the whole attempt and re-coding in JSON mode. Rows carrying an `.error` are
+#' not counted: they are reported as failed already, with their reason.
 #'
 #' @param results The result of [ellmer::parallel_chat_structured()].
 #' @param schema An [ellmer::type_object()].
@@ -877,7 +998,8 @@ n_incomplete <- function(results, schema) {
   if (!length(fields)) {
     return(0L)
   }
-  sum(Reduce(`|`, lapply(fields, function(f) is.na(results[[f]]))))
+  missing <- Reduce(`|`, lapply(fields, function(f) is.na(results[[f]])))
+  sum(missing & !errored_rows(results))
 }
 
 

--- a/R/qlm_failures.R
+++ b/R/qlm_failures.R
@@ -14,7 +14,10 @@
 #' * it carries an `.error`. ellmer records one when the request failed.
 #'   [qlm_code()] records one when a response came back but ellmer could
 #'   extract no structured data from it, which ellmer reports only by
-#'   warning, and on the JSON path when a response never validated; or
+#'   warning; when a response used the whole declared `max_tokens` limit and
+#'   returned nothing; and on the JSON path when a response never validated
+#'   or was cut off at that limit (see the *Truncated responses* section of
+#'   [qlm_code()]); or
 #' * every required scalar property of the codebook schema is `NA` for it.
 #'   A structured call can succeed at the HTTP level and still return nothing
 #'   usable, when the endpoint accepted the JSON schema and ignored it, so an
@@ -73,7 +76,7 @@ qlm_failures <- function(x) {
 #' @keywords internal
 #' @noRd
 failed_units <- function(x) {
-  errored <- !vapply(recorded_errors(x), is.null, logical(1))
+  errored <- errored_rows(x)
 
   # required_scalar_fields() ignores arrays and nested objects deliberately;
   # for those, empty is not missing.
@@ -104,6 +107,18 @@ recorded_errors <- function(x) {
   } else {
     vector("list", nrow(x))
   }
+}
+
+
+#' Which rows carry a recorded error?
+#'
+#' @param x A `qlm_coded` object, or any data frame that may have an `.error`
+#'   list-column.
+#' @return A logical vector of length `nrow(x)`.
+#' @keywords internal
+#' @noRd
+errored_rows <- function(x) {
+  !vapply(recorded_errors(x), is.null, logical(1))
 }
 
 

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -158,9 +158,11 @@ conform. The reliable choice for an endpoint known not to enforce.}
 \item{\code{"auto"}}{Attempt the structured call; fall back to \code{"json"} if it
 errors, or if it returns a result in which every required field is \code{NA}
 in every row, which is what an endpoint that ignored the schema
-produces. Rows carrying an \code{.error} are left out of that judgement:
-they failed for a recorded reason, which says nothing about the
-schema.}
+produces. Rows whose request failed, or whose response was cut off
+at \code{max_tokens}, are left out of that judgement, since neither says
+anything about the schema; a row from which ellmer could extract no
+structured data counts, since that is what an endpoint that ignored
+the schema produces.}
 }
 
 \code{"auto"} catches wholesale non-enforcement, not the intermittent kind: a

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -158,7 +158,9 @@ conform. The reliable choice for an endpoint known not to enforce.}
 \item{\code{"auto"}}{Attempt the structured call; fall back to \code{"json"} if it
 errors, or if it returns a result in which every required field is \code{NA}
 in every row, which is what an endpoint that ignored the schema
-produces.}
+produces. Rows carrying an \code{.error} are left out of that judgement:
+they failed for a recorded reason, which says nothing about the
+schema.}
 }
 
 \code{"auto"} catches wholesale non-enforcement, not the intermittent kind: a
@@ -185,6 +187,38 @@ codebooks
 are not supported there, so \code{"auto"} will not fall back under
 \code{batch = TRUE}. The path actually taken is recorded in the run metadata as
 \code{backend}.
+}
+
+\section{Truncated responses}{
+
+
+A response that runs into the provider's output limit (\code{max_tokens}) is cut
+off mid-JSON, and the request is billed in full. The affected units are
+systematically the longest and richest ones, and for a codebook where an
+empty answer is a legitimate outcome, a cut-off answer that reads as empty
+is the worst kind of silent failure. What arrives depends on the path.
+
+On the JSON path the finish reason travels with the response, so a unit cut
+off this way is recorded in \code{.error} with the token count, is listed by
+\code{\link[=qlm_failures]{qlm_failures()}}, and is not retried: a repair prompt cannot supply what the
+limit withheld, and would only press the model into a shorter answer.
+
+On the structured path, \code{\link[ellmer:parallel_chat_structured]{ellmer::parallel_chat_structured()}} returns the
+converted table and discards the turns, and the finish reason with them. A
+truncated response therefore arrives as a row of \code{NA} scalars and
+zero-length arrays. Where the cut leaves unparsable JSON behind, ellmer
+warns that it could extract no data, and that warning becomes an \code{.error}
+naming a parse error rather than the cut. Where it leaves nothing behind,
+as on Anthropic's forced-tool path, there is no warning, and nothing in the
+table distinguishes the row from a unit to which nothing applied. What the
+table can carry is the output token count, so when \code{params(max_tokens = )}
+is set, a row that used the whole budget and has nothing in it is recorded
+in \code{.error} as cut off, with that as the reason in either case. Without a
+declared limit the cap is not known here (ellmer supplies a provider
+default, 4096 for Anthropic, inside its request builder), and the silent
+case stays silent. So set \code{max_tokens} explicitly, high enough for the
+longest answer the codebook can produce: the limit is then both less likely
+to be hit and detectable when it is.
 
 When \code{batch = TRUE}, the function uses \code{\link[ellmer:batch_chat_structured]{ellmer::batch_chat_structured()}}
 which submits jobs to the provider's batch API. This is typically more

--- a/man/qlm_failures.Rd
+++ b/man/qlm_failures.Rd
@@ -31,7 +31,10 @@ A unit counts as failed when either of two things holds:
 \item it carries an \code{.error}. ellmer records one when the request failed.
 \code{\link[=qlm_code]{qlm_code()}} records one when a response came back but ellmer could
 extract no structured data from it, which ellmer reports only by
-warning, and on the JSON path when a response never validated; or
+warning; when a response used the whole declared \code{max_tokens} limit and
+returned nothing; and on the JSON path when a response never validated
+or was cut off at that limit (see the \emph{Truncated responses} section of
+\code{\link[=qlm_code]{qlm_code()}}); or
 \item every required scalar property of the codebook schema is \code{NA} for it.
 A structured call can succeed at the HTTP level and still return nothing
 usable, when the endpoint accepted the JSON schema and ignored it, so an

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -700,6 +700,187 @@ test_that("a partly incomplete structured result warns without falling back", {
 })
 
 
+test_that("a wholly failed structured run is reported, not re-coded in JSON mode", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  # Every row carries a reason -- here, as ellmer will report a cut-off
+  # response once it consults the finish reason on the parallel path
+  failed <- tibble::tibble(score = NA_real_, .error = list(simpleError("cut off")))
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", structured_stub(results = failed))
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  result <- f("a", structured_test_codebook(), model = "openai/gpt-4o-mini")
+
+  expect_null(calls$json)
+  expect_equal(qlm_meta(result, type = "object")$backend, "structured")
+  expect_equal(qlm_failures(result)$reason, "cut off")
+})
+
+
+# Truncated structured responses ----------------------------------------------
+
+test_that("declared_max_tokens reads params() and nothing else", {
+  expect_equal(declared_max_tokens(list(params = ellmer::params(max_tokens = 200))), 200)
+  expect_null(declared_max_tokens(list()))
+  expect_null(declared_max_tokens(list(params = ellmer::params(temperature = 0))))
+  expect_null(declared_max_tokens(list(params = "not a list")))
+  expect_null(declared_max_tokens(list(params = list(max_tokens = -1))))
+  # api_args is forwarded unread
+  expect_null(declared_max_tokens(list(api_args = list(max_tokens = 5))))
+})
+
+test_that("mark_truncated_rows flags only rows that spent the whole limit and hold nothing", {
+  schema <- structured_test_codebook()$schema
+  results <- tibble::tibble(
+    score = c(NA_real_, 0.4, NA_real_),
+    input_tokens = c(10, 10, 10),
+    output_tokens = c(100, 100, 30),
+    cached_input_tokens = c(0, 0, 0)
+  )
+
+  expect_warning(
+    out <- mark_truncated_rows(results, schema, cap = 100),
+    "1 response from the structured call used the whole"
+  )
+  errors <- out$.error
+  expect_s3_class(errors[[1]], "simpleError")  # spent it all, nothing back
+  expect_null(errors[[2]])                      # spent it all, but answered
+  expect_null(errors[[3]])                      # nothing back, but well under the limit
+  expect_match(conditionMessage(errors[[1]]), "max_tokens limit of 100")
+  expect_match(conditionMessage(errors[[1]]), "params\\(max_tokens = \\)")
+  # ellmer's column order: coded values, .error, usage
+  expect_equal(
+    names(out),
+    c("score", ".error", "input_tokens", "output_tokens", "cached_input_tokens")
+  )
+})
+
+test_that("mark_truncated_rows keeps a request failure but replaces a parse symptom", {
+  schema <- structured_test_codebook()$schema
+  results <- tibble::tibble(
+    score = c(NA_real_, NA_real_, NA_real_),
+    # A failed request spends nothing; an extraction failure at the limit is
+    # what a cut-off response looks like after with_extraction_errors()
+    .error = list(simpleError("HTTP 500"), simpleError("parse error: premature EOF"), NULL),
+    input_tokens = c(0, 3, 3), output_tokens = c(0, 100, 100), cached_input_tokens = c(0, 0, 0)
+  )
+
+  expect_warning(out <- mark_truncated_rows(results, schema, cap = 100), "2 responses")
+  expect_equal(conditionMessage(out$.error[[1]]), "HTTP 500")
+  expect_match(conditionMessage(out$.error[[2]]), "most likely cut off")
+  expect_match(conditionMessage(out$.error[[3]]), "most likely cut off")
+})
+
+test_that("mark_truncated_rows removes token columns it asked for itself", {
+  schema <- structured_test_codebook()$schema
+  results <- tibble::tibble(
+    score = 0.4, input_tokens = 1, output_tokens = 5, cached_input_tokens = 0, cost = 0.01
+  )
+
+  expect_equal(names(mark_truncated_rows(results, schema, cap = 100, keep_tokens = FALSE)),
+               c("score", "cost"))
+  expect_equal(names(mark_truncated_rows(results, schema, cap = 100, keep_tokens = TRUE)),
+               names(results))
+})
+
+test_that("mark_truncated_rows is a no-op without a declared limit or token counts", {
+  schema <- structured_test_codebook()$schema
+  results <- tibble::tibble(score = NA_real_)
+
+  expect_identical(mark_truncated_rows(results, schema, cap = NULL), results)
+  expect_identical(mark_truncated_rows(results, schema, cap = 100), results)
+  # convert = FALSE would hand back a list; there is no table to mark
+  expect_identical(mark_truncated_rows(list(1), schema, cap = 100), list(1))
+  expect_identical(mark_truncated_rows(tibble::tibble(), schema, cap = 100), tibble::tibble())
+})
+
+test_that("mark_truncated_rows reads arrays and nested objects as blank when empty", {
+  # The shape from the issue: the content sits inside a type_array(), so a
+  # cut-off response converts to a zero-row tibble, not NA
+  schema <- ellmer::type_object(
+    domains = ellmer::type_array(ellmer::type_object(name = ellmer::type_string())),
+    meta = ellmer::type_object(a = ellmer::type_string(), b = ellmer::type_integer())
+  )
+  converted <- ellmer:::convert_from_type(
+    list(
+      NULL,
+      list(domains = list(list(name = "x")), meta = list(a = "q", b = 1L)),
+      list(domains = list(), meta = list(a = "q", b = 1L))
+    ),
+    ellmer::type_array(schema)
+  )
+  expect_equal(NROW(converted$domains[[1]]), 0)
+  converted$input_tokens <- c(5, 5, 5)
+  converted$output_tokens <- c(4096, 4096, 4096)
+  converted$cached_input_tokens <- c(0, 0, 0)
+
+  expect_warning(out <- mark_truncated_rows(converted, schema, cap = 4096), "1 response")
+  expect_s3_class(out$.error[[1]], "simpleError")
+  expect_null(out$.error[[2]])
+  # An empty array beside a filled nested object is an answer, not a blank
+  expect_null(out$.error[[3]])
+})
+
+test_that("a declared max_tokens lets the structured path flag a cut-off response", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", function(...) structure(list(), class = "Chat"))
+  mockery::stub(tsc, "warn_unenforced_schema", function(...) invisible(NULL))
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", function(chat, prompts, type, ...) {
+    calls$args <- list(...)
+    tibble::tibble(
+      score = c(NA_real_, 0.7),
+      input_tokens = c(50, 40), output_tokens = c(100, 12), cached_input_tokens = c(0, 0)
+    )
+  })
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  expect_warning(
+    result <- f(c("a", "b"), structured_test_codebook(),
+                model = "anthropic/claude-sonnet-5",
+                params = ellmer::params(max_tokens = 100)),
+    "used the whole"
+  )
+
+  # Token counts were requested for the check, and not handed on
+  expect_true(isTRUE(calls$args$include_tokens))
+  expect_false("output_tokens" %in% names(result))
+  # The cut-off row is a failure with a reason, not grounds for a JSON re-run
+  expect_null(calls$json)
+  expect_equal(qlm_meta(result, type = "object")$backend, "structured")
+  failures <- qlm_failures(result)
+  expect_equal(nrow(failures), 1)
+  expect_match(failures$reason, "max_tokens")
+  expect_equal(result$score[[2]], 0.7)
+})
+
+test_that("without a declared limit the structured path asks for nothing extra", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", function(...) structure(list(), class = "Chat"))
+  mockery::stub(tsc, "warn_unenforced_schema", function(...) invisible(NULL))
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", function(chat, prompts, type, ...) {
+    calls$args <- list(...)
+    tibble::tibble(score = 0.7)
+  })
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
+
+  result <- f("a", structured_test_codebook(), model = "anthropic/claude-sonnet-5")
+
+  expect_null(calls$args$include_tokens)
+  expect_equal(result$score, 0.7)
+})
+
+
 test_that("structured = 'structured' aborts rather than falling back", {
   skip_if_not_installed("mockery")
 

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -700,6 +700,33 @@ test_that("a partly incomplete structured result warns without falling back", {
 })
 
 
+test_that("structured = 'auto' still falls back when the endpoint answered in prose", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  # Every row carries the extraction error qlm_code() records from ellmer's
+  # warning: the endpoint answered, but not with the schema
+  prose <- tibble::tibble(
+    score = c(NA_real_, NA_real_),
+    .error = list(
+      extraction_error("Data extraction failed: no JSON responses found."),
+      extraction_error("Data extraction failed: no JSON responses found.")
+    )
+  )
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", structured_stub(results = prose))
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+
+  expect_warning(
+    result <- f(c("a", "b"), structured_test_codebook(), model = "openai_compatible/x",
+                base_url = "https://example.com/v1"),
+    "no usable values"
+  )
+  expect_true(calls$json)
+  expect_equal(qlm_meta(result, type = "object")$backend, "json_mode")
+})
+
+
 test_that("a wholly failed structured run is reported, not re-coded in JSON mode", {
   skip_if_not_installed("mockery")
   calls <- new.env()

--- a/tests/testthat/test-qlm_code_json.R
+++ b/tests/testthat/test-qlm_code_json.R
@@ -23,8 +23,8 @@ json_test_usage <- function(n) {
 }
 
 # A code_handler_json() with ellmer::chat() and json_chat_turns() stubbed out.
-# `attempts` is a list of list(text =, error =, status =), one per expected
-# round trip; `error` and `status` default to NA.
+# `attempts` is a list of list(text =, error =, status =, finish =), one per
+# expected round trip; `error`, `status` and `finish` default to NA.
 json_test_handler <- function(attempts, calls = NULL) {
   h <- code_handler_json
   mockery::stub(h, "ellmer::chat", function(...) structure(list(), class = "fake_chat"))
@@ -41,6 +41,7 @@ json_test_handler <- function(attempts, calls = NULL) {
       text = attempt$text,
       error = attempt$error %||% rep(NA_character_, n),
       status = attempt$status %||% rep(NA_integer_, n),
+      finish = attempt$finish %||% rep(NA_character_, n),
       usage = json_test_usage(n)
     )
   })
@@ -280,6 +281,7 @@ test_that("json_chat_turns extracts text, tokens and cost from turns", {
   expect_equal(result$text, "{\"score\":1}")
   expect_true(is.na(result$error))
   expect_true(is.na(result$status))
+  expect_true(is.na(result$finish))
   expect_equal(unname(result$usage[1, ]), c(10, 5, 2, 0.004))
 })
 
@@ -293,7 +295,149 @@ test_that("json_chat_turns captures the reason a request failed", {
   expect_equal(result$error[[1]], "context length exceeded")
   expect_equal(result$error[[2]], "the request failed")
   expect_true(all(is.na(result$text)))
+  expect_true(all(is.na(result$finish)))
   expect_equal(sum(result$usage), 0)
+})
+
+test_that("json_chat_turns keeps the finish reason of each turn", {
+  cut <- ellmer::AssistantTurn(
+    contents = list(ellmer::ContentText("{\"score\":")),
+    tokens = c(10L, 60L, 0L), cost = 0.01, finish_reason = "max_tokens"
+  )
+  done <- ellmer::AssistantTurn(
+    contents = list(ellmer::ContentText("{\"score\":1}")),
+    tokens = c(10L, 5L, 0L), cost = 0.01, finish_reason = "success"
+  )
+
+  f <- json_chat_turns
+  mockery::stub(f, "ellmer::parallel_chat", list(
+    list(last_turn = function() cut),
+    list(last_turn = function() done),
+    simpleError("boom")
+  ))
+  result <- f(structure(list(), class = "fake_chat"), list("a", "b", "c"), list())
+
+  expect_equal(result$finish, c("max_tokens", "success", NA))
+})
+
+test_that("turn_finish_reason reads what is there and shrugs at what is not", {
+  turn <- function(...) {
+    ellmer::AssistantTurn(
+      contents = list(ellmer::ContentText("x")), tokens = c(1L, 1L, 0L), cost = 0, ...
+    )
+  }
+  expect_true(is.na(turn_finish_reason(turn())))
+  expect_identical(turn_finish_reason(turn(finish_reason = "max_tokens")), "max_tokens")
+  # ellmer wraps a reason it did not recognise in I(); the marker is dropped
+  expect_identical(turn_finish_reason(turn(finish_reason = I("odd"))), "odd")
+  # A turn class without the property, as older ellmer versions produce
+  expect_true(is.na(turn_finish_reason(structure(list(), class = "not_a_turn"))))
+})
+
+
+# Incomplete responses --------------------------------------------------------
+
+test_that("incomplete_response_reason names the provider's reason, and only when there is one", {
+  expect_null(incomplete_response_reason(NA_character_))
+  expect_null(incomplete_response_reason(character()))
+  expect_null(incomplete_response_reason("success"))
+  expect_null(incomplete_response_reason("tool_use"))
+  expect_null(incomplete_response_reason("stop_sequence"))
+
+  expect_match(
+    incomplete_response_reason("max_tokens", 4096),
+    "cut off at the max_tokens limit after 4,096 output tokens; raise"
+  )
+  # No token count to report: the sentence still reads
+  expect_match(
+    incomplete_response_reason("max_tokens"),
+    "cut off at the max_tokens limit; raise"
+  )
+  expect_match(incomplete_response_reason("context_window"), "context window")
+  expect_match(incomplete_response_reason("content_filter"), "content filter")
+  # ... and that wording is what is_content_refusal() recognises
+  expect_true(is_content_refusal(incomplete_response_reason("content_filter")))
+  expect_match(incomplete_response_reason("odd"), "finish reason \"odd\"")
+})
+
+test_that("is_truncation covers the limits a retry cannot lift", {
+  expect_true(is_truncation("max_tokens"))
+  expect_true(is_truncation("context_window"))
+  expect_false(is_truncation("content_filter"))
+  expect_false(is_truncation("success"))
+  expect_false(is_truncation(NA_character_))
+  expect_false(is_truncation(character()))
+})
+
+test_that("code_handler_json records a cut-off response and does not retry it", {
+  calls <- new.env()
+  h <- json_test_handler(list(
+    list(
+      text = c("{\"score\":1,\"lab\":", "{\"score\":1,\"lab\":\"pos\"}"),
+      finish = c("max_tokens", "success")
+    )
+  ), calls)
+
+  expect_warning(
+    result <- h(
+      x = c("a", "b"), codebook = json_test_codebook(),
+      model = "deepseek/deepseek-chat", chat_args = list(), execution_args = list()
+    ),
+    "1 response could not be coded"
+  )
+
+  # One round trip: no repair attempt was spent on a response the same
+  # limit would cut again
+  expect_equal(calls$n, 1)
+  msgs <- json_test_messages(result)
+  expect_match(msgs[[1]], "cut off at the max_tokens limit after 5 output tokens")
+  expect_match(msgs[[1]], "params\\(max_tokens = \\)")
+  expect_true(is.na(msgs[[2]]))
+  expect_equal(result$score, c(NA, 1))
+  expect_equal(attr(result, "qlm_backend_meta")$n_invalid, 1)
+})
+
+test_that("code_handler_json accepts a response that validates despite hitting the limit", {
+  calls <- new.env()
+  h <- json_test_handler(list(
+    list(text = "{\"score\":1,\"lab\":\"pos\"}", finish = "max_tokens")
+  ), calls)
+
+  result <- h(
+    x = "a", codebook = json_test_codebook(),
+    model = "deepseek/deepseek-chat", chat_args = list(), execution_args = list()
+  )
+
+  expect_equal(calls$n, 1)
+  expect_equal(result$score, 1)
+  expect_false(".error" %in% names(result))
+})
+
+test_that("code_handler_json retries a content-filtered response and names the filter", {
+  calls <- new.env()
+  h <- json_test_handler(list(
+    list(text = "", finish = "content_filter"),
+    list(text = "{\"score\":1,\"lab\":\"pos\"}", finish = "success")
+  ), calls)
+
+  result <- h(
+    x = "a", codebook = json_test_codebook(),
+    model = "deepseek/deepseek-chat", chat_args = list(), execution_args = list()
+  )
+  expect_equal(calls$n, 2)
+  expect_equal(result$score, 1)
+
+  # One that never clears records the provider's reason, not "empty response"
+  h2 <- json_test_handler(rep(list(list(text = "", finish = "content_filter")), 3))
+  expect_warning(
+    result2 <- h2(
+      x = "a", codebook = json_test_codebook(),
+      model = "deepseek/deepseek-chat", chat_args = list(), execution_args = list(),
+      max_retries = 2
+    ),
+    "content filter"
+  )
+  expect_match(json_test_messages(result2)[[1]], "withheld by the provider's content filter")
 })
 
 
@@ -763,6 +907,23 @@ test_that("n_incomplete counts partially failed rows", {
   expect_equal(n_incomplete(results, schema), 2)
   expect_equal(n_incomplete(data.frame(score = 1, lab = "pos"), schema), 0)
   expect_equal(n_incomplete(list(), schema), 0L)
+})
+
+test_that("rows with a recorded error are not evidence about schema enforcement", {
+  schema <- json_test_codebook()$schema
+
+  # Every row failed for a recorded reason: nothing to judge enforcement from,
+  # and nothing to count as incomplete that is not already counted as failed
+  failed <- data.frame(score = c(NA_real_, NA_real_), lab = c(NA_character_, NA_character_))
+  failed$.error <- list(simpleError("HTTP 401"), simpleError("cut off"))
+  expect_false(all_required_missing(failed, schema))
+  expect_equal(n_incomplete(failed, schema), 0L)
+
+  # The one intact row is all NA: that is the non-enforcement signal
+  mixed <- data.frame(score = c(NA_real_, NA_real_), lab = c(NA_character_, NA_character_))
+  mixed$.error <- list(simpleError("HTTP 401"), NULL)
+  expect_true(all_required_missing(mixed, schema))
+  expect_equal(n_incomplete(mixed, schema), 1L)
 })
 
 

--- a/tests/testthat/test-qlm_code_json.R
+++ b/tests/testthat/test-qlm_code_json.R
@@ -397,20 +397,26 @@ test_that("code_handler_json records a cut-off response and does not retry it", 
   expect_equal(attr(result, "qlm_backend_meta")$n_invalid, 1)
 })
 
-test_that("code_handler_json accepts a response that validates despite hitting the limit", {
+test_that("code_handler_json rejects a response reported as cut off even when it parses", {
+  # The provider's word wins over a clean parse, as in ellmer's own
+  # check_finish_reason(): an object that closed just before the limit may
+  # still be short of what the model would have written
   calls <- new.env()
   h <- json_test_handler(list(
     list(text = "{\"score\":1,\"lab\":\"pos\"}", finish = "max_tokens")
   ), calls)
 
-  result <- h(
-    x = "a", codebook = json_test_codebook(),
-    model = "deepseek/deepseek-chat", chat_args = list(), execution_args = list()
+  expect_warning(
+    result <- h(
+      x = "a", codebook = json_test_codebook(),
+      model = "deepseek/deepseek-chat", chat_args = list(), execution_args = list()
+    ),
+    "could not be coded"
   )
 
   expect_equal(calls$n, 1)
-  expect_equal(result$score, 1)
-  expect_false(".error" %in% names(result))
+  expect_true(is.na(result$score))
+  expect_match(json_test_messages(result)[[1]], "cut off at the max_tokens limit")
 })
 
 test_that("code_handler_json retries a content-filtered response and names the filter", {
@@ -924,6 +930,16 @@ test_that("rows with a recorded error are not evidence about schema enforcement"
   mixed$.error <- list(simpleError("HTTP 401"), NULL)
   expect_true(all_required_missing(mixed, schema))
   expect_equal(n_incomplete(mixed, schema), 1L)
+
+  # A response ellmer could extract nothing from is the signal itself: the
+  # endpoint answered, in prose, so these rows are judged and "auto" falls back
+  prose <- data.frame(score = c(NA_real_, NA_real_), lab = c(NA_character_, NA_character_))
+  prose$.error <- list(
+    extraction_error("Data extraction failed: no JSON responses found."),
+    extraction_error("Data extraction failed: no JSON responses found.")
+  )
+  expect_true(all_required_missing(prose, schema))
+  expect_equal(n_incomplete(prose, schema), 0L)
 })
 
 

--- a/tests/testthat/test-qlm_failures.R
+++ b/tests/testthat/test-qlm_failures.R
@@ -201,6 +201,9 @@ test_that("attach_extraction_errors records only rows without an .error, before 
   expect_equal(names(out), c("score", ".error", "input_tokens", "cost"))
   expect_null(out$.error[[1]])
   expect_equal(conditionMessage(out$.error[[2]]), "m2")
+  # Tagged, so the schema-enforcement check can tell it from a request failure
+  expect_s3_class(out$.error[[2]], "quallmer_extraction_error")
+  expect_s3_class(out$.error[[2]], "simpleError")
   expect_equal(conditionMessage(out$.error[[3]]), "m3")
 
   # An .error ellmer already recorded takes precedence


### PR DESCRIPTION
## Summary

A response that hits the provider's `max_tokens` limit no longer comes back from `qlm_code()` as a successful empty result. It is recorded in `.error`, listed by `qlm_failures()`, counted by `print()`, and on the JSON path not retried.

Fixes #153.

## Relationship to #140

Checked before writing this, as suggested. #140 does not subsume it, and neither would land the other for free:

- #140's raw validation would see the Anthropic forced-tool truncation (`claude-sonnet-5`, `claude-opus-5`) as "required property missing", i.e. a schema violation, and could attribute it to a non-enforcing endpoint and fall back to JSON mode, where the same limit cuts the answer again. OpenAI's case arrives as no JSON content at all. Only the finish reason says what happened.
- Both issues share the same blocker the #134 handover already flagged: `parallel_chat_structured()` returns the converted table and discards the turns, and the finish reason, raw JSON and usage all live on the turns. That is an ellmer change; a draft issue is at `dev/ellmer-issue-parallel-finish-reason.md` (untracked, `dev/` is build-ignored), with measurements.

## What ellmer does today (0.4.2, and on `main`)

`AssistantTurn@finish_reason` exists and `chat_structured()` raises `check_finish_reason()` on it. `parallel_chat_structured()` and `batch_chat_structured()` never look at it. Probed with a 60-token cap:

| provider / model | `parallel_chat_structured()` | `chat_structured()` |
|---|---|---|
| anthropic / claude-sonnet-5 (forced tool) | zero-row tibble, no warning, no `.error` | error: truncated at `max_tokens` |
| anthropic / claude-haiku-4-5 (native) | zero-row tibble, ellmer warns "premature EOF", no `.error` | same error |
| openai / gpt-5-mini | zero-row tibble, `output_tokens` = 0, no `.error` | same error |

## Scope

- `R/qlm_code_json.R`: `json_chat_turns()` returns the finish reason; `code_handler_json()` records a cut-off or filtered response under the provider's reason and does not retry a truncation; `all_required_missing()` / `n_incomplete()` skip rows carrying an `.error`.
- `R/qlm_code.R`: `try_structured_call()` asks for token counts when `params(max_tokens = )` was declared and marks rows that spent the whole budget and hold nothing (`mark_truncated_rows()`, `blank_rows()`, `declared_max_tokens()`); token columns the caller did not ask for are removed again. New *Truncated responses* section in `?qlm_code`.
- `R/qlm_failures.R`: shared `errored_rows()`; docs mention truncation as a source of `.error`.

## What is not covered, and why

On the structured path with no declared `max_tokens`, a truncated response is still silent. ellmer supplies the Anthropic default of 4096 inside its request builder, invisible from quallmer, and I chose not to hardcode a copy of it or reach into ellmer internals to rebuild `parallel_chat_structured()` (six internals, one of which has already changed signature on ellmer `main`). The docs say to set `max_tokens` explicitly; the upstream draft is the real fix.

Noticed on the way, pre-existing and out of scope here: `structured = "json"` on Anthropic fails with HTTP 400 (`response_format: Extra inputs are not permitted`), so the `auto` fallback cannot help there either.

## Tests

`devtools::test()`: 1550 passing, 0 failing (rebased onto main after #157 merged) (the two remaining warnings are pre-existing in `test-qlm_compare.R` / `test-qlm_validate.R`). `R CMD check --as-cran`: 0 errors, 0 warnings, 1 NOTE (dev version number).

New tests cover the finish reason on turns, the message helper, terminal handling of a cut-off response and retry of a filtered one on the JSON path, `.error` rows being ignored by the enforcement heuristics, the structured-path marker on scalar, array-only and nested schemas, token-column cleanup, precedence of an ellmer-recorded error, and the `auto` path not re-coding a wholly failed run.

Live, against real endpoints with `params(max_tokens = 60)`:

- structured, `anthropic/claude-sonnet-5`: both units flagged, print reports `2 (0 scored, 2 failed)`, `qlm_failures()` gives the reason, backend stays `structured`.
- JSON, `deepseek/deepseek-chat`: the long unit recorded as cut off after 60 output tokens with a single request (no retries), the short unit coded normally.

## NEWS

Bullet added under *Bug fixes*.
