### PR TITLE
Name the model when the provider does not list it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,9 @@
   with the nearest names it does have, instead of reporting only the
   provider's HTTP error. The provider's model list is fetched through
   ellmer's `models_<provider>()`, only after a run has been rejected in its
-  entirety and once per session; where no listing exists the provider's own
-  error is reported unchanged (#133).
+  entirety and at most once per failed run, and only for providers whose
+  listing covers every name they accept; where it cannot decide, the
+  provider's own error is reported unchanged (#133).
 
 * The `.id` column of a `qlm_coded` object must now be a key: unique and
   never missing. Every later operation merges on `.id`, and `qlm_compare()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Bug fixes
 
+* `qlm_code()` now says when a model name is not one its provider lists,
+  with the nearest names it does have, instead of reporting only the
+  provider's HTTP error. The provider's model list is fetched through
+  ellmer's `models_<provider>()`, only after a run has been rejected in its
+  entirety and once per session; where no listing exists the provider's own
+  error is reported unchanged (#133).
+
 * The `.id` column of a `qlm_coded` object must now be a key: unique and
   never missing. Every later operation merges on `.id`, and `qlm_compare()`
   and `qlm_validate()` silently formed a Cartesian product of repeated

--- a/R/providers.R
+++ b/R/providers.R
@@ -92,3 +92,136 @@ check_model_provider <- function(model, call = rlang::caller_env()) {
     call = call
   )
 }
+
+
+#' Explain a rejected run when the model name is the likely cause
+#'
+#' A model name that does not exist for its provider is the easiest mistake to
+#' make and the worst reported: the first sign is an HTTP 4xx whose message
+#' varies from a list of valid names (DeepSeek) to a bare "HTTP 400 Bad
+#' Request." (#133). Called only once a run has already been rejected in its
+#' entirety, so the happy path costs nothing; it then asks the provider for
+#' its model list, through ellmer's `models_<provider>()`, and says whether
+#' the name is on it.
+#'
+#' A diagnostic, never a gate. Whenever the lookup cannot run -- the provider
+#' publishes no list, ellmer has no `models_*()` for it, no credentials, no
+#' network -- nothing is added and the provider's own error stands unchanged.
+#' Nothing is added either when the name is on the list, since the cause is
+#' then something else.
+#'
+#' @param model The model specification, as passed to [qlm_code()].
+#' @param chat_args The run's arguments to [ellmer::chat()]; `base_url`,
+#'   `api_key` and `credentials` are passed on to the lookup where it takes
+#'   them, so a custom endpoint is asked rather than the provider's default.
+#'
+#' @return A character vector of cli bullets, empty when there is nothing to
+#'   say.
+#' @keywords internal
+#' @noRd
+model_name_hint <- function(model, chat_args = list()) {
+  # "provider" alone means the provider's default model, which exists
+  if (!is.character(model) || length(model) != 1L || is.na(model) ||
+      !grepl("/", model, fixed = TRUE)) {
+    return(character())
+  }
+  provider <- model_provider(model)
+  id <- sub("^[^/]*/", "", model)
+  models <- provider_models(provider, chat_args)
+  if (is.null(models) || id %in% models) {
+    return(character())
+  }
+
+  lines <- cli::format_inline(
+    "{.val {id}} is not a model that {.val {provider}} lists; ",
+    "{.fn ellmer::models_{provider}} gives the {length(models)} it does."
+  )
+  close <- closest_model_names(id, models)
+  if (length(close)) {
+    lines <- c(lines, cli::format_inline("Did you mean {.val {close}}?"))
+  }
+  set_bullets(lines, n = Inf, bullet = "i")
+}
+
+
+#' The model names a provider publishes, or `NULL`
+#'
+#' Asks ellmer's `models_<provider>()`, a credentialed network call, so the
+#' answer is memoised for the session in a package-local environment, keyed
+#' by provider and `base_url`. Negative results are cached too: a run that
+#' fails on every unit must not re-probe the provider each time it reports.
+#' Populated on first use, never at load, so `library(quallmer)` touches no
+#' network and no credential.
+#'
+#' @param provider The provider prefix.
+#' @param chat_args The run's arguments to [ellmer::chat()].
+#'
+#' @return A character vector of model ids, or `NULL` when the provider has no
+#'   `models_*()` in ellmer or the lookup failed.
+#' @keywords internal
+#' @noRd
+provider_models <- function(provider, chat_args = list()) {
+  key <- paste(provider, chat_args$base_url %||% "", sep = "\n")
+  if (exists(key, envir = model_list_cache, inherits = FALSE)) {
+    return(get(key, envir = model_list_cache, inherits = FALSE))
+  }
+  lister <- models_lister(provider)
+  models <- NULL
+  if (!is.null(lister)) {
+    args <- chat_args[intersect(names(chat_args), names(formals(lister)))]
+    models <- tryCatch(
+      {
+        listing <- suppressMessages(suppressWarnings(do.call(lister, args)))
+        ids <- listing$id
+        if (is.character(ids) && length(ids)) ids else NULL
+      },
+      error = function(e) NULL
+    )
+  }
+  assign(key, models, envir = model_list_cache)
+  models
+}
+
+model_list_cache <- new.env(parent = emptyenv())
+
+
+#' ellmer's model-listing function for a provider, or `NULL`
+#'
+#' Looked up in ellmer's exports at run time, as `ellmer::chat()` looks up
+#' `chat_<provider>()`, so a listing ellmer adds later is used without a
+#' change here. Fifteen of ellmer's providers have one; the rest are
+#' bring-your-own-endpoint providers for which a list would be meaningless.
+#'
+#' @param provider The provider prefix.
+#'
+#' @return A function, or `NULL`.
+#' @keywords internal
+#' @noRd
+models_lister <- function(provider) {
+  fn <- paste0("models_", provider)
+  if (!fn %in% getNamespaceExports("ellmer")) {
+    return(NULL)
+  }
+  get(fn, envir = asNamespace("ellmer"))
+}
+
+
+#' The published model names nearest a mistyped one
+#'
+#' Edit distance, case-insensitive, keeping only names within half the length
+#' of the one typed (and never fewer than two edits), so that a name unlike
+#' anything on the list gets no suggestion rather than a misleading one.
+#'
+#' @param id The model name as typed.
+#' @param models The provider's model names.
+#' @param n At most this many suggestions.
+#'
+#' @return A character vector, possibly empty, nearest first.
+#' @keywords internal
+#' @noRd
+closest_model_names <- function(id, models, n = 3L) {
+  d <- utils::adist(tolower(id), tolower(models))[1, ]
+  near <- d <= max(2, ceiling(nchar(id) / 2))
+  candidates <- models[near][order(d[near])]
+  utils::head(unique(candidates), n)
+}

--- a/R/providers.R
+++ b/R/providers.R
@@ -108,7 +108,9 @@ check_model_provider <- function(model, call = rlang::caller_env()) {
 #' publishes no list, ellmer has no `models_*()` for it, no credentials, no
 #' network -- nothing is added and the provider's own error stands unchanged.
 #' Nothing is added either when the name is on the list, since the cause is
-#' then something else.
+#' then something else, or when the provider's listing is known not to cover
+#' every identifier it will invoke, since absence from it then proves
+#' nothing; see `listing_is_complete()`.
 #'
 #' @param model The model specification, as passed to [qlm_code()].
 #' @param chat_args The run's arguments to [ellmer::chat()]; `base_url`,
@@ -127,6 +129,9 @@ model_name_hint <- function(model, chat_args = list()) {
   }
   provider <- model_provider(model)
   id <- sub("^[^/]*/", "", model)
+  if (!listing_is_complete(provider, id)) {
+    return(character())
+  }
   models <- provider_models(provider, chat_args)
   if (is.null(models) || id %in% models) {
     return(character())
@@ -144,45 +149,77 @@ model_name_hint <- function(model, chat_args = list()) {
 }
 
 
-#' The model names a provider publishes, or `NULL`
+#' Does a provider's model listing cover every identifier it will invoke?
 #'
-#' Asks ellmer's `models_<provider>()`, a credentialed network call, so the
-#' answer is memoised for the session in a package-local environment, keyed
-#' by provider and `base_url`. Negative results are cached too: a run that
-#' fails on every unit must not re-probe the provider each time it reports.
-#' Populated on first use, never at load, so `library(quallmer)` touches no
-#' network and no credential.
+#' Absence from a listing proves a name wrong only where the listing is
+#' complete, and for some providers it is not. AWS Bedrock's
+#' `ListFoundationModels` returns foundation models only, while invocation
+#' also accepts cross-region inference profiles (`us.anthropic...`),
+#' provisioned, custom and imported models, and ARNs; Google Vertex likewise
+#' serves tuned endpoints its publisher list does not name; Portkey and Posit
+#' are gateways whose catalogue is not what they will route. Gemini lists
+#' its models but not the caller's tuned ones, which live under
+#' `tunedModels/`. For all of these a mistyped name gets no diagnosis rather
+#' than a false one, which would also stop the JSON-mode fallback that might
+#' have succeeded.
+#'
+#' An allowlist rather than a denylist, so that a provider ellmer adds later
+#' loses only the hint until it is checked, never gains a false claim.
 #'
 #' @param provider The provider prefix.
-#' @param chat_args The run's arguments to [ellmer::chat()].
+#' @param id The model name as typed, without the prefix.
+#'
+#' @return `TRUE` when a name absent from the listing can be called wrong.
+#' @keywords internal
+#' @noRd
+listing_is_complete <- function(provider, id) {
+  if (!provider %in% complete_listings) {
+    return(FALSE)
+  }
+  !(provider == "google_gemini" && startsWith(id, "tunedModels/"))
+}
+
+# Providers whose models_*() enumerates every identifier the endpoint will
+# invoke, checked 2026-09-03 against ellmer 0.4.2.
+complete_listings <- c(
+  "anthropic", "claude", "deepseek", "github", "google_gemini", "groq",
+  "lmstudio", "mistral", "ollama", "openai", "vllm"
+)
+
+
+#' The model names a provider publishes, or `NULL`
+#'
+#' Asks ellmer's `models_<provider>()`, a credentialed network call whose
+#' answer depends on the account asking: fine-tuned and gated models differ
+#' by key, by project and by region. So it is asked afresh each time and
+#' never cached across runs, where a stale or foreign answer could pin a
+#' wrong diagnosis to a repaired credential. It is asked at most once per
+#' failed run, which is the only time it is asked at all.
+#'
+#' @param provider The provider prefix.
+#' @param chat_args The run's arguments to [ellmer::chat()]; those the lister
+#'   takes (`base_url`, `api_key`, `credentials`, and for some providers
+#'   `profile`, `project_id` or `location`) are passed on.
 #'
 #' @return A character vector of model ids, or `NULL` when the provider has no
 #'   `models_*()` in ellmer or the lookup failed.
 #' @keywords internal
 #' @noRd
 provider_models <- function(provider, chat_args = list()) {
-  key <- paste(provider, chat_args$base_url %||% "", sep = "\n")
-  if (exists(key, envir = model_list_cache, inherits = FALSE)) {
-    return(get(key, envir = model_list_cache, inherits = FALSE))
-  }
   lister <- models_lister(provider)
-  models <- NULL
-  if (!is.null(lister)) {
-    args <- chat_args[intersect(names(chat_args), names(formals(lister)))]
-    models <- tryCatch(
-      {
-        listing <- suppressMessages(suppressWarnings(do.call(lister, args)))
-        ids <- listing$id
-        if (is.character(ids) && length(ids)) ids else NULL
-      },
-      error = function(e) NULL
-    )
+  if (is.null(lister)) {
+    return(NULL)
   }
-  assign(key, models, envir = model_list_cache)
-  models
+  args <- chat_args[intersect(names(chat_args), names(formals(lister)))]
+  tryCatch(
+    {
+      listing <- suppressMessages(suppressWarnings(do.call(lister, args)))
+      ids <- listing$id
+      if (is.character(ids) && length(ids)) ids else NULL
+    },
+    error = function(e) NULL
+  )
 }
-
-model_list_cache <- new.env(parent = emptyenv())
 
 
 #' ellmer's model-listing function for a provider, or `NULL`

--- a/R/providers.R
+++ b/R/providers.R
@@ -110,7 +110,8 @@ check_model_provider <- function(model, call = rlang::caller_env()) {
 #' Nothing is added either when the name is on the list, since the cause is
 #' then something else, or when the provider's listing is known not to cover
 #' every identifier it will invoke, since absence from it then proves
-#' nothing; see `listing_is_complete()`.
+#' nothing; see `listing_is_complete()`. Nor when the name begins a listed
+#' one, since that is the shape of an alias; see `may_be_alias()`.
 #'
 #' @param model The model specification, as passed to [qlm_code()].
 #' @param chat_args The run's arguments to [ellmer::chat()]; `base_url`,
@@ -133,7 +134,7 @@ model_name_hint <- function(model, chat_args = list()) {
     return(character())
   }
   models <- provider_models(provider, chat_args)
-  if (is.null(models) || id %in% models) {
+  if (is.null(models) || id %in% models || may_be_alias(id, models)) {
     return(character())
   }
 
@@ -146,6 +147,30 @@ model_name_hint <- function(model, chat_args = list()) {
     lines <- c(lines, cli::format_inline("Did you mean {.val {close}}?"))
   }
   set_bullets(lines, n = Inf, bullet = "i")
+}
+
+
+#' Could a name absent from the listing be an alias of a listed one?
+#'
+#' Providers accept convenience aliases their listings do not carry.
+#' Anthropic's listing gives the dated identifier, `claude-haiku-4-5-20251001`,
+#' while the API also takes `claude-haiku-4-5`, and once took `-latest`
+#' forms; every alias documented is the listed name with a suffix removed.
+#' So a name that begins a listed one is left alone rather than called
+#' wrong: the cost of silence is a lost hint for a truncated typo, the cost
+#' of a false claim is a valid model made unusable on the structured path,
+#' since the claim also stops the JSON-mode fallback. Applied to every
+#' provider, since the rule is about the shape of aliases, not one API.
+#'
+#' @param id The model name as typed, without the prefix.
+#' @param models The provider's listed names.
+#'
+#' @return `TRUE` when some listed name starts with `id`.
+#' @keywords internal
+#' @noRd
+may_be_alias <- function(id, models) {
+  stem <- sub("-latest$", "", id)
+  nzchar(stem) && any(startsWith(models, stem))
 }
 
 
@@ -248,6 +273,10 @@ models_lister <- function(provider) {
 #' Edit distance, case-insensitive, keeping only names within half the length
 #' of the one typed (and never fewer than two edits), so that a name unlike
 #' anything on the list gets no suggestion rather than a misleading one.
+#' Each listed name is also compared as its alias, without a trailing date,
+#' since that is the form people type: against a dated listing,
+#' `claude-haiku-4-6` is one edit from `claude-haiku-4-5`, not ten from
+#' `claude-haiku-4-5-20251001`. The listed name is what is suggested.
 #'
 #' @param id The model name as typed.
 #' @param models The provider's model names.
@@ -257,7 +286,11 @@ models_lister <- function(provider) {
 #' @keywords internal
 #' @noRd
 closest_model_names <- function(id, models, n = 3L) {
-  d <- utils::adist(tolower(id), tolower(models))[1, ]
+  stems <- sub("-[0-9]{8}$", "", models)
+  d <- pmin(
+    utils::adist(tolower(id), tolower(models))[1, ],
+    utils::adist(tolower(id), tolower(stems))[1, ]
+  )
   near <- d <= max(2, ceiling(nchar(id) / 2))
   candidates <- models[near][order(d[near])]
   utils::head(unique(candidates), n)

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -154,6 +154,18 @@
 #' `batch = TRUE`. The path actually taken is recorded in the run metadata as
 #' `backend`.
 #'
+#' @section Rejected runs:
+#' When the provider rejects every request with a status that will not change
+#' on retry (400, 401, 403, 404 or 422), `qlm_code()` stops rather than
+#' returning a table of `NA`s. The most common cause is a model name the
+#' provider does not have, and providers rarely say so; many answer with a
+#' bare "HTTP 400 Bad Request". So before reporting, `qlm_code()` asks the
+#' provider for its model list, through ellmer's `models_<provider>()`, and
+#' says when the name is not on it, with the nearest names it does have. The
+#' lookup runs only after a run has failed, once per session and provider,
+#' and only where ellmer has a listing function; where it cannot run, or the
+#' name is on the list, the provider's own error is reported unchanged.
+#'
 #' @section Truncated responses:
 #'
 #' A response that runs into the provider's output limit (`max_tokens`) is cut
@@ -350,6 +362,18 @@ qlm_code <- function(x, codebook, model, ...,
         "i" = "Coding {.val {model}} in JSON mode with local validation.",
         "i" = attempt$error,
         "i" = "Use {.code structured = \"structured\"} to rely on the provider instead."
+      ))
+    } else if (isTRUE(attempt$rejected) &&
+               length(hint <- model_name_hint(model, chat_args))) {
+      # The provider refused every request, and confirms it has no such
+      # model. Falling back to JSON mode would only send the same name again,
+      # so stop here. A refusal the provider does not explain that way may
+      # be its answer to the schema-constrained request itself, which JSON
+      # mode is the cure for, so that case falls through as before.
+      cli::cli_abort(c(
+        "Every request to model {.val {model}} was rejected by the provider.",
+        set_bullets(attempt$error),
+        hint
       ))
     } else if (identical(structured, "structured")) {
       cli::cli_abort(c(
@@ -548,9 +572,15 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
     }
   }
 
+  # `rejected` records whether the provider refused the run with a status
+  # that will not change on retry, so qlm_code() can ask about the model
+  # name when it reports; the message alone rarely says.
   attempt <- tryCatch(
     list(ok = TRUE, value = run(chat)),
-    error = function(e) list(ok = FALSE, error = strip_ansi(conditionMessage(e)))
+    error = function(e) list(
+      ok = FALSE, error = strip_ansi(conditionMessage(e)),
+      rejected = is_fatal_status(api_error_status(e))
+    )
   )
 
   # Alibaba Model Studio refuses `response_format` unless the word "json"
@@ -570,13 +600,30 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
     )
     attempt <- tryCatch(
       list(ok = TRUE, value = run(build_chat(retry_prompt))),
-      error = function(e) list(ok = FALSE, error = strip_ansi(conditionMessage(e)))
+      error = function(e) list(
+        ok = FALSE, error = strip_ansi(conditionMessage(e)),
+        rejected = is_fatal_status(api_error_status(e))
+      )
     )
   }
 
   if (isTRUE(attempt$ok)) {
     attempt$value <- mark_truncated_rows(
       attempt$value, codebook$schema, cap, keep_tokens = keep_tokens
+    )
+  }
+
+  # Every request refused with a status that will not change on retry is
+  # misconfiguration, most often a model name the provider does not have.
+  # Returned as a failed attempt, with the reasons, so that qlm_code() can ask
+  # the provider about the name rather than hand back a table of NAs.
+  if (isTRUE(attempt$ok) && all_rejected(attempt$value)) {
+    attempt <- list(
+      ok = FALSE,
+      rejected = TRUE,
+      error = unique(failure_reasons(
+        recorded_errors(attempt$value), errored_rows(attempt$value)
+      ))
     )
   }
 
@@ -1164,3 +1211,29 @@ print.qlm_coded <- function(x, ...) {
   NextMethod()
 }
 
+
+
+#' Did the provider reject every row of a structured result?
+#'
+#' On the structured path a rejected request arrives as a row whose `.error`
+#' is the HTTP condition, with every field `NA`. A run rejected in its
+#' entirety is misconfiguration, not a schema problem, and should be reported
+#' as such.
+#'
+#' @param results What the structured call returned.
+#'
+#' @return `TRUE` when every row carries an error with a status that will not
+#'   change on retry.
+#' @keywords internal
+#' @noRd
+all_rejected <- function(results) {
+  errors <- recorded_errors(results)
+  if (!length(errors)) {
+    return(FALSE)
+  }
+  all(vapply(
+    errors,
+    function(e) !is.null(e) && is_fatal_status(api_error_status(e)),
+    logical(1)
+  ))
+}

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -162,9 +162,11 @@
 #' bare "HTTP 400 Bad Request". So before reporting, `qlm_code()` asks the
 #' provider for its model list, through ellmer's `models_<provider>()`, and
 #' says when the name is not on it, with the nearest names it does have. The
-#' lookup runs only after a run has failed, once per session and provider,
-#' and only where ellmer has a listing function; where it cannot run, or the
-#' name is on the list, the provider's own error is reported unchanged.
+#' lookup runs only after a run has failed, once per failed run, and only for
+#' providers whose listing is known to cover every name they will invoke
+#' (Bedrock, for one, invokes inference profiles its listing omits). Where
+#' it cannot run, or the name is on the list, the provider's own error is
+#' reported unchanged.
 #'
 #' @section Truncated responses:
 #'
@@ -335,6 +337,7 @@ qlm_code <- function(x, codebook, model, ...,
   backend_meta <- list()
   results <- NULL
   fallback_reason <- NULL
+  model_hint <- NULL
 
   # ---- schema-constrained structured output -------------------------------
   if (structured %in% c("auto", "structured")) {
@@ -364,16 +367,17 @@ qlm_code <- function(x, codebook, model, ...,
         "i" = "Use {.code structured = \"structured\"} to rely on the provider instead."
       ))
     } else if (isTRUE(attempt$rejected) &&
-               length(hint <- model_name_hint(model, chat_args))) {
+               length(model_hint <- model_name_hint(model, chat_args))) {
       # The provider refused every request, and confirms it has no such
       # model. Falling back to JSON mode would only send the same name again,
       # so stop here. A refusal the provider does not explain that way may
       # be its answer to the schema-constrained request itself, which JSON
-      # mode is the cure for, so that case falls through as before.
+      # mode is the cure for, so that case falls through as before, carrying
+      # the (empty) answer so the JSON path does not ask again.
       cli::cli_abort(c(
         "Every request to model {.val {model}} was rejected by the provider.",
         set_bullets(attempt$error),
-        hint
+        model_hint
       ))
     } else if (identical(structured, "structured")) {
       cli::cli_abort(c(
@@ -409,7 +413,8 @@ qlm_code <- function(x, codebook, model, ...,
       chat_args = chat_args,
       execution_args = execution_args,
       batch = batch,
-      max_retries = max_retries
+      max_retries = max_retries,
+      model_hint = model_hint
     )
     backend_meta <- attr(results, "qlm_backend_meta") %||% list()
     attr(results, "qlm_backend_meta") <- NULL

--- a/R/qlm_code_json.R
+++ b/R/qlm_code_json.R
@@ -206,10 +206,16 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
   # Nothing was coded and the provider rejected every request outright: the run
   # is misconfigured, so say so rather than handing back a tibble of NAs.
   if (all(failed) && all(fatal)) {
+    # A wrong model name is the usual cause and the worst reported, so ask the
+    # provider whether the name exists before telling the user to check it.
+    hint <- model_name_hint(model, chat_args)
+    if (!length(hint)) {
+      hint <- c("i" = "Check the model name, your credentials, and any {.arg base_url}.")
+    }
     cli::cli_abort(c(
       "Every request to model {.val {model}} was rejected by the provider.",
       set_bullets(unique(unlist(problems))),
-      "i" = "Check the model name, your credentials, and any {.arg base_url}."
+      hint
     ), call = error_call)
   }
 
@@ -726,11 +732,13 @@ is_fatal_status <- function(status) {
 #' interpolated. Doubling them makes cli emit them literally.
 #'
 #' @param x A character vector of messages.
+#' @param n Keep at most this many, noting how many were dropped.
+#' @param bullet The cli bullet to name them with, `"x"` by default.
 #'
-#' @return A character vector named `"x"`, truncated to the first three.
+#' @return A character vector named `bullet`, truncated to the first `n`.
 #' @keywords internal
 #' @noRd
-set_bullets <- function(x, n = 3L) {
+set_bullets <- function(x, n = 3L, bullet = "x") {
   x <- x[!is.na(x) & nzchar(x)]
   if (!length(x)) {
     return(character())
@@ -739,7 +747,7 @@ set_bullets <- function(x, n = 3L) {
     x <- c(x[seq_len(n)], paste0("... and ", length(x) - n, " other reason(s)"))
   }
   x <- gsub("}", "}}", gsub("{", "{{", x, fixed = TRUE), fixed = TRUE)
-  stats::setNames(x, rep("x", length(x)))
+  stats::setNames(x, rep(bullet, length(x)))
 }
 
 

--- a/R/qlm_code_json.R
+++ b/R/qlm_code_json.R
@@ -22,6 +22,9 @@
 #' @param batch Logical. Must be `FALSE`; JSON-mode coding has no batch path.
 #' @param max_retries Number of repair attempts for each empty, unparsable, or
 #'   schema-invalid response. Default is 2.
+#' @param model_hint What `model_name_hint()` answered when [qlm_code()]
+#'   already asked it for this run, so a wholly rejected run asks the provider
+#'   at most once; `NULL` when it has not been asked.
 #'
 #' @return A data frame with one row per unit, carrying `.error` for units that
 #'   never validated, plus token and cost columns when requested. Handler
@@ -29,7 +32,8 @@
 #' @keywords internal
 #' @noRd
 code_handler_json <- function(x, codebook, model, chat_args, execution_args,
-                              batch = FALSE, max_retries = 2L) {
+                              batch = FALSE, max_retries = 2L,
+                              model_hint = NULL) {
   # The handler is reached via do.call(), so report guard failures against
   # qlm_code() rather than against an anonymous function.
   error_call <- rlang::caller_env()
@@ -208,7 +212,7 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
   if (all(failed) && all(fatal)) {
     # A wrong model name is the usual cause and the worst reported, so ask the
     # provider whether the name exists before telling the user to check it.
-    hint <- model_name_hint(model, chat_args)
+    hint <- if (is.null(model_hint)) model_name_hint(model, chat_args) else model_hint
     if (!length(hint)) {
       hint <- c("i" = "Check the model name, your credentials, and any {.arg base_url}.")
     }

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -193,6 +193,20 @@ are not supported there, so \code{"auto"} will not fall back under
 \code{backend}.
 }
 
+\section{Rejected runs}{
+
+When the provider rejects every request with a status that will not change
+on retry (400, 401, 403, 404 or 422), \code{qlm_code()} stops rather than
+returning a table of \code{NA}s. The most common cause is a model name the
+provider does not have, and providers rarely say so; many answer with a
+bare "HTTP 400 Bad Request". So before reporting, \code{qlm_code()} asks the
+provider for its model list, through ellmer's \verb{models_<provider>()}, and
+says when the name is not on it, with the nearest names it does have. The
+lookup runs only after a run has failed, once per session and provider,
+and only where ellmer has a listing function; where it cannot run, or the
+name is on the list, the provider's own error is reported unchanged.
+}
+
 \section{Truncated responses}{
 
 

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -202,9 +202,11 @@ provider does not have, and providers rarely say so; many answer with a
 bare "HTTP 400 Bad Request". So before reporting, \code{qlm_code()} asks the
 provider for its model list, through ellmer's \verb{models_<provider>()}, and
 says when the name is not on it, with the nearest names it does have. The
-lookup runs only after a run has failed, once per session and provider,
-and only where ellmer has a listing function; where it cannot run, or the
-name is on the list, the provider's own error is reported unchanged.
+lookup runs only after a run has failed, once per failed run, and only for
+providers whose listing is known to cover every name they will invoke
+(Bedrock, for one, invokes inference profiles its listing omits). Where
+it cannot run, or the name is on the list, the provider's own error is
+reported unchanged.
 }
 
 \section{Truncated responses}{

--- a/tests/testthat/test-providers.R
+++ b/tests/testthat/test-providers.R
@@ -225,6 +225,9 @@ test_that("closest_model_names() suggests near misses and nothing for the rest",
   models <- c("gpt-4o-mini", "gpt-4o", "gpt-4.1", "o3-mini", "text-embedding-3-small")
   expect_equal(closest_model_names("gpt-4o-mimi", models)[1], "gpt-4o-mini")
   expect_equal(closest_model_names("GPT-4O", models)[1], "gpt-4o")
+  # Compared as the alias people type, suggesting the listed name
+  dated <- c("claude-haiku-4-5-20251001", "claude-sonnet-4-5-20250929")
+  expect_equal(closest_model_names("claude-haiku-4-6", dated)[1], "claude-haiku-4-5-20251001")
   expect_length(closest_model_names("gpt-4o-mimi", models, n = 1L), 1)
   expect_length(closest_model_names("llama-3.3-70b-versatile", models), 0)
 })
@@ -236,15 +239,17 @@ test_that("model_name_hint() speaks only when the provider has no such model", {
   })
   mockery::stub(f, "listing_is_complete", function(provider, id) provider == "acme")
 
-  hint <- f("acme/m-larg")
+  hint <- f("acme/m-lrage")
   expect_named(hint, c("i", "i"))
-  expect_match(hint[[1]], "\"m-larg\" is not a model that \"acme\" lists")
+  expect_match(hint[[1]], "\"m-lrage\" is not a model that \"acme\" lists")
   expect_match(hint[[1]], "ellmer::models_acme\\(\\)")
   expect_match(hint[[2]], "Did you mean \"m-large\"")
 
   # A name unlike anything on the list gets the list pointer but no guess
   hint <- f("acme/completely-different")
   expect_length(hint, 1)
+  # A name that begins a listed one may be an alias, so it gets no claim
+  expect_length(f("acme/m-larg"), 0)
 
   # Listed: the cause is something else, so nothing is added
   expect_length(f("acme/m-large"), 0)
@@ -253,6 +258,34 @@ test_that("model_name_hint() speaks only when the provider has no such model", {
   # A bare provider means its default model, which exists
   expect_length(f("acme"), 0)
   expect_length(f(NA_character_), 0)
+})
+
+test_that("may_be_alias() treats a name that begins a listed one as possibly valid", {
+  listed <- c("claude-haiku-4-5-20251001", "claude-sonnet-4-5-20250929", "claude-opus-5")
+  expect_true(may_be_alias("claude-haiku-4-5", listed))
+  expect_true(may_be_alias("claude-sonnet-4-5-latest", listed))
+  expect_true(may_be_alias("claude-opus-5", listed))
+  expect_false(may_be_alias("claude-haiku-4-6", listed))
+  expect_false(may_be_alias("claude-haiku-4-5-20251002", listed))
+  expect_false(may_be_alias("", listed))
+  expect_false(may_be_alias("-latest", listed))
+})
+
+test_that("model_name_hint() leaves an Anthropic alias alone against a canonical-only listing", {
+  # Anthropic lists dated identifiers; the API also accepts the undated
+  # alias, which a listing-only check would have called wrong and, worse,
+  # used to stop the JSON-mode fallback
+  f <- model_name_hint
+  mockery::stub(f, "provider_models", function(provider, chat_args) {
+    c("claude-opus-4-5-20251101", "claude-haiku-4-5-20251001", "claude-sonnet-4-5-20250929")
+  })
+  expect_length(f("anthropic/claude-haiku-4-5"), 0)
+  expect_length(f("claude/claude-sonnet-4-5"), 0)
+  expect_length(f("anthropic/claude-sonnet-4-5-latest"), 0)
+  # A name that begins nothing listed is still a typo, with the nearest names
+  hint <- f("anthropic/claude-haiku-4-6")
+  expect_match(hint[[1]], "\"claude-haiku-4-6\" is not a model")
+  expect_match(hint[[2]], "claude-haiku-4-5-20251001")
 })
 
 test_that("model_name_hint() makes no claim where the listing is not exhaustive (Bedrock)", {

--- a/tests/testthat/test-providers.R
+++ b/tests/testthat/test-providers.R
@@ -141,3 +141,99 @@ test_that("qlm_code() still reports a malformed model before looking at the prov
     "must be a single string"
   )
 })
+
+
+# Model-name diagnosis (#133) --------------------------------------------------
+
+clear_model_list_cache <- function() {
+  rm(list = ls(model_list_cache), envir = model_list_cache)
+}
+
+test_that("models_lister() finds ellmer's listing function, or nothing", {
+  expect_identical(models_lister("openai"), ellmer::models_openai)
+  expect_identical(models_lister("deepseek"), ellmer::models_deepseek)
+  # Bring-your-own-endpoint providers publish no list
+  expect_null(models_lister("openai_compatible"))
+  expect_null(models_lister("not_a_provider"))
+})
+
+test_that("provider_models() asks once per provider and endpoint, negatives included", {
+  clear_model_list_cache()
+  on.exit(clear_model_list_cache())
+  calls <- new.env()
+  lister <- function(base_url = "https://api.example", api_key = NULL, credentials = NULL) {
+    calls$n <- (calls$n %||% 0L) + 1L
+    calls$base_url <- base_url
+    if (grepl("down", base_url)) stop("HTTP 503 Service Unavailable.")
+    data.frame(id = c("m-large", "m-small"), created_at = Sys.Date())
+  }
+  f <- provider_models
+  mockery::stub(f, "models_lister", function(provider) if (provider == "acme") lister else NULL)
+
+  expect_equal(f("acme"), c("m-large", "m-small"))
+  expect_equal(f("acme"), c("m-large", "m-small"))
+  expect_equal(calls$n, 1)
+
+  # Only the arguments the lister takes travel, and a custom endpoint is a
+  # different cache entry
+  expect_equal(
+    f("acme", chat_args = list(base_url = "https://eu.example", params = list(), api_args = list())),
+    c("m-large", "m-small")
+  )
+  expect_equal(calls$n, 2)
+  expect_equal(calls$base_url, "https://eu.example")
+
+  # A failed lookup is NULL, and is not re-tried on the next report
+  expect_null(f("acme", chat_args = list(base_url = "https://down.example")))
+  expect_null(f("acme", chat_args = list(base_url = "https://down.example")))
+  expect_equal(calls$n, 3)
+
+  # No lister, no lookup
+  expect_null(f("openai_compatible"))
+})
+
+test_that("closest_model_names() suggests near misses and nothing for the rest", {
+  models <- c("gpt-4o-mini", "gpt-4o", "gpt-4.1", "o3-mini", "text-embedding-3-small")
+  expect_equal(closest_model_names("gpt-4o-mimi", models)[1], "gpt-4o-mini")
+  expect_equal(closest_model_names("GPT-4O", models)[1], "gpt-4o")
+  expect_length(closest_model_names("gpt-4o-mimi", models, n = 1L), 1)
+  expect_length(closest_model_names("llama-3.3-70b-versatile", models), 0)
+})
+
+test_that("model_name_hint() speaks only when the provider has no such model", {
+  clear_model_list_cache()
+  on.exit(clear_model_list_cache())
+  f <- model_name_hint
+  mockery::stub(f, "provider_models", function(provider, chat_args) {
+    if (provider == "acme") c("m-large", "m-small") else NULL
+  })
+
+  hint <- f("acme/m-larg")
+  expect_named(hint, c("i", "i"))
+  expect_match(hint[[1]], "\"m-larg\" is not a model that \"acme\" lists")
+  expect_match(hint[[1]], "ellmer::models_acme\\(\\)")
+  expect_match(hint[[2]], "Did you mean \"m-large\"")
+
+  # A name unlike anything on the list gets the list pointer but no guess
+  hint <- f("acme/completely-different")
+  expect_length(hint, 1)
+
+  # Listed: the cause is something else, so nothing is added
+  expect_length(f("acme/m-large"), 0)
+  # No list to consult: nothing is claimed either way
+  expect_length(f("openai_compatible/m-large"), 0)
+  # A bare provider means its default model, which exists
+  expect_length(f("acme"), 0)
+  expect_length(f(NA_character_), 0)
+})
+
+test_that("a diagnosis never reaches the network in tests", {
+  # The lookups above are all stubbed; the real lister must fail closed when
+  # it cannot run, returning nothing rather than raising
+  clear_model_list_cache()
+  on.exit(clear_model_list_cache())
+  withr::local_envvar(OPENAI_API_KEY = NA)
+  f <- provider_models
+  mockery::stub(f, "models_lister", function(provider) function(...) stop("no key"))
+  expect_null(f("openai"))
+})

--- a/tests/testthat/test-providers.R
+++ b/tests/testthat/test-providers.R
@@ -145,10 +145,6 @@ test_that("qlm_code() still reports a malformed model before looking at the prov
 
 # Model-name diagnosis (#133) --------------------------------------------------
 
-clear_model_list_cache <- function() {
-  rm(list = ls(model_list_cache), envir = model_list_cache)
-}
-
 test_that("models_lister() finds ellmer's listing function, or nothing", {
   expect_identical(models_lister("openai"), ellmer::models_openai)
   expect_identical(models_lister("deepseek"), ellmer::models_deepseek)
@@ -157,39 +153,72 @@ test_that("models_lister() finds ellmer's listing function, or nothing", {
   expect_null(models_lister("not_a_provider"))
 })
 
-test_that("provider_models() asks once per provider and endpoint, negatives included", {
-  clear_model_list_cache()
-  on.exit(clear_model_list_cache())
+test_that("provider_models() asks afresh each time, with the run's own credentials", {
   calls <- new.env()
   lister <- function(base_url = "https://api.example", api_key = NULL, credentials = NULL) {
     calls$n <- (calls$n %||% 0L) + 1L
     calls$base_url <- base_url
     if (grepl("down", base_url)) stop("HTTP 503 Service Unavailable.")
-    data.frame(id = c("m-large", "m-small"), created_at = Sys.Date())
+    data.frame(id = paste0("model-for-", api_key %||% "default"), created_at = Sys.Date())
   }
   f <- provider_models
   mockery::stub(f, "models_lister", function(provider) if (provider == "acme") lister else NULL)
 
-  expect_equal(f("acme"), c("m-large", "m-small"))
-  expect_equal(f("acme"), c("m-large", "m-small"))
-  expect_equal(calls$n, 1)
+  # The answer depends on who asks, so nothing is remembered between calls
+  expect_equal(f("acme", list(api_key = "account-A")), "model-for-account-A")
+  expect_equal(f("acme", list(api_key = "account-B")), "model-for-account-B")
+  expect_equal(calls$n, 2)
 
-  # Only the arguments the lister takes travel, and a custom endpoint is a
-  # different cache entry
+  # Only the arguments the lister takes travel
   expect_equal(
     f("acme", chat_args = list(base_url = "https://eu.example", params = list(), api_args = list())),
-    c("m-large", "m-small")
+    "model-for-default"
   )
-  expect_equal(calls$n, 2)
   expect_equal(calls$base_url, "https://eu.example")
 
-  # A failed lookup is NULL, and is not re-tried on the next report
+  # A failed lookup is NULL, and a later call after the cause is repaired asks again
   expect_null(f("acme", chat_args = list(base_url = "https://down.example")))
-  expect_null(f("acme", chat_args = list(base_url = "https://down.example")))
-  expect_equal(calls$n, 3)
+  expect_equal(f("acme"), "model-for-default")
 
   # No lister, no lookup
   expect_null(f("openai_compatible"))
+  expect_equal(calls$n, 5)
+})
+
+test_that("provider_models() passes project, location and profile where the lister takes them", {
+  seen <- NULL
+  f <- provider_models
+  mockery::stub(f, "models_lister", function(provider) {
+    switch(provider,
+      google_vertex = function(location = NULL, project_id = NULL, credentials = NULL) {
+        seen <<- list(location = location, project_id = project_id)
+        data.frame(id = "gemini-x")
+      },
+      aws_bedrock = function(profile = NULL, base_url = NULL) {
+        seen <<- list(profile = profile)
+        data.frame(id = "anthropic.claude-x")
+      }
+    )
+  })
+  f("google_vertex", list(location = "europe-west1", project_id = "p-1", api_key = "unused"))
+  expect_equal(seen, list(location = "europe-west1", project_id = "p-1"))
+  f("aws_bedrock", list(profile = "research"))
+  expect_equal(seen, list(profile = "research"))
+})
+
+test_that("listing_is_complete() trusts absence only where the listing is exhaustive", {
+  expect_true(listing_is_complete("openai", "gpt-4o-mimi"))
+  expect_true(listing_is_complete("anthropic", "claude-sonnet-4"))
+  expect_true(listing_is_complete("google_gemini", "gemini-2.5-pro"))
+  # Bedrock invokes inference profiles, ARNs and custom models its listing omits
+  expect_false(listing_is_complete("aws_bedrock", "us.anthropic.claude-3-5-sonnet-20241022-v2:0"))
+  expect_false(listing_is_complete("aws_bedrock", "anthropic.claude-3-5-sonnet-20241022-v2:0"))
+  # Tuned Gemini models live outside the listing
+  expect_false(listing_is_complete("google_gemini", "tunedModels/my-classifier"))
+  expect_false(listing_is_complete("google_vertex", "gemini-2.5-pro"))
+  expect_false(listing_is_complete("portkey", "gpt-4o"))
+  # A provider not yet checked gets no claim rather than a false one
+  expect_false(listing_is_complete("some_new_provider", "m"))
 })
 
 test_that("closest_model_names() suggests near misses and nothing for the rest", {
@@ -201,12 +230,11 @@ test_that("closest_model_names() suggests near misses and nothing for the rest",
 })
 
 test_that("model_name_hint() speaks only when the provider has no such model", {
-  clear_model_list_cache()
-  on.exit(clear_model_list_cache())
   f <- model_name_hint
   mockery::stub(f, "provider_models", function(provider, chat_args) {
     if (provider == "acme") c("m-large", "m-small") else NULL
   })
+  mockery::stub(f, "listing_is_complete", function(provider, id) provider == "acme")
 
   hint <- f("acme/m-larg")
   expect_named(hint, c("i", "i"))
@@ -227,11 +255,22 @@ test_that("model_name_hint() speaks only when the provider has no such model", {
   expect_length(f(NA_character_), 0)
 })
 
+test_that("model_name_hint() makes no claim where the listing is not exhaustive (Bedrock)", {
+  f <- model_name_hint
+  asked <- FALSE
+  mockery::stub(f, "provider_models", function(provider, chat_args) {
+    asked <<- TRUE
+    "anthropic.claude-3-5-sonnet-20241022-v2:0"
+  })
+  # A valid cross-region inference profile, absent from ListFoundationModels:
+  # calling it wrong would also have stopped the JSON-mode fallback
+  expect_length(f("aws_bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0"), 0)
+  expect_false(asked)
+})
+
 test_that("a diagnosis never reaches the network in tests", {
   # The lookups above are all stubbed; the real lister must fail closed when
   # it cannot run, returning nothing rather than raising
-  clear_model_list_cache()
-  on.exit(clear_model_list_cache())
   withr::local_envvar(OPENAI_API_KEY = NA)
   f <- provider_models
   mockery::stub(f, "models_lister", function(provider) function(...) stop("no key"))

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -727,6 +727,63 @@ test_that("structured = 'auto' still falls back when the endpoint answered in pr
 })
 
 
+test_that("a structured run the provider rejects outright names the model (#133)", {
+  skip_if_not_installed("mockery")
+  calls <- new.env()
+
+  # ellmer's parallel path hands back every rejected request as a row whose
+  # .error is the HTTP condition, all fields NA
+  http_400 <- function() {
+    structure(
+      list(message = "HTTP 400 Bad Request.", status = 400L, call = NULL),
+      class = c("httr2_http_400", "httr2_http", "httr2_error", "rlang_error", "error", "condition")
+    )
+  }
+  rejected <- tibble::tibble(
+    score = c(NA_real_, NA_real_),
+    .error = list(http_400(), http_400())
+  )
+  expect_true(all_rejected(rejected))
+  expect_false(all_rejected(tibble::tibble(score = NA_real_, .error = list(simpleError("cut off")))))
+  expect_false(all_rejected(tibble::tibble(score = c(NA_real_, 1), .error = list(http_400(), NULL))))
+  expect_false(all_rejected(tibble::tibble(score = NA_real_)))
+
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", structured_stub(results = rejected))
+  mockery::stub(f, "code_handler_json", json_stub(calls))
+  mockery::stub(f, "model_name_hint", function(model, chat_args) {
+    c("i" = "\"gpt-4o-mimi\" is not a model that \"openai\" lists.")
+  })
+
+  # The provider confirms the name is wrong: stop, rather than send it again
+  # in JSON mode
+  expect_error(
+    f(c("a", "b"), structured_test_codebook(), model = "openai/gpt-4o-mimi"),
+    "is not a model that"
+  )
+  expect_null(calls$json)
+
+  # Without that confirmation, a rejection may be the provider refusing the
+  # schema-constrained request itself, so the fallback runs as before
+  g <- qlm_code
+  mockery::stub(g, "try_structured_call", structured_stub(results = rejected))
+  mockery::stub(g, "code_handler_json", json_stub(calls))
+  mockery::stub(g, "model_name_hint", function(model, chat_args) character())
+  expect_warning(
+    g(c("a", "b"), structured_test_codebook(), model = "openai/gpt-4o-mimi"),
+    "falling back to JSON mode"
+  )
+  expect_true(calls$json)
+
+  # And under structured = "structured" the rejection is the reported failure
+  expect_error(
+    g(c("a", "b"), structured_test_codebook(), model = "openai/gpt-4o-mimi",
+      structured = "structured"),
+    "HTTP 400 Bad Request"
+  )
+})
+
+
 test_that("a wholly failed structured run is reported, not re-coded in JSON mode", {
   skip_if_not_installed("mockery")
   calls <- new.env()

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -453,7 +453,7 @@ test_that("qlm_code delegates to the handler and records the backend", {
 
   handler_args <- NULL
   fake_handler <- function(x, codebook, model, chat_args, execution_args, batch,
-                           max_retries = 2L) {
+                           max_retries = 2L, model_hint = NULL) {
     handler_args <<- list(model = model, batch = batch, max_retries = max_retries,
                           chat_args = chat_args, execution_args = execution_args)
     results <- tibble::tibble(score = c(0.5, 0.8))
@@ -542,7 +542,7 @@ test_that("qlm_code passes its max_retries default to the handler", {
 
   seen <- NULL
   fake_handler <- function(x, codebook, model, chat_args, execution_args, batch,
-                           max_retries) {
+                           max_retries, model_hint = NULL) {
     seen <<- max_retries
     tibble::tibble(score = 0.5)
   }
@@ -589,10 +589,12 @@ structured_stub <- function(results = data.frame(score = 0.5), errors = NULL,
 }
 
 json_stub <- function(calls = NULL) {
-  function(x, codebook, model, chat_args, execution_args, batch, max_retries) {
+  function(x, codebook, model, chat_args, execution_args, batch, max_retries,
+           model_hint = NULL) {
     if (!is.null(calls)) {
       calls$json <- TRUE
       calls$max_retries <- max_retries
+      calls$model_hint <- model_hint
     }
     results <- tibble::tibble(score = rep(0.99, length(x)))
     attr(results, "qlm_backend_meta") <- list(backend = "json_mode", n_invalid = 0)
@@ -774,6 +776,8 @@ test_that("a structured run the provider rejects outright names the model (#133)
     "falling back to JSON mode"
   )
   expect_true(calls$json)
+  # The provider was asked once; the JSON path is told the answer, not sent to ask again
+  expect_identical(calls$model_hint, character())
 
   # And under structured = "structured" the rejection is the reported failure
   expect_error(

--- a/tests/testthat/test-qlm_code_json.R
+++ b/tests/testthat/test-qlm_code_json.R
@@ -24,10 +24,13 @@ json_test_usage <- function(n) {
 
 # A code_handler_json() with ellmer::chat() and json_chat_turns() stubbed out.
 # `attempts` is a list of list(text =, error =, status =, finish =), one per
-# expected round trip; `error`, `status` and `finish` default to NA.
-json_test_handler <- function(attempts, calls = NULL) {
+# expected round trip; `error`, `status` and `finish` default to NA. The
+# model-name lookup a wholly rejected run makes is stubbed out too, since it
+# would otherwise ask the provider; `hint` is what it answers.
+json_test_handler <- function(attempts, calls = NULL, hint = character()) {
   h <- code_handler_json
   mockery::stub(h, "ellmer::chat", function(...) structure(list(), class = "fake_chat"))
+  mockery::stub(h, "model_name_hint", function(...) hint)
   i <- 0L
   mockery::stub(h, "json_chat_turns", function(chat, prompts, pc_args) {
     i <<- i + 1L
@@ -785,6 +788,36 @@ test_that("code_handler_json aborts when the provider rejects every request", {
 
   # No point re-sending a request the provider rejected outright
   expect_equal(calls$n, 1)
+})
+
+test_that("code_handler_json names the model when the provider does not list it (#133)", {
+  rejected <- list(
+    text = c(NA_character_, NA_character_),
+    error = rep("HTTP 400 Bad Request.", 2),
+    status = c(400L, 400L)
+  )
+  hint <- c("i" = "\"gpt-4o-mimi\" is not a model that \"openai\" lists.",
+            "i" = "Did you mean \"gpt-4o-mini\"?")
+  h <- json_test_handler(list(rejected), hint = hint)
+
+  err <- tryCatch(
+    h(x = c("a", "b"), codebook = json_test_codebook(), model = "openai/gpt-4o-mimi",
+      chat_args = list(), execution_args = list()),
+    error = function(e) e
+  )
+  msg <- strip_ansi(conditionMessage(err))
+  expect_match(msg, "Every request to model \"openai/gpt-4o-mimi\" was rejected")
+  expect_match(msg, "Did you mean \"gpt-4o-mini\"")
+  # The provider has answered the question, so the generic advice is dropped
+  expect_no_match(msg, "Check the model name")
+
+  # With nothing to add, the provider's error and the generic advice stand
+  h <- json_test_handler(list(rejected))
+  expect_error(
+    h(x = c("a", "b"), codebook = json_test_codebook(), model = "openai/gpt-4o-mimi",
+      chat_args = list(), execution_args = list()),
+    "Check the model name"
+  )
 })
 
 test_that("code_handler_json does not retry a fatal failure in a mixed batch", {

--- a/tests/testthat/test-qlm_code_json.R
+++ b/tests/testthat/test-qlm_code_json.R
@@ -818,6 +818,14 @@ test_that("code_handler_json names the model when the provider does not list it 
       chat_args = list(), execution_args = list()),
     "Check the model name"
   )
+
+  # An answer qlm_code() already has is used rather than asked for again
+  h <- json_test_handler(list(rejected), hint = hint)
+  expect_error(
+    h(x = c("a", "b"), codebook = json_test_codebook(), model = "openai/gpt-4o-mimi",
+      chat_args = list(), execution_args = list(), model_hint = character()),
+    "Check the model name"
+  )
 })
 
 test_that("code_handler_json does not retry a fatal failure in a mixed batch", {


### PR DESCRIPTION
Fixes #133.

## What this does

When a run is rejected in its entirety with a status that will not change on retry (400, 401, 403, 404, 422), `qlm_code()` now asks the provider for its model list and says when the name is not on it:

```
Error in `qlm_code()`:
! Every request to model "openai/gpt-4o-mimi" was rejected by the provider.
✖ HTTP 400 Bad Request.
ℹ "gpt-4o-mimi" is not a model that "openai" lists; `ellmer::models_openai()` gives the 132 it does.
ℹ Did you mean "gpt-4o-mini", "gpt-5-mini", and "gpt-4.1-mini"?
```

Verified live against OpenAI, DeepSeek and Anthropic (the model-list endpoints are free).

## Design, following the issue

- **Lazy.** Nothing happens on the happy path. The lookup runs only after a whole run has been rejected, so a mistyped name costs one round of immediately rejected requests, as before, and then a clear message.
- **Ask ellmer, keep no table.** `models_<provider>()` is looked up in ellmer's exports at run time, the way `ellmer::chat()` looks up `chat_<provider>()`. Fifteen providers have one; the bring-your-own-endpoint providers do not, and for those nothing is claimed either way.
- **Asked at most once per failed run, never cached.** The listing depends on who asks (fine-tuned and gated models differ by key, project, region and profile), and a run rejected in its entirety has already stopped, so there is nothing to memoise. Where `qlm_code()` has asked on the structured path it hands the answer to the JSON-mode handler rather than asking twice. Never runs at load.
- **Only where absence means something.** The claim is made only for providers on an allowlist whose listing covers every name they accept (Bedrock invokes inference profiles and ARNs its listing omits; Vertex serves tuned endpoints; Portkey and Posit are gateways), never for Gemini's `tunedModels/` names, and never for a name that begins a listed one, which is the shape of an alias (`claude-haiku-4-5` for `claude-haiku-4-5-20251001`).
- **A diagnostic, never a gate.** No listing, no credentials, no network, or a name that *is* listed: nothing is added and the provider's own error stands unchanged. `base_url`, `api_key` and `credentials` from the run are passed to the lookup where it takes them, so a custom endpoint is asked rather than the provider default.

## The structured path

A wholly rejected structured run previously came back as a table of `NA`s with an `.error` per row, since `all_required_missing()` rightly sets rejected rows aside as saying nothing about the schema. It is now a failed attempt in its own right, and the reporting depends on what the provider says:

- Provider confirms the name is unknown: stop with the message above, rather than send the same name again in JSON mode.
- Provider cannot say (no listing, or the name is listed): fall through exactly as before. A 4xx here may be the provider refusing the schema-constrained request itself, which JSON mode is the cure for, so that path must stay open.

Partial rejections are untouched: if some units succeeded, the model exists.

## Scope

- `R/providers.R`: `model_name_hint()`, `provider_models()` with its session cache, `models_lister()`, `closest_model_names()`.
- `R/qlm_code_json.R`: the all-rejected abort carries the hint; `set_bullets()` gains a `bullet` argument.
- `R/qlm_code.R`: `try_structured_call()` records rejection; `qlm_code()` gains the abort branch; new "Rejected runs" section in `?qlm_code`.
- Tests in all three files, all with the lookup stubbed; the JSON-path test helper stubs it by default so no test reaches the network.

## Verification

- 1656 tests pass, 0 failures; the two warnings are the pre-existing mismatched-unit ones.
- `R CMD check --as-cran`: 0 errors, 0 warnings, the dev-version NOTE only.

