### PR TITLE
Pass model_name to qlm_code() as model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Bug fixes
 
+* The deprecated `annotate()` and `trail_record()` run again. `annotate()`
+  passed its `model_name` to `qlm_code()` under that name, whose argument is
+  `model`, so the value fell through to the provider call and every use
+  failed, with `model` reported missing or `model_name` reported unused. The
+  functions still warn that `qlm_code()` replaces them (#141).
+
 * `qlm_code()` now says when a model name is not one its provider lists,
   with the nearest names it does have, instead of reporting only the
   provider's HTTP error. The provider's model list is fetched through

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,12 @@
 * The deprecated `annotate()` and `trail_record()` run again. `annotate()`
   passed its `model_name` to `qlm_code()` under that name, whose argument is
   `model`, so the value fell through to the provider call and every use
-  failed, with `model` reported missing or `model_name` reported unused. The
-  functions still warn that `qlm_code()` replaces them (#141).
+  failed, with `model` reported missing or `model_name` reported unused.
+  `annotate()` again returns its identifier column as `id`, as documented,
+  rather than `qlm_code()`'s `.id`, and `trail_record()` now always restores
+  the caller's `id_col` values in place of the sequential ones `annotate()`
+  generates. Both functions still warn that `qlm_code()` replaces them
+  (#141).
 
 * `qlm_code()` now says when a model name is not one its provider lists,
   with the nearest names it does have, instead of reporting only the

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -33,7 +33,11 @@
 annotate <- function(.data, task, model_name, ...) {
   lifecycle::deprecate_warn("0.2.0", "annotate()", "qlm_code()")
 
-  # Call qlm_code() and extract results as data.frame
   coded <- qlm_code(.data, codebook = task, model = model_name, ...)
-  as.data.frame(coded)
+
+  # qlm_code() keys its rows on `.id`; annotate() always returned that column
+  # as `id`, and callers on the deprecation path still read it by that name.
+  out <- as.data.frame(coded)
+  names(out)[names(out) == ".id"] <- "id"
+  out
 }

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -21,10 +21,10 @@
 #' \dontrun{
 #' # Deprecated usage
 #' texts <- c("I love this product!", "This is terrible.")
-#' annotate(texts, task_sentiment(), model_name = "openai")
+#' annotate(texts, data_codebook_sentiment, model_name = "openai/gpt-4o-mini")
 #'
 #' # New recommended usage
-#' coded <- qlm_code(texts, task_sentiment(), model = "openai")
+#' coded <- qlm_code(texts, data_codebook_sentiment, model = "openai/gpt-4o-mini")
 #' coded  # Print as tibble
 #' }
 #'
@@ -34,6 +34,6 @@ annotate <- function(.data, task, model_name, ...) {
   lifecycle::deprecate_warn("0.2.0", "annotate()", "qlm_code()")
 
   # Call qlm_code() and extract results as data.frame
-  coded <- qlm_code(.data, codebook = task, model_name = model_name, ...)
+  coded <- qlm_code(.data, codebook = task, model = model_name, ...)
   as.data.frame(coded)
 }

--- a/R/trail_record.R
+++ b/R/trail_record.R
@@ -96,10 +96,11 @@ trail_record <- function(
 
   annotations <- do.call(annotate_fun, args)
 
-  # Attach ID if not present; align by row position
-  if (!id_col %in% names(annotations)) {
-    annotations[[id_col]] <- data[[id_col]]
-  }
+  # Rows come back in input order, so the identifier is restored by position.
+  # annotate() returns its own `id` column of sequential integers; assigning
+  # only when the column is absent kept those in place of the caller's values
+  # whenever id_col was "id".
+  annotations[[id_col]] <- data[[id_col]]
 
   meta <- list(
     timestamp    = Sys.time(),

--- a/man/annotate.Rd
+++ b/man/annotate.Rd
@@ -34,10 +34,10 @@ returns a richer object that includes metadata and settings for reproducibility.
 \dontrun{
 # Deprecated usage
 texts <- c("I love this product!", "This is terrible.")
-annotate(texts, task_sentiment(), model_name = "openai")
+annotate(texts, data_codebook_sentiment, model_name = "openai/gpt-4o-mini")
 
 # New recommended usage
-coded <- qlm_code(texts, task_sentiment(), model = "openai")
+coded <- qlm_code(texts, data_codebook_sentiment, model = "openai/gpt-4o-mini")
 coded  # Print as tibble
 }
 

--- a/tests/testthat/test-annotate.R
+++ b/tests/testthat/test-annotate.R
@@ -110,6 +110,33 @@ test_that("annotate requires model_name argument", {
   )
 })
 
+test_that("annotate() hands model_name to qlm_code() as model (#141)", {
+  skip_if_not_installed("ellmer")
+  withr::local_options(lifecycle_verbosity = "quiet")
+
+  # qlm_code()'s formal is `model`; `model_name` is longer, so it never
+  # partially matches and fell through `...` to the provider call. Record what
+  # qlm_code() receives rather than spending a request.
+  seen <- NULL
+  local_mocked_bindings(qlm_code = function(x, codebook, model, ...) {
+    seen <<- list(model = model, dots = list(...))
+    tibble::tibble(.id = seq_along(x), score = 1)
+  })
+
+  tsk <- task(
+    name = "Test",
+    system_prompt = "Test prompt",
+    type_def = ellmer::type_object(score = ellmer::type_number("A score"))
+  )
+
+  out <- annotate(c("Hello", "World"), tsk, model_name = "openai/gpt-4o-mini")
+
+  expect_identical(seen$model, "openai/gpt-4o-mini")
+  expect_false("model_name" %in% names(seen$dots))
+  expect_s3_class(out, "data.frame")
+  expect_equal(nrow(out), 2L)
+})
+
 test_that("annotate routes arguments correctly", {
   skip_if_not_installed("ellmer")
 

--- a/tests/testthat/test-annotate.R
+++ b/tests/testthat/test-annotate.R
@@ -120,7 +120,7 @@ test_that("annotate() hands model_name to qlm_code() as model (#141)", {
   seen <- NULL
   local_mocked_bindings(qlm_code = function(x, codebook, model, ...) {
     seen <<- list(model = model, dots = list(...))
-    tibble::tibble(.id = seq_along(x), score = 1)
+    tibble::tibble(.id = names(x) %||% seq_along(x), score = 1)
   })
 
   tsk <- task(
@@ -135,6 +135,32 @@ test_that("annotate() hands model_name to qlm_code() as model (#141)", {
   expect_false("model_name" %in% names(seen$dots))
   expect_s3_class(out, "data.frame")
   expect_equal(nrow(out), 2L)
+})
+
+test_that("annotate() still returns its documented `id` column (#141)", {
+  skip_if_not_installed("ellmer")
+  withr::local_options(lifecycle_verbosity = "quiet")
+
+  # qlm_code() keys rows on `.id`. annotate() documented, and returned, `id`
+  # as the first column, from the input's names or sequential integers.
+  local_mocked_bindings(qlm_code = function(x, codebook, model, ...) {
+    tibble::tibble(.id = names(x) %||% seq_along(x), score = 1)
+  })
+
+  tsk <- task(
+    name = "Test",
+    system_prompt = "Test prompt",
+    type_def = ellmer::type_object(score = ellmer::type_number("A score"))
+  )
+
+  named <- annotate(c("doc-a" = "Hello", "doc-b" = "World"), tsk,
+                    model_name = "openai/gpt-4o-mini")
+  expect_identical(names(named), c("id", "score"))
+  expect_identical(named$id, c("doc-a", "doc-b"))
+  expect_false(".id" %in% names(named))
+
+  unnamed <- annotate(c("Hello", "World"), tsk, model_name = "openai/gpt-4o-mini")
+  expect_identical(unnamed$id, 1:2)
 })
 
 test_that("annotate routes arguments correctly", {

--- a/tests/testthat/test-trail_record.R
+++ b/tests/testthat/test-trail_record.R
@@ -8,7 +8,7 @@ test_that("trail_record() reaches qlm_code() through annotate() (#141)", {
   seen <- NULL
   local_mocked_bindings(qlm_code = function(x, codebook, model, ...) {
     seen <<- list(model = model, dots = list(...))
-    tibble::tibble(.id = seq_along(x), score = 1)
+    tibble::tibble(.id = names(x) %||% seq_along(x), score = 1)
   })
 
   tsk <- task(
@@ -18,12 +18,36 @@ test_that("trail_record() reaches qlm_code() through annotate() (#141)", {
   )
   setting <- trail_settings(provider = "openai", model = "gpt-4o-mini",
                             temperature = 0)
-  d <- data.frame(id = 1:2, text = c("great", "awful"))
+  # Non-sequential identifiers, so that annotate()'s own sequential `id`
+  # column cannot pass for the caller's when id_col is also "id".
+  d <- data.frame(id = c("doc-a", "doc-b"), text = c("great", "awful"))
 
   rec <- trail_record(d, "text", tsk, setting, id_col = "id")
 
   expect_s3_class(rec, "trail_record")
   expect_identical(seen$model, "openai/gpt-4o-mini")
   expect_false("model_name" %in% names(seen$dots))
-  expect_equal(rec$annotations$id, 1:2)
+  expect_identical(rec$annotations$id, c("doc-a", "doc-b"))
+})
+
+test_that("trail_record() keeps annotate()'s id beside a differently named id_col (#141)", {
+  skip_if_not_installed("ellmer")
+  withr::local_options(lifecycle_verbosity = "quiet")
+
+  local_mocked_bindings(qlm_code = function(x, codebook, model, ...) {
+    tibble::tibble(.id = names(x) %||% seq_along(x), score = 1)
+  })
+
+  tsk <- task(
+    name = "Test",
+    system_prompt = "Test prompt",
+    type_def = ellmer::type_object(score = ellmer::type_number("A score"))
+  )
+  setting <- trail_settings(provider = "openai", model = "gpt-4o-mini")
+  d <- data.frame(doc = c("doc-a", "doc-b"), text = c("great", "awful"))
+
+  rec <- trail_record(d, "text", tsk, setting, id_col = "doc")
+
+  expect_identical(rec$annotations$doc, c("doc-a", "doc-b"))
+  expect_identical(rec$annotations$id, 1:2)
 })

--- a/tests/testthat/test-trail_record.R
+++ b/tests/testthat/test-trail_record.R
@@ -1,0 +1,29 @@
+test_that("trail_record() reaches qlm_code() through annotate() (#141)", {
+  skip_if_not_installed("ellmer")
+  withr::local_options(lifecycle_verbosity = "quiet")
+
+  # trail_record() has no route to results except annotate(), so the wrong
+  # argument name there stopped this path entirely. Exercise the default
+  # annotate_fun with qlm_code() recorded rather than called.
+  seen <- NULL
+  local_mocked_bindings(qlm_code = function(x, codebook, model, ...) {
+    seen <<- list(model = model, dots = list(...))
+    tibble::tibble(.id = seq_along(x), score = 1)
+  })
+
+  tsk <- task(
+    name = "Test",
+    system_prompt = "Test prompt",
+    type_def = ellmer::type_object(score = ellmer::type_number("A score"))
+  )
+  setting <- trail_settings(provider = "openai", model = "gpt-4o-mini",
+                            temperature = 0)
+  d <- data.frame(id = 1:2, text = c("great", "awful"))
+
+  rec <- trail_record(d, "text", tsk, setting, id_col = "id")
+
+  expect_s3_class(rec, "trail_record")
+  expect_identical(seen$model, "openai/gpt-4o-mini")
+  expect_false("model_name" %in% names(seen$dots))
+  expect_equal(rec$annotations$id, 1:2)
+})


### PR DESCRIPTION
## Summary

`annotate()` forwarded `model_name` to `qlm_code()` under that name, but `qlm_code()`'s argument is `model`. Since `model_name` is not a prefix of `model`, partial matching never applied, and the value fell through `...` to `chat_args` and on to the provider call. No argument combination made `annotate()` succeed, and `trail_record()` failed the same way because `annotate()` is its only route to results.

Both functions are deprecated but still exported and only warn, so a user following the documented deprecation path got a hard error naming an argument they never passed.

Review of the first commit found that execution alone did not restore the old contract: `annotate()` always returned its identifier column as `id`, first, and its documentation still says so, but through `qlm_code()` it arrived as `.id`. The second commit renames it back. It also fixes a pre-existing quirk in `trail_record()`, which attached `data[[id_col]]` only when that column was absent; since `annotate()` supplies an `id` column of its own, an `id_col` of `"id"` kept sequential integers in place of the caller's identifiers.

## Changes

- `R/annotate.R`: pass `model = model_name`; rename `.id` to `id` in the returned data frame. The `@examples` referred to `task_sentiment()`, which the package does not define; they now use `data_codebook_sentiment`.
- `R/trail_record.R`: always restore `data[[id_col]]` by position rather than only when absent.
- `tests/testthat/test-annotate.R`: regression tests that mock `qlm_code()` and assert `model` arrives and `model_name` does not, and that `id` comes back first, from names or sequential integers. The existing tests only reached pre-dispatch validation, which aborts before `model` is read.
- `tests/testthat/test-trail_record.R`: new file; the same checks through `trail_record()`'s default `annotate_fun`, with non-sequential identifiers so `annotate()`'s own `id` cannot pass for the caller's, and a case where `id_col` differs from `"id"` so both columns survive.
- `NEWS.md`: bullet under bug fixes.

## Tests

The argument tests fail on the old line with `argument "model" is missing` and pass on the fix. Full suite: 1698 pass, 0 fail.

Fixes #141

