### PR TITLE
CI: drop unused OPENAI_API_KEY and scope the pkgdown write token to the deploy job

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,7 +25,6 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@v7
       - uses: r-lib/actions/setup-pandoc@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -13,18 +13,19 @@ name: pkgdown.yaml
 permissions: read-all
 
 jobs:
-  pkgdown:
+  # Build and deploy are separate jobs so that the write token exists only in
+  # the deploy job, which runs no code from the commit under test. The build
+  # job installs the package and runs pkgdown on it, and on a pull request
+  # that is the PR's own code; it gets a read-only token. See #147.
+  pkgdown-build:
     runs-on: ubuntu-latest
     # Healthy runs take ~2m30s. See #126.
     timeout-minutes: 20
-    # Only restrict concurrency for non-PR jobs
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # API keys removed - no longer needed without article builds
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
 
@@ -39,8 +40,6 @@ jobs:
           extra-packages: any::pkgdown, local::.
           needs: website
 
-      # Debug step removed - was for API key troubleshooting
-
       - name: Build site (reference only, preserve articles)
         run: |
           pkgdown::init_site()
@@ -50,8 +49,35 @@ jobs:
           # Deliberately skip build_articles()
         shell: Rscript {0}
 
+      - name: Upload site
+        uses: actions/upload-artifact@v7
+        with:
+          name: pkgdown-site
+          path: docs
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+
+  pkgdown-deploy:
+    needs: pkgdown-build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Deploys to gh-pages must not overlap; builds may
+    concurrency:
+      group: pkgdown-deploy
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download site
+        uses: actions/download-artifact@v8
+        with:
+          name: pkgdown-site
+          path: docs
+
       - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false    # Critical: preserves existing articles

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -12,6 +12,13 @@ name: pkgdown.yaml
 
 permissions: read-all
 
+# One non-PR run at a time, build and deploy together. Serialising only the
+# deploy job is not enough: builds would overlap, and a slow build for an
+# older commit could deploy after a fast one for a newer commit and leave
+# gh-pages stale. PR runs get a group of their own and never queue.
+concurrency:
+  group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+
 jobs:
   # Build and deploy are separate jobs so that the write token exists only in
   # the deploy job, which runs no code from the commit under test. The build
@@ -63,9 +70,6 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Deploys to gh-pages must not overlap; builds may
-    concurrency:
-      group: pkgdown-deploy
     permissions:
       contents: write
     steps:

--- a/R/accessors-doc.R
+++ b/R/accessors-doc.R
@@ -42,7 +42,7 @@
 #' - [qlm_failures()]: List the units a coding run failed on, with reasons
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' # Create a coded object
 #' texts <- c("I love this!", "Terrible.", "It's okay.")
 #' coded <- qlm_code(

--- a/R/data.R
+++ b/R/data.R
@@ -99,7 +99,7 @@
 #' # View the codebook
 #' data_codebook_sentiment
 #'
-#' \donttest{
+#' \dontrun{
 #' # Use with movie review corpus (requires API key)
 #' coded <- qlm_code(data_corpus_LMRDsample[1:10],
 #'                   data_codebook_sentiment,

--- a/R/qlm_codebook.R
+++ b/R/qlm_codebook.R
@@ -75,7 +75,7 @@
 #'   levels = list(score = "interval", explanation = "nominal")
 #' )
 #'
-#' \donttest{
+#' \dontrun{
 #' # Use with qlm_code() (requires API key)
 #' texts <- c("I love this!", "This is terrible.")
 #' coded <- qlm_code(texts, my_codebook, model = "openai/gpt-4o-mini")

--- a/R/qlm_replicate.R
+++ b/R/qlm_replicate.R
@@ -47,7 +47,7 @@
 #'   replicated results.
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' # First create a coded object
 #' texts <- c("I love this!", "Terrible.", "It's okay.")
 #' coded <- qlm_code(texts, data_codebook_sentiment, model = "openai/gpt-4o-mini", name = "run1")

--- a/man/accessors.Rd
+++ b/man/accessors.Rd
@@ -55,7 +55,7 @@ quallmer objects store metadata in three categories:
 }
 
 \examples{
-\donttest{
+\dontrun{
 # Create a coded object
 texts <- c("I love this!", "Terrible.", "It's okay.")
 coded <- qlm_code(

--- a/man/data_codebook_sentiment.Rd
+++ b/man/data_codebook_sentiment.Rd
@@ -26,7 +26,7 @@ polarity scale that includes a "mixed" category.
 # View the codebook
 data_codebook_sentiment
 
-\donttest{
+\dontrun{
 # Use with movie review corpus (requires API key)
 coded <- qlm_code(data_corpus_LMRDsample[1:10],
                   data_codebook_sentiment,

--- a/man/qlm_codebook.Rd
+++ b/man/qlm_codebook.Rd
@@ -93,7 +93,7 @@ my_codebook_levels <- qlm_codebook(
   levels = list(score = "interval", explanation = "nominal")
 )
 
-\donttest{
+\dontrun{
 # Use with qlm_code() (requires API key)
 texts <- c("I love this!", "This is terrible.")
 coded <- qlm_code(texts, my_codebook, model = "openai/gpt-4o-mini")

--- a/man/qlm_replicate.Rd
+++ b/man/qlm_replicate.Rd
@@ -68,7 +68,7 @@ conforming endpoint cannot quietly skip the local validation the original
 relied on. Pass \code{structured} explicitly to override.
 }
 \examples{
-\donttest{
+\dontrun{
 # First create a coded object
 texts <- c("I love this!", "Terrible.", "It's okay.")
 coded <- qlm_code(texts, data_codebook_sentiment, model = "openai/gpt-4o-mini", name = "run1")


### PR DESCRIPTION
Fixes #147.

## What

Two CI jobs held a privilege on steps that run the commit under test. Both are removed.

- **`R-CMD-check.yaml`**: delete the job-level `OPENAI_API_KEY`. The issue's survey missed one consumer: four example blocks that call `qlm_code()` on a live model were wrapped in `\donttest{}`, which `R CMD check` runs, so they executed on every CI leg and needed the key. The first commit moves them to `\dontrun{}`, as `CLAUDE.md` prescribes for examples needing an API key and as every other provider-calling example already is. The `\donttest{}` block in `qlm_trail()` only writes a temp file and still runs. After that nothing needs the key: the one test naming the variable sets a dummy, and every vignette chunk that reaches a provider is `eval = FALSE`.
- **`pkgdown.yaml`**: split the single job into `pkgdown-build` and `pkgdown-deploy`. The build job runs pkgdown with `contents: read` and uploads `docs/` as a one-day artifact. The deploy job, which runs only off `pull_request`, checks out with `contents: write`, downloads the artifact and pushes it with the same `JamesIves/github-pages-deploy-action` step as before.

## What is preserved

- `clean: false` on the deploy, so the articles built locally under the hybrid strategy in `CLAUDE.md` stay on `gh-pages`. The deploy step is otherwise unchanged.
- The concurrency group moves to workflow level with the original expression, so one non-PR run holds it from build through deploy, as the single job did before. Review caught that serialising only the deploy job let a slow build for an older commit deploy after a fast one for a newer commit. A branch-head check before deploying was the alternative, but it would skip deploys on `release` events, whose `github.sha` is the tag commit.
- Hidden files in `docs/` are included in the artifact, so a `.nojekyll` written by pkgdown would round-trip. `gh-pages` already carries one in any case.

## Not changed

`render-readme.yaml` also holds `contents: write`, but it runs only on push to `main` and needs the token to push the rendered README, so it is left alone. `test-coverage.yaml` passes `CODECOV_TOKEN` only to the codecov step, not the job environment.

## Testing

- CI on the current head: all five check legs, `test-coverage` and `pkgdown-build` pass; `pkgdown-deploy` is skipped on the PR, as intended.
- The first push of this branch, with the key removed but the examples still in `\donttest{}`, failed all five check legs at `checking examples with --run-donttest`, which is how the missing consumer was found. `pkgdown-build` passed with the read-only token and `pkgdown-deploy` was skipped on the PR, as intended.
- Locally, with `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` unset: `devtools::test()` gives 0 failures, 3 skips, 2 warnings, identical to a run with keys; `devtools::run_examples(run_donttest = TRUE)` runs clean; `R CMD check --as-cran` finishes with 1 NOTE, the usual CRAN-incoming one, and no errors or warnings.
- The deploy job cannot run on this PR by design. The first push to `main` after merge will exercise it; check that `gh-pages` still has `articles/` and `workshops/` afterwards.


