### PR TITLE
Read ratings by their declared level, not storage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,28 @@
 
 ## Bug fixes
 
+* `qlm_compare()` now honours `tolerance`, and computes its numeric
+  statistics on the ratings' values, when a coder stores the ratings as
+  text. The ratings were assembled into one matrix before their type was
+  examined, and a single character column made the whole matrix character:
+  every unit then fell through to exact text equality with `tolerance`
+  unused, and Krippendorff's alpha, the ICC and Pearson's r ran on factor
+  codes of the sorted strings, where `"10"` falls between `"1"` and `"2"`.
+  Neither showed in the output, so an LLM column parsed as text against a
+  numeric human column gave a flat agreement curve and a wrong alpha. At
+  ordinal, interval and ratio level every column is now read as numbers, as
+  the declared level asserts; a value that does not read as a number is an
+  error naming the coder and the values; ordinal categories given as text
+  are ranked as before, but a positive `tolerance` on them draws a warning;
+  and nominal categories agree only when identical, as the code's own
+  comment already claimed (#150).
+
+* `qlm_validate()` ranked ordinal ratings by their values sorted as strings,
+  so on a 1 to 10 scale `"10"` fell between `"1"` and `"2"` and Spearman's
+  rho, Kendall's tau and MAE were wrong whenever a rating reached 10, even
+  from numeric input. Ordinal and interval values are now read as numbers
+  the same way as in `qlm_compare()` (#150).
+
 * `qlm_code()` now says when a model name is not one its provider lists,
   with the nearest names it does have, instead of reporting only the
   provider's HTTP error. The provider's model list is fetched through

--- a/R/qlm_compare.R
+++ b/R/qlm_compare.R
@@ -31,7 +31,10 @@
 #'   and `0.1 + 0.2` equals `0.3`; it is numerical equality rather than bit
 #'   identity. The allowance is far smaller than any meaningful rating
 #'   difference, so a genuinely different pair is never counted as agreeing.
-#'   Used for percent agreement calculation.
+#'   Used for percent agreement at ordinal, interval and ratio level, where
+#'   the ratings are numbers. Nominal categories agree only when identical,
+#'   as do ordinal categories given as text, and a positive `tolerance` on
+#'   text categories draws a warning since it cannot be applied.
 #' @param ci Confidence interval method:
 #'   \describe{
 #'     \item{`"none"`}{No confidence intervals (default)}
@@ -96,6 +99,16 @@
 #' Kendall's W, ICC, and percent agreement are computed using all raters
 #' simultaneously. For 3 or more raters, Spearman's rho and Pearson's r are
 #' computed as the mean of all pairwise correlations between raters.
+#'
+#' **How ratings are read.** At ordinal, interval and ratio level every
+#' coder's ratings are read as numbers, whatever type they are stored as, so a
+#' column of digits held as text is compared on its values and not on the
+#' alphabetical order of its strings. A value that does not read as a number
+#' is an error at interval and ratio level, naming the coder and the values.
+#' At ordinal level the categories may instead all be text, in which case they
+#' are ranked by their sorted labels; numbers from one coder and text from
+#' another cannot be placed on one scale and are an error. Nominal ratings are
+#' compared as text.
 #'
 #' **Per-category statistics.** When `by_category = TRUE` and `level = "nominal"`,
 #' the result also includes one row per category for `alpha_per_value` (from
@@ -407,6 +420,9 @@ qlm_compare <- function(...,
     rater_names[empty] <- paste0("rater", seq_len(n_raters))[empty]
   }
 
+  # How each coder is named in messages: its recorded name where it has one
+  coder_labels <- ifelse(is.na(object_names), rater_names, object_names)
+
   # Initialize results list
   all_results <- list()
   n_subjects_total <- NULL
@@ -441,8 +457,10 @@ qlm_compare <- function(...,
       next
     }
 
-    # Extract rating matrix (exclude .id column)
-    ratings <- as.matrix(merged[, -1, drop = FALSE])
+    # Rating matrix, typed by the level rather than by how each coder stored
+    # the values (#150)
+    ratings <- ratings_matrix(merged[, -1, drop = FALSE], var_level, var,
+                              coders = coder_labels, tolerance = tolerance)
 
     # Remove rows with any NA values
     complete_rows <- stats::complete.cases(ratings)
@@ -586,6 +604,92 @@ qlm_compare <- function(...,
       )
     )
   )
+}
+
+
+#' Type the ratings matrix by the declared measurement level
+#'
+#' `as.matrix()` on the merged coder columns gives a matrix of one type, and a
+#' single character column makes every column character. Every rating then
+#' reaches the agreement test as text, so `tolerance` is never applied, and
+#' the numeric statistics run on factor codes of the sorted strings, where
+#' `"10"` falls between `"1"` and `"2"`. Neither failure shows in the output
+#' (#150). So the type is settled here, per column and before the matrix
+#' exists, from the level the caller declared rather than from how each coder
+#' happened to store the values.
+#'
+#' At ordinal, interval and ratio level every column is read as numbers. A
+#' value that does not read as a number is an error at interval and ratio
+#' level, which assert numeric data. Ordinal categories may be text, so when
+#' no column reads as numbers the ratings stay text and are ranked by their
+#' sorted labels, as before; a positive `tolerance` cannot be honoured on
+#' labels and draws a warning rather than being ignored. A mix of numeric and
+#' text columns at ordinal level is an error, since the ranks of one cannot be
+#' placed against the other. Nominal ratings are left as stored: categories
+#' are compared as text and no tolerance applies.
+#'
+#' @param columns Data frame with one column per coder and no `.id`.
+#' @param level Character; the measurement level.
+#' @param var Character; the variable's name, for messages.
+#' @param coders Character; one label per column, for messages.
+#' @param tolerance Numeric; the tolerance the caller asked for.
+#'
+#' @return A matrix with one column per coder: numeric where the level is
+#'   numeric and every column reads as numbers, otherwise of the stored type.
+#' @keywords internal
+#' @noRd
+ratings_matrix <- function(columns, level, var, coders = names(columns),
+                           tolerance = 0) {
+  if (level == "nominal") {
+    return(as.matrix(columns))
+  }
+
+  numbers <- lapply(columns, function(col) {
+    if (is.factor(col)) col <- as.character(col)
+    if (is.character(col)) suppressWarnings(as.numeric(col)) else as.numeric(col)
+  })
+  unreadable <- vapply(seq_along(numbers), function(i) {
+    any(!is.na(columns[[i]]) & is.na(numbers[[i]]))
+  }, logical(1))
+
+  if (!any(unreadable)) {
+    ratings <- do.call(cbind, numbers)
+    colnames(ratings) <- names(columns)
+    return(ratings)
+  }
+
+  if (level == "ordinal" && all(unreadable)) {
+    if (tolerance > 0) {
+      cli::cli_warn(c(
+        "Ignoring {.arg tolerance} for variable {.var {var}}: its ordinal categories are text.",
+        "i" = "A tolerance applies only to numbers; text categories agree only when identical.",
+        "i" = "Store the categories as numbers to compare them within a tolerance."
+      ))
+    }
+    return(as.matrix(columns))
+  }
+
+  offending <- vapply(which(unreadable), function(i) {
+    bad <- columns[[i]][!is.na(columns[[i]]) & is.na(numbers[[i]])]
+    bad <- unique(as.character(bad))
+    shown <- utils::head(bad, 5)
+    more <- length(bad) - length(shown)
+    cli::format_inline(
+      "{.val {coders[i]}}: {.val {shown}}{if (more > 0) paste0(' and ', more, ' more') else ''}"
+    )
+  }, character(1))
+  names(offending) <- rep("x", length(offending))
+
+  hint <- if (level == "ordinal") {
+    "At ordinal level every coder's ratings must be numbers, or all must be text categories."
+  } else {
+    "Store the ratings as numbers, or compare at {.val nominal} level."
+  }
+  cli::cli_abort(c(
+    "Ratings for {.var {var}} at {.val {level}} level must be numbers, but some are not:",
+    offending,
+    "i" = hint
+  ))
 }
 
 
@@ -733,16 +837,17 @@ compute_reliability_by_level <- function(ratings, n_raters, level, tolerance, us
   results <- list()
   cis <- list()  # Store confidence intervals separately
 
-  # Percent agreement (computed for all levels)
-  # For nominal data: exact agreement (tolerance is ignored)
-  # For ordinal/interval/ratio: agreement within tolerance
-  agrees <- apply(ratings, 1, function(row) {
-    if (is.numeric(row)) {
-      agrees_within_tolerance(row, tolerance)
-    } else {
-      length(unique(as.character(row))) == 1
-    }
-  })
+  # Percent agreement, for every level. The tolerance applies to numbers on a
+  # scale: ordinal, interval and ratio ratings that arrived as numbers. Nominal
+  # categories, and ordinal categories given as text, agree only when
+  # identical. Decided once from the matrix rather than per row: apply() hands
+  # every row the matrix's single type, so a per-row test never saw a mixed
+  # frame and fell through to text equality with the tolerance unused (#150).
+  agrees <- if (level != "nominal" && is.numeric(ratings)) {
+    apply(ratings, 1, agrees_within_tolerance, tolerance = tolerance)
+  } else {
+    apply(ratings, 1, function(row) length(unique(row)) == 1)
+  }
   results$percent_agreement <- mean(agrees)
 
   if (level == "nominal") {

--- a/R/qlm_compare.R
+++ b/R/qlm_compare.R
@@ -457,13 +457,13 @@ qlm_compare <- function(...,
       next
     }
 
-    # Rating matrix, typed by the level rather than by how each coder stored
-    # the values (#150)
-    ratings <- ratings_matrix(merged[, -1, drop = FALSE], var_level, var,
-                              coders = coder_labels, tolerance = tolerance)
-
-    # Remove rows with any NA values
-    complete_rows <- stats::complete.cases(ratings)
+    # Remove rows with any NA values before typing the columns. A unit a
+    # coder did not rate says nothing about how that coder stores ratings,
+    # and a column that is missing throughout would otherwise read as numbers
+    # and be refused against another coder's text categories, aborting the
+    # call over a variable with nothing to compare.
+    coder_columns <- merged[, -1, drop = FALSE]
+    complete_rows <- stats::complete.cases(coder_columns)
     if (!any(complete_rows)) {
       cli::cli_warn(c(
         "No complete cases found for variable {.var {var}}.",
@@ -472,7 +472,11 @@ qlm_compare <- function(...,
       next
     }
 
-    ratings <- ratings[complete_rows, , drop = FALSE]
+    # Rating matrix, typed by the level rather than by how each coder stored
+    # the values (#150)
+    ratings <- ratings_matrix(coder_columns[complete_rows, , drop = FALSE],
+                              var_level, var,
+                              coders = coder_labels, tolerance = tolerance)
     n_subjects <- nrow(ratings)
 
     # Store n_subjects for first variable (for metadata)

--- a/R/qlm_validate.R
+++ b/R/qlm_validate.R
@@ -102,9 +102,8 @@ bootstrap_validation_ci <- function(merged, var_level, metrics_to_compute, estim
       }
 
     } else if (var_level == "ordinal") {
-      # Convert to numeric for ordinal measures
-      estimate_num <- as.numeric(boot_merged$estimate)
-      truth_num <- as.numeric(boot_merged$truth)
+      estimate_num <- boot_merged$estimate_num
+      truth_num <- boot_merged$truth_num
 
       # Spearman's rho
       if ("rho" %in% metrics_to_compute) {
@@ -129,9 +128,8 @@ bootstrap_validation_ci <- function(merged, var_level, metrics_to_compute, estim
       }
 
     } else if (var_level == "interval") {
-      # Convert to numeric for interval measures
-      estimate_num <- as.numeric(as.character(boot_merged$estimate))
-      truth_num <- as.numeric(as.character(boot_merged$truth))
+      estimate_num <- boot_merged$estimate_num
+      truth_num <- boot_merged$truth_num
 
       numeric_data <- data.frame(truth = truth_num, estimate = estimate_num)
 
@@ -280,6 +278,13 @@ bootstrap_validation_ci <- function(merged, var_level, metrics_to_compute, estim
 #'   continuous measurements). Metrics: ICC (intraclass correlation), Pearson's r
 #'   (linear correlation), MAE (mean absolute error), and RMSE (root mean squared
 #'   error).
+#'
+#' At ordinal and interval level the predictions and the gold standard are
+#' read as numbers, whatever type they are stored as, so a column of digits
+#' held as text is compared on its values and not on the alphabetical order of
+#' its strings. A value that does not read as a number is an error at interval
+#' level. Ordinal categories may instead all be text, in which case they are
+#' ranked by their sorted labels.
 #'
 #' For multiclass problems with nominal data, the `average` parameter controls
 #' how per-class metrics are aggregated:
@@ -765,6 +770,26 @@ qlm_validate <- function(
       merged$truth <- factor(merged$truth, levels = all_levels)
     }
 
+    # Numbers for the ordinal and interval measures, read by the declared
+    # level rather than taken as codes of the string-sorted factor levels,
+    # which ranked "10" between "1" and "2" (#150). Ordinal categories that
+    # are all text keep those codes: their sorted labels are the only order
+    # there is.
+    if (var_level != "nominal") {
+      numbers <- ratings_matrix(
+        merged[, c("estimate", "truth")], var_level, var,
+        coders = c(if (is.na(x_obj_name)) "x" else x_obj_name,
+                   if (is.na(gold_name)) "gold" else gold_name)
+      )
+      if (is.numeric(numbers)) {
+        merged$estimate_num <- numbers[, "estimate"]
+        merged$truth_num <- numbers[, "truth"]
+      } else {
+        merged$estimate_num <- as.numeric(merged$estimate)
+        merged$truth_num <- as.numeric(merged$truth)
+      }
+    }
+
     # Map `average` to the estimator label used by the metric_* functions.
     estimator <- switch(average,
       "macro" = "macro",
@@ -822,11 +847,10 @@ qlm_validate <- function(
       )$value
     }
 
-    # Ordinal measures (require numeric conversion)
+    # Ordinal measures
     if (var_level == "ordinal") {
-      # Convert ordered factors to numeric for correlation and distance measures
-      estimate_num <- as.numeric(merged$estimate)
-      truth_num <- as.numeric(merged$truth)
+      estimate_num <- merged$estimate_num
+      truth_num <- merged$truth_num
 
       # Spearman's rho (rank correlation)
       # Note: cor.test does not provide CIs for Spearman's rho
@@ -848,11 +872,10 @@ qlm_validate <- function(
       }
     }
 
-    # Interval measures (require numeric conversion)
+    # Interval measures
     if (var_level == "interval") {
-      # For interval data, convert to numeric
-      estimate_num <- as.numeric(as.character(merged$estimate))
-      truth_num <- as.numeric(as.character(merged$truth))
+      estimate_num <- merged$estimate_num
+      truth_num <- merged$truth_num
 
       numeric_data <- data.frame(
         truth = truth_num,

--- a/man/qlm_compare.Rd
+++ b/man/qlm_compare.Rd
@@ -44,7 +44,10 @@ being compared, so a difference of exactly \code{tolerance} counts as agreement
 and \code{0.1 + 0.2} equals \code{0.3}; it is numerical equality rather than bit
 identity. The allowance is far smaller than any meaningful rating
 difference, so a genuinely different pair is never counted as agreeing.
-Used for percent agreement calculation.}
+Used for percent agreement at ordinal, interval and ratio level, where
+the ratings are numbers. Nominal categories agree only when identical,
+as do ordinal categories given as text, and a positive \code{tolerance} on
+text categories draws a warning since it cannot be applied.}
 
 \item{ci}{Confidence interval method:
 \describe{
@@ -123,6 +126,16 @@ formula which accounts for proportional differences.
 Kendall's W, ICC, and percent agreement are computed using all raters
 simultaneously. For 3 or more raters, Spearman's rho and Pearson's r are
 computed as the mean of all pairwise correlations between raters.
+
+\strong{How ratings are read.} At ordinal, interval and ratio level every
+coder's ratings are read as numbers, whatever type they are stored as, so a
+column of digits held as text is compared on its values and not on the
+alphabetical order of its strings. A value that does not read as a number
+is an error at interval and ratio level, naming the coder and the values.
+At ordinal level the categories may instead all be text, in which case they
+are ranked by their sorted labels; numbers from one coder and text from
+another cannot be placed on one scale and are an error. Nominal ratings are
+compared as text.
 
 \strong{Per-category statistics.} When \code{by_category = TRUE} and \code{level = "nominal"},
 the result also includes one row per category for \code{alpha_per_value} (from

--- a/man/qlm_validate.Rd
+++ b/man/qlm_validate.Rd
@@ -120,6 +120,13 @@ continuous measurements). Metrics: ICC (intraclass correlation), Pearson's r
 error).
 }
 
+At ordinal and interval level the predictions and the gold standard are
+read as numbers, whatever type they are stored as, so a column of digits
+held as text is compared on its values and not on the alphabetical order of
+its strings. A value that does not read as a number is an error at interval
+level. Ordinal categories may instead all be text, in which case they are
+ranked by their sorted labels.
+
 For multiclass problems with nominal data, the \code{average} parameter controls
 how per-class metrics are aggregated:
 \itemize{

--- a/tests/testthat/test-qlm_compare.R
+++ b/tests/testthat/test-qlm_compare.R
@@ -772,6 +772,32 @@ test_that("bootstrap CIs use the typed ratings too (#150)", {
 })
 
 
+test_that("a variable one coder never rated is skipped, not refused (#150)", {
+  # Typing the columns before dropping incomplete units read an all-missing
+  # column as numbers and refused it against the other coder's text categories,
+  # which aborted the whole call and lost the variables that could be compared.
+  x <- as_qlm_coded(data.frame(.id = 1:3, a = NA_character_, b = 1:3),
+                    id = .id, name = "x")
+  y <- as_qlm_coded(data.frame(.id = 1:3, a = c("low", "mid", "high"), b = 1:3),
+                    id = .id, name = "y")
+
+  expect_warning(
+    res <- as.data.frame(qlm_compare(x, y, by = c("a", "b"),
+                                     level = c(a = "ordinal", b = "interval"))),
+    "No complete cases"
+  )
+  expect_equal(unique(res$variable), "b")
+  expect_equal(res$value[res$measure == "percent_agreement"], 1)
+
+  # A value that is not a number in a unit both coders rated is still refused
+  z <- as_qlm_coded(data.frame(.id = 1:3, a = c(NA, "2", "high"), b = 1:3),
+                    id = .id, name = "z")
+  w <- as_qlm_coded(data.frame(.id = 1:3, a = c(1, 2, 3), b = 1:3),
+                    id = .id, name = "w")
+  expect_error(qlm_compare(w, z, by = "a", level = "interval"), "must be numbers")
+})
+
+
 test_that("ratings_matrix() types the columns by level (#150)", {
   cols <- data.frame(A = c(1, 2), B = c("1", "2"), stringsAsFactors = FALSE)
 

--- a/tests/testthat/test-qlm_compare.R
+++ b/tests/testthat/test-qlm_compare.R
@@ -668,6 +668,129 @@ test_that("nominal comparison is unaffected by the tolerance change (#121)", {
 })
 
 
+# ---- ratings typed by the declared level, not by storage (#150) --------------
+
+test_that("tolerance is honoured when one coder stores the ratings as text (#150)", {
+  # The issue's example: one genuine difference of 1, compared at tolerance 1
+  expect_equal(compare_pair(c(1, 2, 3, 4), c("1", "2", "3", "5"), tolerance = 1), 1)
+  expect_equal(compare_pair(c(1, 2, 3, 4), c("1", "2", "3", "5"), tolerance = 0), 0.75)
+  expect_equal(compare_pair(c(1, 2, 3, 4), c("1", "2", "3", "5"), tolerance = 1,
+                            level = "ordinal"), 1)
+})
+
+
+test_that("text digits are compared on their values, not their sorted strings (#150)", {
+  numbers <- list(A = c(1, 2, 10, 3), B = c(1, 2, 9, 3))
+  text <- lapply(numbers, as.character)
+
+  for (level in c("ordinal", "interval", "ratio")) {
+    from_numbers <- as.data.frame(qlm_compare(
+      as_qlm_coded(data.frame(.id = 1:4, g = numbers$A), id = .id, name = "A"),
+      as_qlm_coded(data.frame(.id = 1:4, g = numbers$B), id = .id, name = "B"),
+      by = "g", level = level
+    ))
+    from_text <- as.data.frame(qlm_compare(
+      as_qlm_coded(data.frame(.id = 1:4, g = text$A), id = .id, name = "A"),
+      as_qlm_coded(data.frame(.id = 1:4, g = text$B), id = .id, name = "B"),
+      by = "g", level = level
+    ))
+    mixed <- as.data.frame(qlm_compare(
+      as_qlm_coded(data.frame(.id = 1:4, g = numbers$A), id = .id, name = "A"),
+      as_qlm_coded(data.frame(.id = 1:4, g = text$B), id = .id, name = "B"),
+      by = "g", level = level
+    ))
+    expect_equal(from_text$measure, from_numbers$measure)
+    expect_equal(from_text$value, from_numbers$value)
+    expect_equal(mixed$value, from_numbers$value)
+  }
+})
+
+
+test_that("a rating that is not a number is an error at interval level (#150)", {
+  x <- as_qlm_coded(data.frame(.id = 1:3, g = c(1, 2, 3)), id = .id, name = "human")
+  y <- as_qlm_coded(data.frame(.id = 1:3, g = c("1", "high", "n/a")), id = .id, name = "llm")
+
+  err <- expect_error(qlm_compare(x, y, by = "g", level = "interval"), "must be numbers")
+  expect_match(conditionMessage(err), "llm")
+  expect_match(conditionMessage(err), "high")
+  expect_match(conditionMessage(err), "n/a")
+  expect_no_match(conditionMessage(err), "human")
+
+  expect_error(qlm_compare(x, y, by = "g", level = "ratio"), "must be numbers")
+  # Nominal has no such requirement
+  expect_no_error(qlm_compare(x, y, by = "g", level = "nominal"))
+})
+
+
+test_that("ordinal text categories rank as before, and a tolerance on them warns (#150)", {
+  a <- c("low", "mid", "high", "low")
+  b <- c("low", "high", "high", "mid")
+
+  expect_no_warning(pct <- compare_pair(a, b, tolerance = 0, level = "ordinal"))
+  expect_equal(pct, 0.5)
+
+  expect_warning(
+    pct_tol <- compare_pair(a, b, tolerance = 1, level = "ordinal"),
+    "Ignoring `tolerance`"
+  )
+  expect_equal(pct_tol, 0.5)
+})
+
+
+test_that("numbers from one coder and text from another is an error at ordinal level (#150)", {
+  expect_error(
+    compare_pair(c(1, 2, 3), c("low", "mid", "high"), tolerance = 0, level = "ordinal"),
+    "must be numbers"
+  )
+})
+
+
+test_that("nominal categories agree only when identical, whatever the tolerance (#150)", {
+  expect_equal(compare_pair(c(1, 2), c(1, 3), tolerance = 1, level = "nominal"), 0.5)
+  expect_equal(compare_pair(c(1, 2), c("1", "2"), tolerance = 0, level = "nominal"), 1)
+})
+
+
+test_that("factor ratings are read by their labels at a numeric level (#150)", {
+  expect_equal(compare_pair(factor(c("1", "2", "10")), c(1, 2, 10), tolerance = 0), 1)
+  expect_equal(compare_pair(factor(c("1", "2", "10")), c(1, 2, 9), tolerance = 1), 1)
+})
+
+
+test_that("bootstrap CIs use the typed ratings too (#150)", {
+  x <- as_qlm_coded(data.frame(.id = 1:6, g = c(1, 2, 3, 4, 5, 6)), id = .id, name = "A")
+  y <- as_qlm_coded(data.frame(.id = 1:6, g = c("1", "2", "3", "5", "5", "6")),
+                    id = .id, name = "B")
+
+  set.seed(150)
+  res <- as.data.frame(qlm_compare(x, y, by = "g", level = "interval", tolerance = 1,
+                                   ci = "bootstrap", bootstrap_n = 20))
+  pct <- res[res$measure == "percent_agreement", ]
+  expect_equal(pct$value, 1)
+  expect_equal(pct$ci_lower, 1)
+  expect_equal(pct$ci_upper, 1)
+})
+
+
+test_that("ratings_matrix() types the columns by level (#150)", {
+  cols <- data.frame(A = c(1, 2), B = c("1", "2"), stringsAsFactors = FALSE)
+
+  expect_true(is.numeric(ratings_matrix(cols, "interval", "g")))
+  expect_true(is.numeric(ratings_matrix(cols, "ratio", "g")))
+  expect_true(is.numeric(ratings_matrix(cols, "ordinal", "g")))
+  expect_equal(unname(ratings_matrix(cols, "interval", "g")[, "B"]), c(1, 2))
+  expect_equal(colnames(ratings_matrix(cols, "interval", "g")), c("A", "B"))
+
+  # Nominal keeps the stored types, so a mixed frame is text
+  expect_true(is.character(ratings_matrix(cols, "nominal", "g")))
+  expect_true(is.numeric(ratings_matrix(cols["A"], "nominal", "g")))
+
+  # A missing rating is not an unreadable one
+  with_na <- data.frame(A = c(1, NA), B = c("1", NA), stringsAsFactors = FALSE)
+  expect_true(is.numeric(ratings_matrix(with_na, "interval", "g")))
+})
+
+
 test_that("qlm_compare refuses objects whose .id is not a key, whatever their class", {
   x <- as_qlm_coded(data.frame(.id = c("a", "b"), score = c(1, 0)), name = "A")
   # Row subsetting keeps the class, and refuses to repeat an identifier

--- a/tests/testthat/test-qlm_validate.R
+++ b/tests/testthat/test-qlm_validate.R
@@ -793,3 +793,67 @@ test_that("qlm_validate refuses objects whose .id is not a key, whatever their c
     "must be unique"
   )
 })
+
+
+# ---- ordinal and interval values read as numbers (#150) ----------------------
+
+test_that("qlm_validate ranks ordinal ratings by their values, not their sorted strings (#150)", {
+  truth <- data.frame(.id = 1:12, g = c(1:10, 2, 9))
+  est <- data.frame(.id = 1:12, g = c(1:10, 3, 10))
+  gold <- as_qlm_coded(truth, id = .id, name = "gold")
+  pred <- as_qlm_coded(est, id = .id, name = "pred")
+
+  v <- as.data.frame(qlm_validate(pred, gold = gold, by = "g", level = "ordinal"))
+  expect_equal(v$value[v$measure == "rho"], cor(truth$g, est$g, method = "spearman"))
+  expect_equal(v$value[v$measure == "tau"], cor(truth$g, est$g, method = "kendall"))
+  expect_equal(v$value[v$measure == "mae"], mean(abs(truth$g - est$g)))
+
+  # The same ratings held as text give the same answer
+  pred_text <- as_qlm_coded(data.frame(.id = 1:12, g = as.character(est$g)),
+                            id = .id, name = "pred")
+  v_text <- as.data.frame(qlm_validate(pred_text, gold = gold, by = "g", level = "ordinal"))
+  expect_equal(v_text$value, v$value)
+
+  # And the interval measures are unchanged by the storage type
+  i <- as.data.frame(qlm_validate(pred, gold = gold, by = "g", level = "interval"))
+  i_text <- as.data.frame(qlm_validate(pred_text, gold = gold, by = "g", level = "interval"))
+  expect_equal(i$value[i$measure == "r"], cor(truth$g, est$g))
+  expect_equal(i_text$value, i$value)
+})
+
+
+test_that("qlm_validate bootstrap CIs on ordinal data bracket the value-based estimate (#150)", {
+  truth <- data.frame(.id = 1:12, g = c(1:10, 2, 9))
+  est <- data.frame(.id = 1:12, g = c(1:10, 3, 10))
+  gold <- as_qlm_coded(truth, id = .id, name = "gold")
+  pred <- as_qlm_coded(est, id = .id, name = "pred")
+
+  set.seed(150)
+  v <- as.data.frame(qlm_validate(pred, gold = gold, by = "g", level = "ordinal",
+                                  ci = "bootstrap", bootstrap_n = 50))
+  mae <- v[v$measure == "mae", ]
+  expect_equal(mae$value, mean(abs(truth$g - est$g)))
+  expect_lte(mae$ci_lower, mae$value)
+  expect_gte(mae$ci_upper, mae$value)
+  expect_lt(mae$ci_upper, 0.75)  # the string-sorted ranks gave 0.75
+})
+
+
+test_that("qlm_validate refuses a rating that is not a number at interval level (#150)", {
+  gold <- as_qlm_coded(data.frame(.id = 1:3, g = c(1, 2, 3)), id = .id, name = "gold")
+  pred <- as_qlm_coded(data.frame(.id = 1:3, g = c("1", "2", "unclear")), id = .id, name = "pred")
+
+  err <- expect_error(qlm_validate(pred, gold = gold, by = "g", level = "interval"),
+                      "must be numbers")
+  expect_match(conditionMessage(err), "unclear")
+  expect_match(conditionMessage(err), "pred")
+})
+
+
+test_that("qlm_validate ordinal text categories are still ranked by their sorted labels (#150)", {
+  gold <- as_qlm_coded(data.frame(.id = 1:4, g = c("a", "b", "c", "a")), id = .id, name = "gold")
+  pred <- as_qlm_coded(data.frame(.id = 1:4, g = c("a", "b", "c", "b")), id = .id, name = "pred")
+
+  v <- as.data.frame(qlm_validate(pred, gold = gold, by = "g", level = "ordinal"))
+  expect_equal(v$value[v$measure == "mae"], 0.25)
+})


### PR DESCRIPTION
Fixes #150.

## What was wrong

`qlm_compare()` built the ratings matrix with `as.matrix()` before looking at the coders' column types. A matrix has one type, so one character column made every column character, and two things then went wrong with nothing in the output to show it:

- **`tolerance` was inert.** The per-row test that chose between the tolerance comparison and text equality ran inside `apply()`, which had already handed it text. The issue's example gives 0.75 at `tolerance = 1` where 1 is right.
- **The numeric statistics ran on the wrong values.** `convert_to_numeric()` turned the strings into factor codes of their sorted order, where `"10"` falls between `"1"` and `"2"`. No mixing is needed for this one: digits held as text are enough.

| ratings `(1, 2, 10)` vs `(1, 2, 9)`, interval | stored as numbers | stored as text |
|---|---|---|
| alpha_interval | 0.990 | 0.545 |
| icc | 0.992 | 0.600 |
| r | 0.9999 | 0.655 |

The issue asked whether `qlm_validate()` shares the pattern. It does, by another route: it sorts the values as strings to build the factor levels and takes the ordinal ranks from those codes, so on a 1 to 10 scale rho, tau and MAE are wrong from purely numeric input. Twelve ratings on that scale, two of them off by one:

| ordinal, 1 to 10 | reported | correct |
|---|---|---|
| rho | 0.68 | 0.99 |
| tau | 0.72 | 0.97 |
| mae | 0.75 | 0.17 |

## The fix

A new internal helper, `ratings_matrix()`, settles the type per column, before the matrix exists, from the level the caller declared rather than from how each coder stored the values. Both functions use it.

- **Ordinal, interval and ratio** read every column as numbers, whatever its storage type. A value that does not read as a number is an error naming the coder and the values. Reading it as missing instead would drop the unit as silently as before.
- **Ordinal text categories** (all coders text) are ranked by sorted label as before. A positive `tolerance` on them now draws a warning rather than being ignored. Numbers from one coder against text from another is an error.
- **Nominal** ratings are left as stored and agree only when identical. The comment above the old per-row test claimed this already; the code applied `tolerance` to numeric nominal codes. This is the one deliberate behaviour change beyond the bug, and it is called out in NEWS.
- The agreement rule in `compute_reliability_by_level()` is chosen once from the matrix and the level, since a per-row type test can never see a mixed frame.

## Not done here

Ordinal text categories are still ordered alphabetically (`"high" < "low" < "medium"`) in both functions, and factor levels are not consulted. That is a pre-existing and separate problem, worth its own issue.

## Tests

Thirteen new tests: the issue's example, text digits against numeric digits at every numeric level giving identical output, the error and warning paths, nominal ignoring `tolerance`, factor columns, the bootstrap path, and the `qlm_validate()` ranks checked against `cor()` on the values. Full suite passes; `R CMD check --as-cran --no-manual` gives only the dev-version NOTE.
