### PR TITLE
Keep credential values out of the audit trail

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 ## Bug fixes
 
+* `qlm_trail()` no longer writes credentials into the trail. An `api_key`,
+  a credential-named `api_headers` entry, or a `base_url` carrying userinfo
+  or a credential-named query parameter, given to `qlm_code()` as a literal,
+  previously appeared verbatim in the report's Call section and in the saved
+  `.rds`. Their values are now replaced by `"<redacted>"` in each run's
+  recorded call and chat arguments, in the returned trail and in both files,
+  and a message says which runs were affected. Reading the key where it is
+  needed, through an environment variable or
+  `credentials = function() Sys.getenv(...)`, keeps it out of the record
+  entirely and is the recommended form (#154).
+
 * `qlm_compare()` now honours `tolerance`, and computes its numeric
   statistics on the ratings' values, when a coder stores the ratings as
   text. The ratings were assembled into one matrix before their type was

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,10 +8,11 @@
   previously appeared verbatim in the report's Call section and in the saved
   `.rds`. Their values are now replaced by `"<redacted>"` in each run's
   recorded call and chat arguments, in the returned trail and in both files,
-  and a message says which runs were affected. Reading the key where it is
-  needed, through an environment variable or
-  `credentials = function() Sys.getenv(...)`, keeps it out of the record
-  entirely and is the recommended form (#154).
+  and a message says which runs were affected. A `credentials` callback is
+  kept only as `function() Sys.getenv("NAME")`, rebuilt without its
+  environment; any other callback is redacted too. Reading the key where it
+  is needed, through an environment variable or that callback form, keeps
+  it out of the record entirely and is the recommended form (#154).
 
 * `qlm_compare()` now honours `tolerance`, and computes its numeric
   statistics on the ratings' values, when a coder stores the ratings as

--- a/R/credentials.R
+++ b/R/credentials.R
@@ -29,10 +29,17 @@ url_arg_names <- c("base_url", "endpoint")
 #'
 #' Only literals are redacted from the call. An argument given as a variable
 #' or an expression, `api_key = key` or `api_key = Sys.getenv("KEY")`, names
-#' where the value came from rather than containing it, and stays. A
-#' `credentials` function is left whole for the same reason: it is recorded as
-#' written, which is safe when it reads an environment variable, and that is
-#' the recommended form.
+#' where the value came from rather than containing it, and stays.
+#'
+#' A `credentials` callback is a literal of its own kind: ellmer calls it for
+#' the secret, so `function() "sk-..."` holds the value as surely as
+#' `api_key = "sk-..."` does, and a closure serialised to the `.rds` carries
+#' its enclosing environment with whatever that captured. The one form that
+#' is kept is a zero-argument function whose body is a single
+#' `Sys.getenv("NAME")`, which names a variable rather than holding a value;
+#' it is rebuilt in the base environment so that nothing captured travels
+#' with it. Any other callback becomes `"<redacted>"`, in `chat_args` and in
+#' the call.
 #'
 #' @param meta A `meta` attribute as built by `new_qlm_coded()` and its
 #'   counterparts for comparisons and validations.
@@ -69,6 +76,9 @@ redact_chat_args <- function(chat_args) {
   if (!is.null(chat_args[["api_headers"]])) {
     chat_args[["api_headers"]] <- redact_headers(chat_args[["api_headers"]])
   }
+  if (!is.null(chat_args[["credentials"]])) {
+    chat_args[["credentials"]] <- redact_credentials(chat_args[["credentials"]])
+  }
   for (arg in intersect(names(chat_args), url_arg_names)) {
     if (is.character(chat_args[[arg]])) {
       chat_args[[arg]] <- redact_url(chat_args[[arg]])
@@ -104,6 +114,8 @@ redact_call <- function(call) {
       call[[i]] <- REDACTED
     } else if (identical(nm, "api_headers")) {
       call[[i]] <- redact_header_expr(value)
+    } else if (identical(nm, "credentials")) {
+      call[[i]] <- redact_credentials_expr(value)
     } else if (nm %in% url_arg_names && is.character(value)) {
       call[[i]] <- redact_url(value)
     }
@@ -159,6 +171,82 @@ redact_header_expr <- function(expr) {
   }
 
   expr
+}
+
+
+#' Redact a `credentials` callback held in `chat_args`
+#'
+#' A recognised safe callback is rebuilt from its body alone, in the base
+#' environment, so that the function serialised into the `.rds` carries no
+#' captured environment. Anything else, a function with another body or
+#' with arguments (a default can hold a secret), or a value that is not a
+#' function at all, becomes `"<redacted>"`.
+#'
+#' @param f The recorded `credentials` value.
+#'
+#' @return A rebuilt function, or `"<redacted>"`.
+#' @keywords internal
+#' @noRd
+redact_credentials <- function(f) {
+  if (!is.function(f) || is.primitive(f) || !is.null(formals(f)) ||
+      !is_safe_credentials_body(body(f))) {
+    return(REDACTED)
+  }
+  as.function(list(body(f)), envir = baseenv())
+}
+
+
+#' Redact a `credentials` argument in a recorded call
+#'
+#' A `function` literal is kept only in the recognised safe form, and then
+#' rebuilt from its parts so that no source reference, which can carry text
+#' beyond the code, travels with it. A variable or any other expression names
+#' a source and stays as written.
+#'
+#' @param expr The `credentials` argument of a recorded call.
+#'
+#' @return `expr`, a rebuilt function expression, or `"<redacted>"`.
+#' @keywords internal
+#' @noRd
+redact_credentials_expr <- function(expr) {
+  if (!is.call(expr) || !identical(expr[[1]], as.name("function"))) {
+    return(expr)
+  }
+  if (!is.null(expr[[2]]) || !is_safe_credentials_body(expr[[3]])) {
+    return(REDACTED)
+  }
+  as.call(list(as.name("function"), NULL, expr[[3]], NULL))
+}
+
+
+#' Is this function body a bare `Sys.getenv("NAME")`?
+#'
+#' Exactly one call, optionally wrapped in braces, to `Sys.getenv` or
+#' `base::Sys.getenv`, with a single string argument. A second argument is
+#' refused because `Sys.getenv("NAME", unset = "sk-...")` would hold the
+#' secret as its fallback.
+#'
+#' @param body A function body or expression.
+#'
+#' @return `TRUE` for the safe form only.
+#' @keywords internal
+#' @noRd
+is_safe_credentials_body <- function(body) {
+  if (is.call(body) && identical(body[[1]], as.name("{"))) {
+    if (length(body) != 2L) {
+      return(FALSE)
+    }
+    body <- body[[2]]
+  }
+  if (!is.call(body) || length(body) != 2L) {
+    return(FALSE)
+  }
+
+  fn <- body[[1]]
+  is_getenv <- identical(fn, quote(Sys.getenv)) || identical(fn, quote(base::Sys.getenv))
+  arg_name <- names(body)[2] %||% ""
+  is_getenv && is.character(body[[2]]) && length(body[[2]]) == 1L &&
+    arg_name %in% c("", "x")
 }
 
 

--- a/R/credentials.R
+++ b/R/credentials.R
@@ -1,0 +1,215 @@
+#' Placeholder written in place of a credential value
+#' @keywords internal
+#' @noRd
+REDACTED <- "<redacted>"
+
+#' Arguments to `ellmer::chat()` that hold a URL
+#' @keywords internal
+#' @noRd
+url_arg_names <- c("base_url", "endpoint")
+
+
+#' Redact credentials from a run's recorded metadata
+#'
+#' A trail is written to be handed to someone else, so it must not carry the
+#' value of any credential the run was configured with. What is kept is that a
+#' credential was supplied, and where; its value becomes `"<redacted>"`.
+#'
+#' Three routes carry a credential into a run's metadata, and each is closed:
+#'
+#' - `api_key`, as a value in `chat_args` or a string literal in the call.
+#' - `api_headers`, whose entries named like a credential (`Authorization`,
+#'   `x-api-key`, and so on) have their values replaced, in `chat_args` and in
+#'   a `c()` or `list()` literal in the call. Other headers, such as
+#'   `anthropic-beta`, describe the request and are kept.
+#' - A URL argument (`base_url`, `endpoint`) carrying userinfo
+#'   (`https://user:token@host`) or a credential-named query parameter
+#'   (`?api_key=...`), in `chat_args` and as a string literal in the call.
+#'   Other query parameters, such as Azure's `api-version`, are kept.
+#'
+#' Only literals are redacted from the call. An argument given as a variable
+#' or an expression, `api_key = key` or `api_key = Sys.getenv("KEY")`, names
+#' where the value came from rather than containing it, and stays. A
+#' `credentials` function is left whole for the same reason: it is recorded as
+#' written, which is safe when it reads an environment variable, and that is
+#' the recommended form.
+#'
+#' @param meta A `meta` attribute as built by `new_qlm_coded()` and its
+#'   counterparts for comparisons and validations.
+#'
+#' @return `meta` with `object$call` and `object$chat_args` redacted.
+#' @keywords internal
+#' @noRd
+redact_meta <- function(meta) {
+  if (!is.null(meta$object[["call"]])) {
+    meta$object[["call"]] <- redact_call(meta$object[["call"]])
+  }
+  if (!is.null(meta$object[["chat_args"]])) {
+    meta$object[["chat_args"]] <- redact_chat_args(meta$object[["chat_args"]])
+  }
+  meta
+}
+
+
+#' Redact credential values in a list of `ellmer::chat()` arguments
+#'
+#' @param chat_args A named list, as recorded in `meta$object$chat_args`.
+#'
+#' @return The list with credential values replaced.
+#' @keywords internal
+#' @noRd
+redact_chat_args <- function(chat_args) {
+  if (!is.list(chat_args) || is.null(names(chat_args))) {
+    return(chat_args)
+  }
+
+  if (!is.null(chat_args[["api_key"]])) {
+    chat_args[["api_key"]] <- REDACTED
+  }
+  if (!is.null(chat_args[["api_headers"]])) {
+    chat_args[["api_headers"]] <- redact_headers(chat_args[["api_headers"]])
+  }
+  for (arg in intersect(names(chat_args), url_arg_names)) {
+    if (is.character(chat_args[[arg]])) {
+      chat_args[[arg]] <- redact_url(chat_args[[arg]])
+    }
+  }
+
+  chat_args
+}
+
+
+#' Redact credential literals in a recorded call
+#'
+#' @param call A call, as recorded by `match.call()` in `qlm_code()`.
+#'
+#' @return The call with credential literals replaced.
+#' @keywords internal
+#' @noRd
+redact_call <- function(call) {
+  if (!is.call(call)) {
+    return(call)
+  }
+  nms <- names(call)
+  if (is.null(nms)) {
+    return(call)
+  }
+
+  for (i in seq_along(call)[-1]) {
+    nm <- nms[i]
+    if (!nzchar(nm)) next
+    value <- call[[i]]
+
+    if (identical(nm, "api_key") && is.character(value)) {
+      call[[i]] <- REDACTED
+    } else if (identical(nm, "api_headers")) {
+      call[[i]] <- redact_header_expr(value)
+    } else if (nm %in% url_arg_names && is.character(value)) {
+      call[[i]] <- redact_url(value)
+    }
+  }
+
+  call
+}
+
+
+#' Redact the values of credential-named headers
+#'
+#' @param headers A named character vector or list, as passed to
+#'   `api_headers`.
+#'
+#' @return `headers` with matching values replaced.
+#' @keywords internal
+#' @noRd
+redact_headers <- function(headers) {
+  nms <- names(headers)
+  if (is.null(nms)) {
+    return(headers)
+  }
+  hit <- nzchar(nms) & is_credential_name(nms)
+  headers[hit] <- REDACTED
+  headers
+}
+
+
+#' Redact credential-named string literals in a header expression
+#'
+#' Handles the literal form, `c(Authorization = "Bearer ...")` or the same
+#' with `list()`. A header given as a variable or built by an expression is
+#' left as written.
+#'
+#' @param expr The `api_headers` argument of a recorded call.
+#'
+#' @return `expr` with matching string literals replaced.
+#' @keywords internal
+#' @noRd
+redact_header_expr <- function(expr) {
+  if (!is.call(expr)) {
+    return(expr)
+  }
+  nms <- names(expr)
+  if (is.null(nms)) {
+    return(expr)
+  }
+
+  for (i in seq_along(expr)[-1]) {
+    if (nzchar(nms[i]) && is_credential_name(nms[i]) && is.character(expr[[i]])) {
+      expr[[i]] <- REDACTED
+    }
+  }
+
+  expr
+}
+
+
+#' Redact credentials embedded in a URL
+#'
+#' Userinfo is dropped altogether: it is not part of the endpoint's identity
+#' and the fact that it was present is recorded by nothing being there. A
+#' credential-named query parameter keeps its name and loses its value, so
+#' the record still shows that the endpoint was addressed with, say, an
+#' `api_key` parameter.
+#'
+#' @param url A single string. Anything else is returned as is.
+#'
+#' @return The URL with credentials replaced.
+#' @keywords internal
+#' @noRd
+redact_url <- function(url) {
+  if (length(url) != 1L || !is.character(url) || is.na(url)) {
+    return(url)
+  }
+
+  url <- sub("^(\\w+://)[^/@?#]*@", "\\1", url)
+
+  query <- regexpr("\\?[^#]*", url)
+  if (query > 0L) {
+    params <- substring(url, query + 1L, query + attr(query, "match.length") - 1L)
+    params <- strsplit(params, "&", fixed = TRUE)[[1]]
+    param_names <- sub("=.*$", "", params)
+    hit <- grepl("=", params, fixed = TRUE) & is_credential_name(param_names)
+    params[hit] <- paste0(param_names[hit], "=", REDACTED)
+    regmatches(url, query) <- paste0("?", paste(params, collapse = "&"))
+  }
+
+  url
+}
+
+
+#' Does a header or query parameter name look like it carries a credential?
+#'
+#' Matched by substring, case-insensitively, so `Authorization`,
+#' `Proxy-Authorization`, `x-api-key`, `Ocp-Apim-Subscription-Key`,
+#' `X-Auth-Token`, Azure's SAS `sig` and a `?token=` parameter are all caught.
+#' Erring towards redaction is the right side to err on: a value wrongly
+#' redacted costs a reader one lookup, a value wrongly kept is a leak.
+#'
+#' @param x A character vector of names.
+#'
+#' @return A logical vector.
+#' @keywords internal
+#' @noRd
+is_credential_name <- function(x) {
+  grepl("auth|key|token|secret|passw|credential|cookie|session|sig", x,
+        ignore.case = TRUE)
+}

--- a/R/qlm_trail.R
+++ b/R/qlm_trail.R
@@ -39,6 +39,24 @@
 #'   \item `{path}.qmd`: Quarto document with full audit trail documentation
 #' }
 #'
+#' \subsection{Credentials}{
+#' Both files are written to be shared, so neither carries the value of a
+#' credential a run was configured with. An `api_key`, the values of
+#' `api_headers` entries named like a credential, and any userinfo or
+#' credential-named query parameter in a `base_url` are replaced by
+#' `"<redacted>"` in each run's recorded call and chat arguments. The
+#' returned object is redacted in the same way, so the trail in memory and
+#' the two files agree. The trail records that a credential was supplied, not
+#' what it was; a `qlm_coded` object loaded from the `.rds` therefore needs a
+#' credential of its own before it can be replicated.
+#'
+#' Only literal values are redacted from a call. A credential read where it
+#' is needed, through an environment variable ellmer reads by default or a
+#' `credentials = function() Sys.getenv("MY_KEY")` argument, never enters the
+#' record and is the recommended form. A `credentials` function is recorded
+#' as written, so it should not contain the key itself.
+#' }
+#'
 #' @references
 #' Lincoln, Y. S., & Guba, E. G. (1985). *Naturalistic Inquiry*. Sage.
 #'
@@ -73,6 +91,7 @@ qlm_trail <- function(..., path = NULL) {
 
   # Extract runs from all objects
   runs <- list()
+  redacted <- integer()
   for (i in seq_along(objects)) {
     obj <- objects[[i]]
 
@@ -96,6 +115,16 @@ qlm_trail <- function(..., path = NULL) {
       ))
     }
 
+    # A trail is made to be shared. Credential values leave the record here,
+    # before anything is copied out of the metadata, so the returned object,
+    # the .rds and the report agree; see redact_meta().
+    redacted_meta <- redact_meta(meta_attr)
+    if (!identical(redacted_meta, meta_attr)) {
+      redacted <- c(redacted, i)
+      meta_attr <- redacted_meta
+      attr(obj, "meta") <- meta_attr
+    }
+
     # Build a "run" structure for compatibility with trail code
     run <- list(
       name = meta_attr$user$name,
@@ -109,9 +138,10 @@ qlm_trail <- function(..., path = NULL) {
       )
     )
 
-    # Preserve the full object as-is so downstream consumers can replicate
-    # without any lossy conversion. Type-specific mirrors (codebook, chat_args,
-    # etc.) are kept only as convenience pointers for print/report code.
+    # Preserve the full object, minus credential values, so downstream
+    # consumers can replicate without any lossy conversion. Type-specific
+    # mirrors (codebook, chat_args, etc.) are kept only as convenience
+    # pointers for print/report code.
     if (inherits(obj, "qlm_coded")) {
       obj <- check_qlm_coded(obj, what = sprintf("object %d", i))
       run$coded <- obj
@@ -189,6 +219,15 @@ qlm_trail <- function(..., path = NULL) {
     ),
     class = "qlm_trail"
   )
+
+  if (length(redacted) > 0) {
+    indices <- vapply(runs, function(r) r$object_index, integer(1))
+    redacted_runs <- names(runs)[indices %in% redacted]
+    cli::cli_alert_info(paste(
+      "Credential values recorded for {.val {redacted_runs}} are replaced by",
+      "{.val {REDACTED}} in the trail."
+    ))
+  }
 
   # Save if path is provided
 
@@ -1004,10 +1043,10 @@ endpoint_identity <- function(base_url) {
 #' as `?api_key=` as in userinfo, and a trail is written to be handed to
 #' someone else, so neither is printed here.
 #'
-#' This narrows one exposure; it does not make the report credential-free. The
-#' Call section prints `deparse(run$call)`, so a `base_url` written as a
-#' literal at the call site still appears there, and the `.rds` preserves
-#' `chat_args` whole by design. Redacting those is a separate problem.
+#' This is display only. The recorded call and `chat_args` are redacted when
+#' the trail is built, by `redact_meta()`, so the Call section and the `.rds`
+#' are covered there; this keeps the query out of a heading where it would
+#' only be noise.
 #'
 #' Known limitation: an endpoint distinguished only by a query parameter --
 #' Azure's `api-version=`, say -- prints the same label as its sibling, though

--- a/R/qlm_trail.R
+++ b/R/qlm_trail.R
@@ -53,8 +53,10 @@
 #' Only literal values are redacted from a call. A credential read where it
 #' is needed, through an environment variable ellmer reads by default or a
 #' `credentials = function() Sys.getenv("MY_KEY")` argument, never enters the
-#' record and is the recommended form. A `credentials` function is recorded
-#' as written, so it should not contain the key itself.
+#' record and is the recommended form. That is also the only `credentials`
+#' callback the trail keeps, rebuilt without its environment; a callback of
+#' any other shape is replaced by `"<redacted>"`, since it may hold or
+#' capture the secret it returns.
 #' }
 #'
 #' @references

--- a/man/qlm_trail.Rd
+++ b/man/qlm_trail.Rd
@@ -63,8 +63,10 @@ credential of its own before it can be replicated.
 Only literal values are redacted from a call. A credential read where it
 is needed, through an environment variable ellmer reads by default or a
 \code{credentials = function() Sys.getenv("MY_KEY")} argument, never enters the
-record and is the recommended form. A \code{credentials} function is recorded
-as written, so it should not contain the key itself.
+record and is the recommended form. That is also the only \code{credentials}
+callback the trail keeps, rebuilt without its environment; a callback of
+any other shape is replaced by \code{"<redacted>"}, since it may hold or
+capture the secret it returns.
 }
 }
 \examples{

--- a/man/qlm_trail.Rd
+++ b/man/qlm_trail.Rd
@@ -48,6 +48,24 @@ When \code{path} is provided, the function creates:
 \item \verb{\{path\}.rds}: Complete trail object for R (reloadable with \code{readRDS()})
 \item \verb{\{path\}.qmd}: Quarto document with full audit trail documentation
 }
+
+\subsection{Credentials}{
+Both files are written to be shared, so neither carries the value of a
+credential a run was configured with. An \code{api_key}, the values of
+\code{api_headers} entries named like a credential, and any userinfo or
+credential-named query parameter in a \code{base_url} are replaced by
+\code{"<redacted>"} in each run's recorded call and chat arguments. The
+returned object is redacted in the same way, so the trail in memory and
+the two files agree. The trail records that a credential was supplied, not
+what it was; a \code{qlm_coded} object loaded from the \code{.rds} therefore needs a
+credential of its own before it can be replicated.
+
+Only literal values are redacted from a call. A credential read where it
+is needed, through an environment variable ellmer reads by default or a
+\code{credentials = function() Sys.getenv("MY_KEY")} argument, never enters the
+record and is the recommended form. A \code{credentials} function is recorded
+as written, so it should not contain the key itself.
+}
 }
 \examples{
 # Load example coded objects

--- a/tests/testthat/test-credentials.R
+++ b/tests/testthat/test-credentials.R
@@ -53,9 +53,30 @@ test_that("redact_chat_args() handles headers given as a list and Azure's endpoi
   expect_equal(out$endpoint, "https://mine.openai.azure.com")
 })
 
-test_that("redact_chat_args() leaves a credentials function and unnamed input alone", {
-  f <- function() Sys.getenv("KEY")
-  expect_identical(redact_chat_args(list(credentials = f))$credentials, f)
+test_that("redact_chat_args() keeps only a Sys.getenv() credentials callback, rebuilt bare", {
+  f <- local({ captured <- "sk-hidden"; function() Sys.getenv("KEY") })
+  out <- redact_chat_args(list(credentials = f))$credentials
+  expect_true(is.function(out))
+  expect_identical(body(out), quote(Sys.getenv("KEY")))
+  expect_null(formals(out))
+  expect_identical(environment(out), baseenv())
+  expect_equal(out(), Sys.getenv("KEY"))
+
+  # Braces around the one call are fine; base:: is fine
+  expect_true(is.function(redact_chat_args(list(credentials = function() { Sys.getenv("K") }))$credentials))
+  expect_true(is.function(redact_chat_args(list(credentials = function() base::Sys.getenv("K")))$credentials))
+
+  # Anything that can hold the secret is replaced
+  expect_equal(redact_chat_args(list(credentials = function() "sk-secret"))$credentials, "<redacted>")
+  expect_equal(redact_chat_args(list(credentials = local({ k <- "sk"; function() k })))$credentials, "<redacted>")
+  expect_equal(redact_chat_args(list(credentials = function(key = "sk") key))$credentials, "<redacted>")
+  expect_equal(redact_chat_args(list(credentials = function() Sys.getenv("K", "sk-fallback")))$credentials, "<redacted>")
+  expect_equal(redact_chat_args(list(credentials = function() { x <- 1; Sys.getenv("K") }))$credentials, "<redacted>")
+  expect_equal(redact_chat_args(list(credentials = "sk-secret"))$credentials, "<redacted>")
+  expect_equal(redact_chat_args(list(credentials = sum))$credentials, "<redacted>")
+})
+
+test_that("redact_chat_args() leaves unnamed input alone", {
   expect_identical(redact_chat_args(list()), list())
   expect_identical(redact_chat_args(NULL), NULL)
   expect_identical(redact_chat_args(list(1, 2)), list(1, 2))
@@ -85,9 +106,39 @@ test_that("redact_call() keeps an argument that names its source rather than hol
     api_key = Sys.getenv("OPENAI_API_KEY"),
     base_url = my_url,
     api_headers = my_headers,
-    credentials = function() Sys.getenv("KEY")
+    credentials = my_creds
   ))
   expect_identical(redact_call(call), call)
+})
+
+test_that("redact_call() keeps only a Sys.getenv() credentials callback literal", {
+  safe <- quote(qlm_code(x, cb, credentials = function() Sys.getenv("KEY")))
+  expect_identical(redact_call(safe), safe)
+  expect_equal(deparse(redact_call(safe)), 'qlm_code(x, cb, credentials = function() Sys.getenv("KEY"))')
+
+  expect_identical(
+    redact_call(quote(qlm_code(x, cb, credentials = function() "sk-secret"))),
+    quote(qlm_code(x, cb, credentials = "<redacted>"))
+  )
+  expect_identical(
+    redact_call(quote(qlm_code(x, cb, credentials = function(k = "sk") k))),
+    quote(qlm_code(x, cb, credentials = "<redacted>"))
+  )
+  expect_identical(
+    redact_call(quote(qlm_code(x, cb, credentials = function() paste0("sk-", "abc")))),
+    quote(qlm_code(x, cb, credentials = "<redacted>"))
+  )
+})
+
+test_that("a kept callback literal carries no source reference (#154)", {
+  # keep.source = TRUE attaches the source text as the fourth element; a
+  # comment on that line would travel with it
+  old <- options(keep.source = TRUE); withr::defer(options(old))
+  expr <- parse(text = 'qlm_code(x, cb, credentials = function() Sys.getenv("KEY") # sk-in-a-comment\n)',
+                keep.source = TRUE)[[1]]
+  out <- redact_call(expr)
+  expect_null(out$credentials[[4]])
+  expect_false(any(grepl("sk-in-a-comment", deparse(out), fixed = TRUE)))
 })
 
 test_that("redact_call() is a no-op on calls without named arguments and on non-calls", {

--- a/tests/testthat/test-credentials.R
+++ b/tests/testthat/test-credentials.R
@@ -1,0 +1,143 @@
+# ---- redact_url() ------------------------------------------------------------
+
+test_that("redact_url() drops userinfo and keeps the rest of the URL", {
+  expect_equal(redact_url("https://user:tok3n@host/v1"), "https://host/v1")
+  expect_equal(redact_url("https://tok3n@host:8443/v1/"), "https://host:8443/v1/")
+  expect_equal(redact_url("http://localhost:11434"), "http://localhost:11434")
+})
+
+test_that("redact_url() redacts only credential-named query values", {
+  expect_equal(
+    redact_url("https://host/v1?api_key=abc&api-version=2024&sig=xyz"),
+    "https://host/v1?api_key=<redacted>&api-version=2024&sig=<redacted>"
+  )
+  expect_equal(redact_url("https://host/v1?api-version=2024"), "https://host/v1?api-version=2024")
+  # A fragment is not sent to the server and is left alone
+  expect_equal(redact_url("https://host/v1?token=t#frag"), "https://host/v1?token=<redacted>#frag")
+})
+
+test_that("redact_url() leaves anything that is not one string alone", {
+  expect_identical(redact_url(NULL), NULL)
+  expect_identical(redact_url(NA_character_), NA_character_)
+  expect_identical(redact_url(c("a", "b")), c("a", "b"))
+  expect_identical(redact_url(42), 42)
+})
+
+# ---- redact_chat_args() ------------------------------------------------------
+
+test_that("redact_chat_args() replaces api_key and credential headers, keeps the rest", {
+  args <- list(
+    name = "openai/gpt-4o",
+    api_key = "sk-abc",
+    api_headers = c(Authorization = "Bearer x", `anthropic-beta` = "b", `X-Api-Key` = "k"),
+    base_url = "https://u:p@host/v1",
+    params = list(temperature = 0)
+  )
+  out <- redact_chat_args(args)
+  expect_equal(out$api_key, "<redacted>")
+  expect_equal(
+    out$api_headers,
+    c(Authorization = "<redacted>", `anthropic-beta` = "b", `X-Api-Key` = "<redacted>")
+  )
+  expect_equal(out$base_url, "https://host/v1")
+  expect_equal(out$name, "openai/gpt-4o")
+  expect_equal(out$params, list(temperature = 0))
+})
+
+test_that("redact_chat_args() handles headers given as a list and Azure's endpoint", {
+  out <- redact_chat_args(list(
+    api_headers = list(Authorization = "Bearer x", accept = "json"),
+    endpoint = "https://u:p@mine.openai.azure.com"
+  ))
+  expect_equal(out$api_headers, list(Authorization = "<redacted>", accept = "json"))
+  expect_equal(out$endpoint, "https://mine.openai.azure.com")
+})
+
+test_that("redact_chat_args() leaves a credentials function and unnamed input alone", {
+  f <- function() Sys.getenv("KEY")
+  expect_identical(redact_chat_args(list(credentials = f))$credentials, f)
+  expect_identical(redact_chat_args(list()), list())
+  expect_identical(redact_chat_args(NULL), NULL)
+  expect_identical(redact_chat_args(list(1, 2)), list(1, 2))
+})
+
+# ---- redact_call() -----------------------------------------------------------
+
+test_that("redact_call() replaces credential literals and nothing else", {
+  call <- quote(qlm_code(
+    x, cb, model = "m",
+    api_key = "sk-abc",
+    base_url = "https://u:p@host/v1?token=t",
+    api_headers = c(Authorization = "Bearer x", `anthropic-beta` = "b")
+  ))
+  out <- redact_call(call)
+  expect_identical(out, quote(qlm_code(
+    x, cb, model = "m",
+    api_key = "<redacted>",
+    base_url = "https://host/v1?token=<redacted>",
+    api_headers = c(Authorization = "<redacted>", `anthropic-beta` = "b")
+  )))
+})
+
+test_that("redact_call() keeps an argument that names its source rather than holding a value", {
+  call <- quote(qlm_code(
+    x, cb,
+    api_key = Sys.getenv("OPENAI_API_KEY"),
+    base_url = my_url,
+    api_headers = my_headers,
+    credentials = function() Sys.getenv("KEY")
+  ))
+  expect_identical(redact_call(call), call)
+})
+
+test_that("redact_call() is a no-op on calls without named arguments and on non-calls", {
+  expect_identical(redact_call(quote(qlm_code(x, cb))), quote(qlm_code(x, cb)))
+  expect_identical(redact_call(quote(f())), quote(f()))
+  expect_identical(redact_call(NULL), NULL)
+  expect_identical(redact_call("a string"), "a string")
+})
+
+test_that("redact_header_expr() only touches credential-named string literals", {
+  expr <- quote(list(Authorization = paste("Bearer", key), `X-Api-Key` = "k", accept = "json"))
+  out <- redact_header_expr(expr)
+  expect_identical(
+    out,
+    quote(list(Authorization = paste("Bearer", key), `X-Api-Key` = "<redacted>", accept = "json"))
+  )
+  expect_identical(redact_header_expr(quote(c("a", "b"))), quote(c("a", "b")))
+  expect_identical(redact_header_expr(quote(my_headers)), quote(my_headers))
+})
+
+# ---- redact_meta() and is_credential_name() ----------------------------------
+
+test_that("redact_meta() rewrites call and chat_args and leaves other slots alone", {
+  meta <- list(
+    user = list(name = "run1"),
+    object = list(
+      call = quote(qlm_code(x, cb, api_key = "sk-abc")),
+      chat_args = list(name = "m", api_key = "sk-abc"),
+      parent = NULL, n_units = 2
+    ),
+    system = list(timestamp = as.POSIXct("2024-01-01"))
+  )
+  out <- redact_meta(meta)
+  expect_identical(out$object$call, quote(qlm_code(x, cb, api_key = "<redacted>")))
+  expect_equal(out$object$chat_args$api_key, "<redacted>")
+  expect_identical(out$user, meta$user)
+  expect_identical(out$system, meta$system)
+  expect_identical(out$object$n_units, 2)
+
+  # A comparison's metadata has a call but no chat_args
+  comp_meta <- list(object = list(call = quote(qlm_compare(a, b)), parent = c("a", "b")))
+  expect_identical(redact_meta(comp_meta), comp_meta)
+})
+
+test_that("is_credential_name() catches the names credentials travel under", {
+  expect_true(all(is_credential_name(c(
+    "Authorization", "Proxy-Authorization", "x-api-key", "Ocp-Apim-Subscription-Key",
+    "X-Auth-Token", "api_key", "apikey", "sig", "access_token", "Cookie", "password"
+  ))))
+  expect_false(any(is_credential_name(c(
+    "anthropic-beta", "api-version", "accept", "content-type", "OpenAI-Organization", "model"
+  ))))
+})

--- a/tests/testthat/test-qlm_trail.R
+++ b/tests/testthat/test-qlm_trail.R
@@ -764,10 +764,8 @@ test_that("OpenAI-compatible endpoints are no longer collapsed into one (#130)",
 
 
 test_that("a credential in the URL does not appear in the endpoint label (#130)", {
-  # Scoped deliberately to the label. The report is not credential-free: the
-  # Call section prints deparse(run$call), so a base_url written as a literal
-  # at the call site still appears there, and the .rds keeps chat_args whole.
-  # That is a separate problem; this asserts only what this section controls.
+  # Scoped to the label. The recorded call and chat_args are redacted when
+  # the trail is built (#154); this asserts only what this section controls.
   section <- setup_section(endpoint_fixture(
     "openai_compatible/m", "https://user:tok3n@api.example.com/v1?api_key=abc#frag"
   ))
@@ -876,4 +874,94 @@ test_that("a run with no recorded model name does not break the section (#130)",
   # qlm_trail() reports where it saved, so silence is not the assertion here.
   expect_no_error(section <- setup_section(coded))
   expect_length(section, 0)
+})
+
+
+# ---- credentials never reach the trail (#154) --------------------------------
+
+credential_fixture <- function(run = "run1") {
+  coded <- data.frame(.id = 1:2, polarity = c("pos", "neg"))
+  class(coded) <- c("qlm_coded", "data.frame")
+  attr(coded, "run") <- list(
+    name = run, parent = NULL,
+    call = quote(qlm_code(
+      x, cb, model = "openai_compatible/m",
+      base_url = "https://user:s3cret@host/v1?api_key=qs3cret&api-version=2024",
+      api_key = "sk-lit3ral",
+      api_headers = c(Authorization = "Bearer hdr3cret", `anthropic-beta` = "tools-2024")
+    )),
+    metadata = list(timestamp = as.POSIXct("2024-01-01 12:00:00"), n_units = 2),
+    chat_args = list(
+      name = "openai_compatible/m",
+      base_url = "https://user:s3cret@host/v1?api_key=qs3cret&api-version=2024",
+      api_key = "sk-lit3ral",
+      api_headers = c(Authorization = "Bearer hdr3cret", `anthropic-beta` = "tools-2024"),
+      credentials = function() Sys.getenv("MY_KEY")
+    ),
+    codebook = list(name = "sentiment", instructions = "Code sentiment")
+  )
+  coded
+}
+
+secrets <- c("s3cret", "qs3cret", "sk-lit3ral", "hdr3cret")
+
+expect_no_secret <- function(text) {
+  for (secret in secrets) {
+    expect_false(any(grepl(secret, text, fixed = TRUE)), label = secret)
+  }
+}
+
+test_that("qlm_trail() writes no credential into the report or the .rds (#154)", {
+  path <- file.path(tempdir(), "test_trail_credentials")
+  withr::defer(unlink(paste0(path, c(".rds", ".qmd"))))
+
+  expect_message(
+    qlm_trail(credential_fixture(), path = path),
+    "Credential values recorded for \"run1\""
+  )
+
+  report <- readLines(paste0(path, ".qmd"))
+  expect_no_secret(report)
+  # The call is still there, with the shape of what was passed
+  expect_true(any(grepl('api_key = "<redacted>"', report, fixed = TRUE)))
+  expect_true(any(grepl('Authorization = "<redacted>"', report, fixed = TRUE)))
+  expect_true(any(grepl("api-version=2024", report, fixed = TRUE)))
+  expect_true(any(grepl('`anthropic-beta` = "tools-2024"', report, fixed = TRUE)))
+
+  saved <- readRDS(paste0(path, ".rds"))
+  run <- saved$runs[[1]]
+  expect_no_secret(deparse(run$call))
+  expect_no_secret(unlist(run$chat_args[c("base_url", "api_key", "api_headers")]))
+  # The mirror and the object it mirrors agree
+  meta <- attr(run$coded, "meta")$object
+  expect_identical(meta$chat_args[c("base_url", "api_key", "api_headers")],
+                   run$chat_args[c("base_url", "api_key", "api_headers")])
+  expect_identical(meta$call, run$call)
+  # The credentials function is the safe form and is left whole
+  expect_true(is.function(run$chat_args$credentials))
+})
+
+test_that("the returned trail is redacted like the files (#154)", {
+  trail <- suppressMessages(qlm_trail(credential_fixture()))
+  run <- trail$runs[[1]]
+  expect_no_secret(deparse(run$call))
+  expect_no_secret(unlist(run$chat_args[c("base_url", "api_key", "api_headers")]))
+  expect_equal(run$chat_args$api_key, "<redacted>")
+  expect_equal(run$chat_args$base_url, "https://host/v1?api_key=<redacted>&api-version=2024")
+})
+
+test_that("a run with nothing to redact is untouched and gets no message (#154)", {
+  coded <- endpoint_fixture("openai/gpt-4o", "https://api.example.com/v1?api-version=2024")
+  expect_silent(trail <- qlm_trail(coded))
+  run <- trail$runs[[1]]
+  expect_identical(run$call, quote(qlm_code(x, cb)))
+  expect_identical(run$chat_args$base_url, "https://api.example.com/v1?api-version=2024")
+  expect_identical(attr(run$coded, "meta")$object$chat_args, run$chat_args)
+})
+
+test_that("redaction names every affected run once (#154)", {
+  expect_message(
+    qlm_trail(credential_fixture("one"), credential_fixture("two")),
+    "\"one\" and \"two\""
+  )
 })

--- a/tests/testthat/test-qlm_trail.R
+++ b/tests/testthat/test-qlm_trail.R
@@ -888,7 +888,8 @@ credential_fixture <- function(run = "run1") {
       x, cb, model = "openai_compatible/m",
       base_url = "https://user:s3cret@host/v1?api_key=qs3cret&api-version=2024",
       api_key = "sk-lit3ral",
-      api_headers = c(Authorization = "Bearer hdr3cret", `anthropic-beta` = "tools-2024")
+      api_headers = c(Authorization = "Bearer hdr3cret", `anthropic-beta` = "tools-2024"),
+      credentials = function() "cb3cret"
     )),
     metadata = list(timestamp = as.POSIXct("2024-01-01 12:00:00"), n_units = 2),
     chat_args = list(
@@ -896,14 +897,14 @@ credential_fixture <- function(run = "run1") {
       base_url = "https://user:s3cret@host/v1?api_key=qs3cret&api-version=2024",
       api_key = "sk-lit3ral",
       api_headers = c(Authorization = "Bearer hdr3cret", `anthropic-beta` = "tools-2024"),
-      credentials = function() Sys.getenv("MY_KEY")
+      credentials = local({ captured <- "env3cret"; function() "cb3cret" })
     ),
     codebook = list(name = "sentiment", instructions = "Code sentiment")
   )
   coded
 }
 
-secrets <- c("s3cret", "qs3cret", "sk-lit3ral", "hdr3cret")
+secrets <- c("s3cret", "qs3cret", "sk-lit3ral", "hdr3cret", "cb3cret", "env3cret")
 
 expect_no_secret <- function(text) {
   for (secret in secrets) {
@@ -937,8 +938,26 @@ test_that("qlm_trail() writes no credential into the report or the .rds (#154)",
   expect_identical(meta$chat_args[c("base_url", "api_key", "api_headers")],
                    run$chat_args[c("base_url", "api_key", "api_headers")])
   expect_identical(meta$call, run$call)
-  # The credentials function is the safe form and is left whole
+  # A callback that returns a literal is gone, and so is its environment:
+  # the whole file holds neither the literal nor what the closure captured
+  expect_equal(run$chat_args$credentials, "<redacted>")
+  expect_true(any(grepl('credentials = "<redacted>"', report, fixed = TRUE)))
+  rds_file <- paste0(path, ".rds")
+  bytes <- memDecompress(readBin(rds_file, "raw", file.size(rds_file)), "gzip")
+  for (secret in secrets) {
+    expect_length(grepRaw(secret, bytes, fixed = TRUE), 0)
+  }
+})
+
+test_that("a Sys.getenv() credentials callback survives the trail (#154)", {
+  coded <- credential_fixture()
+  attr(coded, "run")$chat_args$credentials <- function() Sys.getenv("MY_KEY")
+  attr(coded, "run")$call <- quote(qlm_code(x, cb, credentials = function() Sys.getenv("MY_KEY")))
+  trail <- suppressMessages(qlm_trail(coded))
+  run <- trail$runs[[1]]
   expect_true(is.function(run$chat_args$credentials))
+  expect_identical(body(run$chat_args$credentials), quote(Sys.getenv("MY_KEY")))
+  expect_identical(run$call, quote(qlm_code(x, cb, credentials = function() Sys.getenv("MY_KEY"))))
 })
 
 test_that("the returned trail is redacted like the files (#154)", {


### PR DESCRIPTION
Fixes #154.

## What

`qlm_trail()` now redacts credential values when it builds the trail, before anything is copied out of a run's metadata, so the returned object, the `.rds` and the `.qmd` all agree. In each run's recorded call and `chat_args`:

- `api_key` becomes `"<redacted>"`
- `api_headers` entries named like a credential (`Authorization`, `x-api-key`, `Ocp-Apim-Subscription-Key`, ...) have their values replaced; other headers such as `anthropic-beta` are kept, since a replicator needs them
- a URL argument (`base_url`, `endpoint`) loses its userinfo, and credential-named query parameters (`?api_key=`, `sig=`) lose their values; `api-version` and the like are kept

Only literals are redacted from the call. `api_key = key` or `api_key = Sys.getenv("KEY")` names where the value came from and stays as written.

A `credentials` callback is treated as a literal of its own kind, since ellmer calls it for the secret and a closure serialised to the `.rds` carries its enclosing environment. Review caught that the first cut left these whole. The one form kept is a zero-argument `function() Sys.getenv("NAME")`, optionally braced, rebuilt in the base environment so nothing captured travels with it, and rebuilt without its source reference in the call. A function with arguments, a second argument to `Sys.getenv()`, or any other body becomes `"<redacted>"`. That form is the documented recommended way to pass a credential.

A message names the runs affected, so the user knows the trail differs from the objects it was built from. Nothing is printed when there is nothing to redact.

## The design call

The issue listed four directions and leaned to redacting the report only, keeping the `.rds` faithful, but flagged that the "faithful record" property was a commitment not to trade away unilaterally. This PR redacts both, and I want to be explicit about why, since it is a judgement call:

- The report tells its reader to load the `.rds`, and its replication section reads codebooks from it. The two files travel together; a report that is safe to attach next to an `.rds` that is not gives a false sense of safety.
- What is lost is only the credential value. A `qlm_coded` object loaded from a trail now needs a credential of its own before `qlm_replicate()` can run it. Anyone entitled to replicate has one, and if the original key was passed as a literal they will have to pass one again either way.
- Redacting at build time, rather than at write time, means the in-memory trail is also clean and there is one code path to test.

If keeping the `.rds` faithful matters more than I have weighed it, the change is easy to narrow: apply `redact_meta()` in `generate_trail_report()` only.

## Scope

- New `R/credentials.R`: `redact_meta()`, `redact_chat_args()`, `redact_call()`, `redact_headers()`, `redact_header_expr()`, `redact_url()`, `is_credential_name()`. All internal.
- `R/qlm_trail.R`: apply redaction when building runs; message; a "Credentials" subsection in `?qlm_trail`; the `endpoint_label()` note that used to say the rest was a separate problem now points here.
- Tests: `tests/testthat/test-credentials.R` for the helpers; four trail-level tests reproducing the issue's example end to end and checking the report, the `.rds` (both the run mirror and the coded object's own metadata), the returned object, the no-op case and the message.
- NEWS entry.

## Testing

- `devtools::test(filter = "credentials|qlm_trail")`: 255 pass, including a raw-bytes scan of the decompressed `.rds` for a key captured in a callback's environment.
- `R CMD check --as-cran`: 1 NOTE (CRAN incoming), no errors or warnings, full suite passes.
- Rerun of the issue's reproducible example: no secret in either file.

