### PR TITLE
Say why cost will be NA before the run

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,16 @@
   is needed, through an environment variable or that callback form, keeps
   it out of the record entirely and is the recommended form (#154).
 
+* `qlm_code()` now says why `cost` will be `NA` when `include_cost = TRUE`
+  cannot be honoured, once and before the run, and keeps the reason with the
+  object so `print()` shows it. ellmer prices from a table fixed at its
+  release, matched exactly on provider and model, and answers `NA` on any
+  miss without saying which kind: DeepSeek and six other providers are absent
+  from the table altogether, so no model of theirs is ever priced; a model
+  newer than the installed ellmer is missed on a provider it otherwise
+  prices; and local endpoints have no per-token charge. Each is now named,
+  since the remedies differ. Token counts are recorded regardless (#135).
+
 * `qlm_compare()` now honours `tolerance`, and computes its numeric
   statistics on the ratings' values, when a coder stores the ratings as
   text. The ratings were assembled into one matrix before their type was

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,9 @@
   from the table altogether, so no model of theirs is ever priced; a model
   newer than the installed ellmer is missed on a provider it otherwise
   prices; and local endpoints have no per-token charge. Each is now named,
-  since the remedies differ. Token counts are recorded regardless (#135).
+  since the remedies differ, and the message says whether the token counts a
+  cost could be worked out from are being recorded, which needs
+  `include_tokens = TRUE` (#135).
 
 * `qlm_compare()` now honours `tolerance`, and computes its numeric
   statistics on the ratings' values, when a coder stores the ratings as

--- a/R/providers.R
+++ b/R/providers.R
@@ -295,3 +295,111 @@ closest_model_names <- function(id, models, n = 3L) {
   candidates <- models[near][order(d[near])]
   utils::head(unique(candidates), n)
 }
+
+
+#' Why a run's cost will be `NA`, if it will be
+#'
+#' ellmer prices a turn by exact lookup of the provider's name and the model
+#' in a table frozen at its build, and answers `NA` on any miss. It does not
+#' say which kind of miss. A provider absent from the table altogether
+#' (DeepSeek and six others as of ellmer 0.4.2) will never price any model,
+#' and only rates supplied by the user can help. A model newer than the
+#' installed ellmer, on a provider it does price, is fixed by upgrading. The
+#' remedies differ, so both are told apart here, before a request is spent,
+#' rather than left to be inferred from a column of `NA` (#135).
+#'
+#' Local endpoints charge nothing per token, so their `NA` is expected rather
+#' than a gap, and is described as such without building a chat: ellmer's
+#' constructors for them look for a running server.
+#'
+#' The table and ellmer's own predicate are read from its namespace at run
+#' time, as the model listing is. Should a later ellmer drop either, no
+#' diagnosis is made and the `NA` stands unexplained, which is what it did
+#' before.
+#'
+#' @param model The model specification, as passed to [qlm_code()].
+#' @param chat_args Arguments for [ellmer::chat()], since the provider's
+#'   display name is known only once the provider is built.
+#'
+#' @return `NULL` when the model is priced. Otherwise a list with `kind`,
+#'   one of `"local"`, `"provider"` or `"model"`; `provider`, ellmer's name
+#'   for it; and `model`.
+#' @keywords internal
+#' @noRd
+unpriced_reason <- function(model, chat_args = list()) {
+  prefix <- model_provider(model)
+  if (prefix %in% c("ollama", "lmstudio", "vllm")) {
+    return(list(kind = "local", provider = prefix,
+                model = sub("^[^/]*/?", "", model)))
+  }
+
+  ns <- asNamespace("ellmer")
+  prices <- get0("prices", envir = ns, inherits = FALSE)
+  has_cost <- get0("has_cost", envir = ns, inherits = FALSE)
+  if (!is.data.frame(prices) || !is.function(has_cost)) {
+    return(NULL)
+  }
+
+  # Building the chat sends nothing. Where it cannot be built, the run itself
+  # will say why; there is nothing to add here.
+  chat <- tryCatch(
+    do.call(ellmer::chat, c(list(name = model), chat_args)),
+    error = function(e) NULL
+  )
+  if (is.null(chat)) {
+    return(NULL)
+  }
+  provider <- chat$get_provider()
+  if (isTRUE(has_cost(provider, provider@model))) {
+    return(NULL)
+  }
+
+  list(
+    kind = if (provider@name %in% prices$provider) "model" else "provider",
+    provider = provider@name,
+    model = provider@model
+  )
+}
+
+
+#' The message for an unpriced run, and the note kept on the object
+#'
+#' @param reason What `unpriced_reason()` returned.
+#'
+#' @return `unpriced_message()`: a character vector for [cli::cli_inform()].
+#'   `unpriced_note()`: one plain sentence, kept in the run's metadata and
+#'   shown by `print.qlm_coded()`.
+#' @keywords internal
+#' @noRd
+unpriced_message <- function(reason) {
+  v <- as.character(utils::packageVersion("ellmer"))
+  # Interpolated here, where `reason` is in scope, rather than by the caller
+  line <- function(...) cli::format_inline(paste0(...))
+  switch(reason$kind,
+    local = c(
+      "i" = line("{.field cost} will be {.code NA}: {reason$provider} runs locally, ",
+                 "and there is no per-token charge to record.")
+    ),
+    provider = c(
+      "i" = line("{.field cost} will be {.code NA}: ellmer {v} has no prices for ",
+                 "{reason$provider} models."),
+      " " = paste0("Token counts are still recorded, so the run can be costed ",
+                   "from the provider's published rates.")
+    ),
+    model = c(
+      "i" = line("{.field cost} will be {.code NA}: ellmer {v} has no price for ",
+                 "{.val {reason$model}}, though it prices other ",
+                 "{reason$provider} models."),
+      " " = "A newer ellmer may price it. Token counts are still recorded."
+    )
+  )
+}
+
+unpriced_note <- function(reason) {
+  switch(reason$kind,
+    local = paste0(reason$provider, " runs locally; no per-token charge"),
+    provider = paste0("ellmer has no prices for ", reason$provider, " models"),
+    model = paste0("ellmer ", utils::packageVersion("ellmer"),
+                   " has no price for ", reason$model)
+  )
+}

--- a/R/providers.R
+++ b/R/providers.R
@@ -308,25 +308,27 @@ closest_model_names <- function(id, models, n = 3L) {
 #' remedies differ, so both are told apart here, before a request is spent,
 #' rather than left to be inferred from a column of `NA` (#135).
 #'
-#' Local endpoints charge nothing per token, so their `NA` is expected rather
-#' than a gap, and is described as such without building a chat: ellmer's
-#' constructors for them look for a running server.
+#' Read from the chat the run itself will use, rather than from one built for
+#' the purpose: building a chat evaluates the credentials, which for some
+#' mechanisms means token discovery or a refresh, and prints ellmer's
+#' default-model message. Local endpoints charge nothing per token, so their
+#' `NA` is expected rather than a gap, and is described as such from the
+#' prefix alone.
 #'
 #' The table and ellmer's own predicate are read from its namespace at run
 #' time, as the model listing is. Should a later ellmer drop either, no
 #' diagnosis is made and the `NA` stands unexplained, which is what it did
 #' before.
 #'
+#' @param chat The [ellmer::Chat] the run will use.
 #' @param model The model specification, as passed to [qlm_code()].
-#' @param chat_args Arguments for [ellmer::chat()], since the provider's
-#'   display name is known only once the provider is built.
 #'
-#' @return `NULL` when the model is priced. Otherwise a list with `kind`,
-#'   one of `"local"`, `"provider"` or `"model"`; `provider`, ellmer's name
-#'   for it; and `model`.
+#' @return `NULL` when the model is priced, or when nothing can be said.
+#'   Otherwise a list with `kind`, one of `"local"`, `"provider"` or
+#'   `"model"`; `provider`, ellmer's name for it; and `model`.
 #' @keywords internal
 #' @noRd
-unpriced_reason <- function(model, chat_args = list()) {
+unpriced_reason <- function(chat, model) {
   prefix <- model_provider(model)
   if (prefix %in% c("ollama", "lmstudio", "vllm")) {
     return(list(kind = "local", provider = prefix,
@@ -340,16 +342,10 @@ unpriced_reason <- function(model, chat_args = list()) {
     return(NULL)
   }
 
-  # Building the chat sends nothing. Where it cannot be built, the run itself
-  # will say why; there is nothing to add here.
-  chat <- tryCatch(
-    do.call(ellmer::chat, c(list(name = model), chat_args)),
-    error = function(e) NULL
-  )
-  if (is.null(chat)) {
+  provider <- tryCatch(chat$get_provider(), error = function(e) NULL)
+  if (is.null(provider)) {
     return(NULL)
   }
-  provider <- chat$get_provider()
   if (isTRUE(has_cost(provider, provider@model))) {
     return(NULL)
   }
@@ -362,19 +358,61 @@ unpriced_reason <- function(model, chat_args = list()) {
 }
 
 
+#' Diagnose an unpriced run from the chat it will use, and say so once
+#'
+#' Called by each coding path right after it builds its chat and before it
+#' sends anything. The structured path may fall back to the JSON path, which
+#' builds a chat of its own; the diagnosis is the same, so the fallback is
+#' told not to repeat the message.
+#'
+#' @param chat The [ellmer::Chat] the path will use.
+#' @param model The model specification.
+#' @param execution_args The caller's execution arguments, for `include_cost`
+#'   and `include_tokens`.
+#' @param say Whether to emit the message.
+#'
+#' @return What `unpriced_reason()` returned, or `NULL` when no cost was
+#'   asked for.
+#' @keywords internal
+#' @noRd
+cost_diagnosis <- function(chat, model, execution_args, say = TRUE) {
+  if (!isTRUE(execution_args$include_cost)) {
+    return(NULL)
+  }
+  reason <- unpriced_reason(chat, model)
+  if (!is.null(reason) && say) {
+    cli::cli_inform(
+      unpriced_message(reason, tokens_recorded = isTRUE(execution_args$include_tokens))
+    )
+  }
+  reason
+}
+
+
 #' The message for an unpriced run, and the note kept on the object
 #'
+#' `include_cost` and `include_tokens` are independent ellmer arguments, so
+#' whether the token counts a cost could be worked out from are being
+#' recorded is a fact about this call, and the message says which.
+#'
 #' @param reason What `unpriced_reason()` returned.
+#' @param tokens_recorded Whether the caller set `include_tokens = TRUE`.
 #'
 #' @return `unpriced_message()`: a character vector for [cli::cli_inform()].
 #'   `unpriced_note()`: one plain sentence, kept in the run's metadata and
 #'   shown by `print.qlm_coded()`.
 #' @keywords internal
 #' @noRd
-unpriced_message <- function(reason) {
+unpriced_message <- function(reason, tokens_recorded = FALSE) {
   v <- as.character(utils::packageVersion("ellmer"))
   # Interpolated here, where `reason` is in scope, rather than by the caller
   line <- function(...) cli::format_inline(paste0(...))
+  tokens <- if (tokens_recorded) {
+    "Token counts are recorded, so the run can be costed from the provider's published rates."
+  } else {
+    line("Set {.code include_tokens = TRUE} to record the token counts, ",
+         "from which the run can be costed at the provider's published rates.")
+  }
   switch(reason$kind,
     local = c(
       "i" = line("{.field cost} will be {.code NA}: {reason$provider} runs locally, ",
@@ -383,14 +421,13 @@ unpriced_message <- function(reason) {
     provider = c(
       "i" = line("{.field cost} will be {.code NA}: ellmer {v} has no prices for ",
                  "{reason$provider} models."),
-      " " = paste0("Token counts are still recorded, so the run can be costed ",
-                   "from the provider's published rates.")
+      " " = tokens
     ),
     model = c(
       "i" = line("{.field cost} will be {.code NA}: ellmer {v} has no price for ",
                  "{.val {reason$model}}, though it prices other ",
                  "{reason$provider} models."),
-      " " = "A newer ellmer may price it. Token counts are still recorded."
+      " " = paste("A newer ellmer may price it.", tokens)
     )
   )
 }

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -111,9 +111,9 @@
 #' a model newer than the installed ellmer is missed on a provider it otherwise
 #' prices, which upgrading fixes; and local endpoints such as ollama have no
 #' per-token charge. In each case `qlm_code()` says so once before the run,
-#' and the reason is kept with the object and shown when it is printed. Token
-#' counts are recorded regardless, so a run can be costed from the provider's
-#' published rates.
+#' and the reason is kept with the object and shown when it is printed. With
+#' `include_tokens = TRUE` the token counts are recorded, from which such a
+#' run can be costed at the provider's published rates.
 #'
 #' @section Schema enforcement:
 #'
@@ -351,17 +351,11 @@ qlm_code <- function(x, codebook, model, ...,
   backend_meta <- list()
   results <- NULL
 
-  # A cost that will come back NA is knowable before any request, and the
-  # reason decides the remedy, so say it once here rather than per row (#135).
-  # The note travels with the object so that the answer outlives the console.
-  cost_note <- NULL
-  if (isTRUE(execution_args$include_cost)) {
-    unpriced <- unpriced_reason(model, chat_args)
-    if (!is.null(unpriced)) {
-      cli::cli_inform(unpriced_message(unpriced))
-      cost_note <- unpriced_note(unpriced)
-    }
-  }
+  # Whether the cost will come back NA, and why, is read by each path from
+  # the chat it builds, before it sends anything (#135). Kept here so the
+  # reason outlives the console: it travels with the object.
+  unpriced <- NULL
+  attempt <- NULL
   fallback_reason <- NULL
   model_hint <- NULL
 
@@ -372,6 +366,8 @@ qlm_code <- function(x, codebook, model, ...,
       chat_args = chat_args, execution_args = execution_args, batch = batch,
       allow_skip = identical(structured, "auto") && !batch
     )
+
+    unpriced <- attempt$unpriced
 
     if (isTRUE(attempt$ok)) {
       results <- attempt$value
@@ -440,10 +436,15 @@ qlm_code <- function(x, codebook, model, ...,
       execution_args = execution_args,
       batch = batch,
       max_retries = max_retries,
-      model_hint = model_hint
+      model_hint = model_hint,
+      cost_message = is.null(attempt)
     )
     backend_meta <- attr(results, "qlm_backend_meta") %||% list()
     attr(results, "qlm_backend_meta") <- NULL
+    if (is.null(unpriced)) {
+      unpriced <- backend_meta$unpriced
+    }
+    backend_meta$unpriced <- NULL
   }
 
   backend_meta$structured <- structured
@@ -472,8 +473,8 @@ qlm_code <- function(x, codebook, model, ...,
 
   # Fields contributed by a provider-specific handler (backend, max_retries, ...)
   metadata <- c(metadata, backend_meta)
-  if (!is.null(cost_note)) {
-    metadata$cost_note <- cost_note
+  if (!is.null(unpriced)) {
+    metadata$cost_note <- unpriced_note(unpriced)
   }
 
   # Add model to chat_args for easy access
@@ -534,7 +535,7 @@ default_structured_mode <- function(model) {
 #' @keywords internal
 #' @noRd
 try_structured_call <- function(x, codebook, model, chat_args, execution_args, batch,
-                                allow_skip = FALSE) {
+                                allow_skip = FALSE, cost_message = TRUE) {
   system_prompt <- if (!is.null(codebook$role)) {
     paste(codebook$role, codebook$instructions, sep = "\n\n")
   } else {
@@ -551,6 +552,9 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
     do.call(ellmer::chat, c(list(name = model, system_prompt = prompt), chat_args))
   }
   chat <- build_chat(system_prompt)
+
+  # From the chat the run will use, before anything is sent (#135)
+  unpriced <- cost_diagnosis(chat, model, execution_args, say = cost_message)
 
   # Whether a failed structured call would even be visible depends on the
   # codebook. Failure is detected from required scalar fields coming back all
@@ -571,6 +575,7 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
   if (undetectable) {
     return(list(
       ok = FALSE,
+      unpriced = unpriced,
       undetectable = TRUE,
       error = paste0(
         "this endpoint's schema enforcement cannot be verified, and the ",
@@ -674,6 +679,7 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
     )
   }
 
+  attempt$unpriced <- unpriced
   attempt
 }
 

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -101,6 +101,20 @@
 #' level does not work: those reach [ellmer::chat()], which has no such
 #' argument. Use `params`.
 #'
+#' @section Cost:
+#'
+#' `include_tokens = TRUE` and `include_cost = TRUE` are forwarded to ellmer,
+#' which adds per-unit token counts and a `cost` column in US dollars. ellmer
+#' prices from a table fixed at its release, matched exactly on provider and
+#' model, and returns `NA` on any miss. Some providers are absent from that
+#' table altogether, DeepSeek among them, so no model of theirs is ever priced;
+#' a model newer than the installed ellmer is missed on a provider it otherwise
+#' prices, which upgrading fixes; and local endpoints such as ollama have no
+#' per-token charge. In each case `qlm_code()` says so once before the run,
+#' and the reason is kept with the object and shown when it is printed. Token
+#' counts are recorded regardless, so a run can be costed from the provider's
+#' published rates.
+#'
 #' @section Schema enforcement:
 #'
 #' Some providers accept a JSON Schema without enforcing it, so a response can
@@ -336,6 +350,18 @@ qlm_code <- function(x, codebook, model, ...,
   # Metadata contributed by the coding path
   backend_meta <- list()
   results <- NULL
+
+  # A cost that will come back NA is knowable before any request, and the
+  # reason decides the remedy, so say it once here rather than per row (#135).
+  # The note travels with the object so that the answer outlives the console.
+  cost_note <- NULL
+  if (isTRUE(execution_args$include_cost)) {
+    unpriced <- unpriced_reason(model, chat_args)
+    if (!is.null(unpriced)) {
+      cli::cli_inform(unpriced_message(unpriced))
+      cost_note <- unpriced_note(unpriced)
+    }
+  }
   fallback_reason <- NULL
   model_hint <- NULL
 
@@ -446,6 +472,9 @@ qlm_code <- function(x, codebook, model, ...,
 
   # Fields contributed by a provider-specific handler (backend, max_retries, ...)
   metadata <- c(metadata, backend_meta)
+  if (!is.null(cost_note)) {
+    metadata$cost_note <- cost_note
+  }
 
   # Add model to chat_args for easy access
   chat_args$name <- model
@@ -1203,6 +1232,11 @@ print.qlm_coded <- function(x, ...) {
 
   if (!is.null(meta_attr$object$parent)) {
     cat("# Parent:   ", meta_attr$object$parent, "\n", sep = "")
+  }
+
+  # Why the cost column is NA, when it was asked for and could not be filled
+  if (!is.null(meta_attr$user$cost_note)) {
+    cat("# Cost:     NA (", meta_attr$user$cost_note, ")\n", sep = "")
   }
 
   # Show notes if present

--- a/R/qlm_code_json.R
+++ b/R/qlm_code_json.R
@@ -25,6 +25,8 @@
 #' @param model_hint What `model_name_hint()` answered when [qlm_code()]
 #'   already asked it for this run, so a wholly rejected run asks the provider
 #'   at most once; `NULL` when it has not been asked.
+#' @param cost_message Whether to say so when the cost will be `NA`. `FALSE`
+#'   when the structured path already has, for this run.
 #'
 #' @return A data frame with one row per unit, carrying `.error` for units that
 #'   never validated, plus token and cost columns when requested. Handler
@@ -33,7 +35,7 @@
 #' @noRd
 code_handler_json <- function(x, codebook, model, chat_args, execution_args,
                               batch = FALSE, max_retries = 2L,
-                              model_hint = NULL) {
+                              model_hint = NULL, cost_message = TRUE) {
   # The handler is reached via do.call(), so report guard failures against
   # qlm_code() rather than against an anonymous function.
   error_call <- rlang::caller_env()
@@ -82,6 +84,10 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
     ),
     chat_args
   ))
+
+  # From the chat the run will use, before anything is sent (#135). Silent
+  # when the structured path already said it for this run.
+  unpriced <- cost_diagnosis(chat, model, execution_args, say = cost_message)
 
   include_tokens <- isTRUE(execution_args$include_tokens)
   include_cost <- isTRUE(execution_args$include_cost)
@@ -253,7 +259,8 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
   attr(results, "qlm_backend_meta") <- list(
     backend = "json_mode",
     max_retries = max_retries,
-    n_invalid = sum(failed)
+    n_invalid = sum(failed),
+    unpriced = unpriced
   )
   results
 }

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -149,9 +149,9 @@ table altogether, DeepSeek among them, so no model of theirs is ever priced;
 a model newer than the installed ellmer is missed on a provider it otherwise
 prices, which upgrading fixes; and local endpoints such as ollama have no
 per-token charge. In each case \code{qlm_code()} says so once before the run,
-and the reason is kept with the object and shown when it is printed. Token
-counts are recorded regardless, so a run can be costed from the provider's
-published rates.
+and the reason is kept with the object and shown when it is printed. With
+\code{include_tokens = TRUE} the token counts are recorded, from which such a
+run can be costed at the provider's published rates.
 }
 
 \section{Schema enforcement}{

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -138,6 +138,22 @@ level does not work: those reach \code{\link[ellmer:chat]{ellmer::chat()}}, whic
 argument. Use \code{params}.
 }
 
+\section{Cost}{
+
+
+\code{include_tokens = TRUE} and \code{include_cost = TRUE} are forwarded to ellmer,
+which adds per-unit token counts and a \code{cost} column in US dollars. ellmer
+prices from a table fixed at its release, matched exactly on provider and
+model, and returns \code{NA} on any miss. Some providers are absent from that
+table altogether, DeepSeek among them, so no model of theirs is ever priced;
+a model newer than the installed ellmer is missed on a provider it otherwise
+prices, which upgrading fixes; and local endpoints such as ollama have no
+per-token charge. In each case \code{qlm_code()} says so once before the run,
+and the reason is kept with the object and shown when it is printed. Token
+counts are recorded regardless, so a run can be costed from the provider's
+published rates.
+}
+
 \section{Schema enforcement}{
 
 

--- a/tests/testthat/test-providers.R
+++ b/tests/testthat/test-providers.R
@@ -313,48 +313,95 @@ test_that("a diagnosis never reaches the network in tests", {
 
 # unpriced_reason() -----------------------------------------------------------
 
-# A credentials function keeps construction off the environment and sends
-# nothing: ellmer builds the provider without contacting it.
-no_creds <- list(credentials = function() list(Authorization = "Bearer x"))
+# A chat as the run would build it. The credentials function keeps
+# construction off the environment, and construction sends nothing.
+test_chat <- function(model) {
+  ellmer::chat(model, credentials = function() list(Authorization = "Bearer x"))
+}
 
 test_that("unpriced_reason() is NULL for a model ellmer prices (#135)", {
-  expect_null(unpriced_reason("openai/gpt-4.1-mini", no_creds))
-  expect_null(unpriced_reason("anthropic/claude-sonnet-4-5", no_creds))
+  expect_null(unpriced_reason(test_chat("openai/gpt-4.1-mini"), "openai/gpt-4.1-mini"))
+  expect_null(unpriced_reason(test_chat("anthropic/claude-sonnet-4-5"),
+                              "anthropic/claude-sonnet-4-5"))
 })
 
 test_that("unpriced_reason() tells a provider gap from a model gap (#135)", {
   # DeepSeek is absent from ellmer's table as a whole
-  r <- unpriced_reason("deepseek/deepseek-chat", no_creds)
+  r <- unpriced_reason(test_chat("deepseek/deepseek-chat"), "deepseek/deepseek-chat")
   expect_equal(r$kind, "provider")
   expect_equal(r$provider, "DeepSeek")
   expect_equal(r$model, "deepseek-chat")
 
   # OpenAI is priced, this model is not
-  r <- unpriced_reason("openai/gpt-99-not-yet-released", no_creds)
+  r <- unpriced_reason(test_chat("openai/gpt-99-not-yet-released"),
+                       "openai/gpt-99-not-yet-released")
   expect_equal(r$kind, "model")
   expect_equal(r$provider, "OpenAI")
   expect_equal(r$model, "gpt-99-not-yet-released")
 })
 
-test_that("unpriced_reason() names a local endpoint without building a chat (#135)", {
-  # ellmer's ollama constructor looks for a running server; none is here
-  r <- unpriced_reason("ollama/llama3")
+test_that("unpriced_reason() names a local endpoint from the prefix alone (#135)", {
+  # No chat is consulted: ellmer's ollama constructor looks for a running server
+  r <- unpriced_reason(NULL, "ollama/llama3")
   expect_equal(r$kind, "local")
   expect_equal(r$provider, "ollama")
   expect_equal(r$model, "llama3")
-  expect_equal(unpriced_reason("vllm/x")$kind, "local")
-  expect_equal(unpriced_reason("lmstudio/x")$kind, "local")
+  expect_equal(unpriced_reason(NULL, "vllm/x")$kind, "local")
+  expect_equal(unpriced_reason(NULL, "lmstudio/x")$kind, "local")
 })
 
 test_that("unpriced_reason() stays silent where it cannot decide (#135)", {
-  # The chat cannot be built: openai_compatible needs a base_url. The run
-  # itself will say so; nothing to add.
-  expect_null(unpriced_reason("openai_compatible/qwen3", no_creds))
+  # Not an ellmer chat, so no provider to read
+  expect_null(unpriced_reason(structure(list(), class = "fake_chat"), "deepseek/deepseek-chat"))
+  expect_null(unpriced_reason(NULL, "deepseek/deepseek-chat"))
 
   # ellmer without the price table or its predicate: no diagnosis
   f <- unpriced_reason
   mockery::stub(f, "get0", function(x, ...) NULL)
-  expect_null(f("deepseek/deepseek-chat", no_creds))
+  expect_null(f(test_chat("deepseek/deepseek-chat"), "deepseek/deepseek-chat"))
+})
+
+test_that("cost_diagnosis() speaks only when a cost was asked for, and only when told to (#135)", {
+  chat <- test_chat("deepseek/deepseek-chat")
+
+  # No cost asked for: no lookup, nothing said
+  expect_no_message(r <- cost_diagnosis(chat, "deepseek/deepseek-chat", list()))
+  expect_null(r)
+  expect_no_message(r <- cost_diagnosis(chat, "deepseek/deepseek-chat", list(include_cost = FALSE)))
+  expect_null(r)
+
+  # Asked for and unpriced: said once, and the reason comes back
+  expect_message(
+    r <- cost_diagnosis(chat, "deepseek/deepseek-chat", list(include_cost = TRUE)),
+    "no prices for DeepSeek models"
+  )
+  expect_equal(r$kind, "provider")
+
+  # The fallback path is told not to repeat it, but still learns the reason
+  expect_no_message(
+    r <- cost_diagnosis(chat, "deepseek/deepseek-chat", list(include_cost = TRUE), say = FALSE)
+  )
+  expect_equal(r$kind, "provider")
+
+  # Priced: nothing to say
+  expect_no_message(
+    r <- cost_diagnosis(test_chat("openai/gpt-4.1-mini"), "openai/gpt-4.1-mini",
+                        list(include_cost = TRUE))
+  )
+  expect_null(r)
+})
+
+test_that("unpriced_message() says whether the token counts are being recorded (#135)", {
+  provider <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
+  model <- list(kind = "model", provider = "OpenAI", model = "gpt-99")
+
+  # include_cost alone records no counts, and the message must not claim it does
+  expect_match(unpriced_message(provider)[[2]], "Set `include_tokens = TRUE` to record")
+  expect_match(unpriced_message(model)[[2]], "Set `include_tokens = TRUE` to record")
+  expect_match(unpriced_message(provider, tokens_recorded = TRUE)[[2]],
+               "^Token counts are recorded")
+  expect_match(unpriced_message(model, tokens_recorded = TRUE)[[2]],
+               "Token counts are recorded")
 })
 
 test_that("unpriced_message() and unpriced_note() cover every kind (#135)", {
@@ -367,6 +414,7 @@ test_that("unpriced_message() and unpriced_note() cover every kind (#135)", {
   expect_match(unpriced_message(model)[["i"]], "other OpenAI models")
   expect_match(unpriced_message(local)[["i"]], "runs locally")
   expect_length(unpriced_message(provider), 2)
+  expect_length(unpriced_message(local), 1)
 
   expect_equal(unpriced_note(provider), "ellmer has no prices for DeepSeek models")
   expect_match(unpriced_note(model), "^ellmer [0-9.]+ has no price for gpt-99$")

--- a/tests/testthat/test-providers.R
+++ b/tests/testthat/test-providers.R
@@ -309,3 +309,66 @@ test_that("a diagnosis never reaches the network in tests", {
   mockery::stub(f, "models_lister", function(provider) function(...) stop("no key"))
   expect_null(f("openai"))
 })
+
+
+# unpriced_reason() -----------------------------------------------------------
+
+# A credentials function keeps construction off the environment and sends
+# nothing: ellmer builds the provider without contacting it.
+no_creds <- list(credentials = function() list(Authorization = "Bearer x"))
+
+test_that("unpriced_reason() is NULL for a model ellmer prices (#135)", {
+  expect_null(unpriced_reason("openai/gpt-4.1-mini", no_creds))
+  expect_null(unpriced_reason("anthropic/claude-sonnet-4-5", no_creds))
+})
+
+test_that("unpriced_reason() tells a provider gap from a model gap (#135)", {
+  # DeepSeek is absent from ellmer's table as a whole
+  r <- unpriced_reason("deepseek/deepseek-chat", no_creds)
+  expect_equal(r$kind, "provider")
+  expect_equal(r$provider, "DeepSeek")
+  expect_equal(r$model, "deepseek-chat")
+
+  # OpenAI is priced, this model is not
+  r <- unpriced_reason("openai/gpt-99-not-yet-released", no_creds)
+  expect_equal(r$kind, "model")
+  expect_equal(r$provider, "OpenAI")
+  expect_equal(r$model, "gpt-99-not-yet-released")
+})
+
+test_that("unpriced_reason() names a local endpoint without building a chat (#135)", {
+  # ellmer's ollama constructor looks for a running server; none is here
+  r <- unpriced_reason("ollama/llama3")
+  expect_equal(r$kind, "local")
+  expect_equal(r$provider, "ollama")
+  expect_equal(r$model, "llama3")
+  expect_equal(unpriced_reason("vllm/x")$kind, "local")
+  expect_equal(unpriced_reason("lmstudio/x")$kind, "local")
+})
+
+test_that("unpriced_reason() stays silent where it cannot decide (#135)", {
+  # The chat cannot be built: openai_compatible needs a base_url. The run
+  # itself will say so; nothing to add.
+  expect_null(unpriced_reason("openai_compatible/qwen3", no_creds))
+
+  # ellmer without the price table or its predicate: no diagnosis
+  f <- unpriced_reason
+  mockery::stub(f, "get0", function(x, ...) NULL)
+  expect_null(f("deepseek/deepseek-chat", no_creds))
+})
+
+test_that("unpriced_message() and unpriced_note() cover every kind (#135)", {
+  provider <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
+  model <- list(kind = "model", provider = "OpenAI", model = "gpt-99")
+  local <- list(kind = "local", provider = "ollama", model = "llama3")
+
+  expect_match(unpriced_message(provider)[["i"]], "no prices for DeepSeek models")
+  expect_match(unpriced_message(model)[["i"]], "no price for \"gpt-99\"")
+  expect_match(unpriced_message(model)[["i"]], "other OpenAI models")
+  expect_match(unpriced_message(local)[["i"]], "runs locally")
+  expect_length(unpriced_message(provider), 2)
+
+  expect_equal(unpriced_note(provider), "ellmer has no prices for DeepSeek models")
+  expect_match(unpriced_note(model), "^ellmer [0-9.]+ has no price for gpt-99$")
+  expect_equal(unpriced_note(local), "ollama runs locally; no per-token charge")
+})

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -1433,3 +1433,58 @@ test_that("every entry point refuses an object a row operation has left with a r
   expect_error(qlm_trail(doubled), "must be unique")
   expect_error(qlm_replicate(doubled), "must be unique")
 })
+
+
+# cost that cannot be priced (#135) --------------------------------------------
+
+# qlm_code() with the structured call stubbed to return `results`, and the
+# pricing lookup stubbed to answer `reason`. Callers pin
+# structured = "structured": DeepSeek defaults to the JSON path, which the
+# stub does not cover.
+coding_run <- function(results, reason) {
+  tsc <- function(...) list(ok = TRUE, value = results)
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
+  mockery::stub(f, "unpriced_reason", function(model, chat_args) reason)
+  f
+}
+
+test_that("qlm_code says once, before the run, why cost will be NA (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Test prompt", type_obj)
+  results <- data.frame(score = c(0.5, 0.8), input_tokens = c(10, 12),
+                        output_tokens = c(3, 4), cached_input_tokens = c(0, 0),
+                        cost = c(NA_real_, NA_real_))
+  reason <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
+
+  f <- coding_run(results, reason)
+  expect_message(
+    coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
+               include_cost = TRUE, structured = "structured"),
+    "no prices for DeepSeek models"
+  )
+  expect_equal(qlm_meta(coded)$cost_note, "ellmer has no prices for DeepSeek models")
+  expect_output(print(coded), "# Cost:     NA (ellmer has no prices for DeepSeek models)",
+                fixed = TRUE)
+})
+
+test_that("qlm_code is silent about cost when it was not asked for, or is priced (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Test prompt", type_obj)
+  results <- data.frame(score = c(0.5, 0.8))
+  reason <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
+
+  # Not asked for: the lookup is not even made
+  f <- coding_run(results, reason)
+  expect_no_message(coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
+                               structured = "structured"))
+  expect_null(qlm_meta(coded)$cost_note)
+  expect_output(print(coded), "# Units:")
+  expect_no_match(paste(capture.output(print(coded)), collapse = "\n"), "# Cost:")
+
+  # Asked for and priced: nothing to say
+  f <- coding_run(results, NULL)
+  expect_no_message(coded <- f(c("a", "b"), codebook, model = "openai/gpt-4.1-mini",
+                               include_cost = TRUE, structured = "structured"))
+  expect_null(qlm_meta(coded)$cost_note)
+})

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -453,7 +453,7 @@ test_that("qlm_code delegates to the handler and records the backend", {
 
   handler_args <- NULL
   fake_handler <- function(x, codebook, model, chat_args, execution_args, batch,
-                           max_retries = 2L, model_hint = NULL) {
+                           max_retries = 2L, model_hint = NULL, ...) {
     handler_args <<- list(model = model, batch = batch, max_retries = max_retries,
                           chat_args = chat_args, execution_args = execution_args)
     results <- tibble::tibble(score = c(0.5, 0.8))
@@ -542,7 +542,7 @@ test_that("qlm_code passes its max_retries default to the handler", {
 
   seen <- NULL
   fake_handler <- function(x, codebook, model, chat_args, execution_args, batch,
-                           max_retries, model_hint = NULL) {
+                           max_retries, model_hint = NULL, ...) {
     seen <<- max_retries
     tibble::tibble(score = 0.5)
   }
@@ -590,7 +590,7 @@ structured_stub <- function(results = data.frame(score = 0.5), errors = NULL,
 
 json_stub <- function(calls = NULL) {
   function(x, codebook, model, chat_args, execution_args, batch, max_retries,
-           model_hint = NULL) {
+           model_hint = NULL, ...) {
     if (!is.null(calls)) {
       calls$json <- TRUE
       calls$max_retries <- max_retries
@@ -1438,29 +1438,27 @@ test_that("every entry point refuses an object a row operation has left with a r
 # cost that cannot be priced (#135) --------------------------------------------
 
 # qlm_code() with the structured call stubbed to return `results`, and the
-# pricing lookup stubbed to answer `reason`. Callers pin
-# structured = "structured": DeepSeek defaults to the JSON path, which the
-# stub does not cover.
-coding_run <- function(results, reason) {
-  tsc <- function(...) list(ok = TRUE, value = results)
+# chat built for real, off the environment and sending nothing, so that the
+# diagnosis reads the provider the run would use. Callers pin
+# structured = "structured": DeepSeek defaults to the JSON path.
+coding_run <- function(results) {
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", results)
   f <- qlm_code
   mockery::stub(f, "try_structured_call", tsc)
-  mockery::stub(f, "unpriced_reason", function(model, chat_args) reason)
   f
 }
+offline <- function() list(Authorization = "Bearer x")
 
 test_that("qlm_code says once, before the run, why cost will be NA (#135)", {
   type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
   codebook <- qlm_codebook("Test", "Test prompt", type_obj)
-  results <- data.frame(score = c(0.5, 0.8), input_tokens = c(10, 12),
-                        output_tokens = c(3, 4), cached_input_tokens = c(0, 0),
-                        cost = c(NA_real_, NA_real_))
-  reason <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
+  results <- data.frame(score = c(0.5, 0.8), cost = c(NA_real_, NA_real_))
 
-  f <- coding_run(results, reason)
+  f <- coding_run(results)
   expect_message(
     coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
-               include_cost = TRUE, structured = "structured"),
+               credentials = offline, include_cost = TRUE, structured = "structured"),
     "no prices for DeepSeek models"
   )
   expect_equal(qlm_meta(coded)$cost_note, "ellmer has no prices for DeepSeek models")
@@ -1468,23 +1466,49 @@ test_that("qlm_code says once, before the run, why cost will be NA (#135)", {
                 fixed = TRUE)
 })
 
+test_that("qlm_code's cost message says whether token counts are recorded (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Test prompt", type_obj)
+
+  # include_cost alone: no token columns come back, and the message says so
+  f <- coding_run(data.frame(score = c(0.5, 0.8), cost = c(NA_real_, NA_real_)))
+  expect_message(
+    coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
+               credentials = offline, include_cost = TRUE, structured = "structured"),
+    "Set `include_tokens = TRUE` to record"
+  )
+  expect_false("input_tokens" %in% names(coded))
+
+  # With include_tokens the counts are there, and the message says that instead
+  with_tokens <- data.frame(score = c(0.5, 0.8), input_tokens = c(10, 12),
+                            output_tokens = c(3, 4), cached_input_tokens = c(0, 0),
+                            cost = c(NA_real_, NA_real_))
+  f <- coding_run(with_tokens)
+  expect_message(
+    coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
+               credentials = offline, include_cost = TRUE, include_tokens = TRUE,
+               structured = "structured"),
+    "Token counts are recorded"
+  )
+  expect_true("input_tokens" %in% names(coded))
+})
+
 test_that("qlm_code is silent about cost when it was not asked for, or is priced (#135)", {
   type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
   codebook <- qlm_codebook("Test", "Test prompt", type_obj)
   results <- data.frame(score = c(0.5, 0.8))
-  reason <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
 
   # Not asked for: the lookup is not even made
-  f <- coding_run(results, reason)
+  f <- coding_run(results)
   expect_no_message(coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
-                               structured = "structured"))
+                               credentials = offline, structured = "structured"))
   expect_null(qlm_meta(coded)$cost_note)
   expect_output(print(coded), "# Units:")
   expect_no_match(paste(capture.output(print(coded)), collapse = "\n"), "# Cost:")
 
   # Asked for and priced: nothing to say
-  f <- coding_run(results, NULL)
   expect_no_message(coded <- f(c("a", "b"), codebook, model = "openai/gpt-4.1-mini",
-                               include_cost = TRUE, structured = "structured"))
+                               credentials = offline, include_cost = TRUE,
+                               structured = "structured"))
   expect_null(qlm_meta(coded)$cost_note)
 })

--- a/tests/testthat/test-qlm_code_json.R
+++ b/tests/testthat/test-qlm_code_json.R
@@ -1018,3 +1018,59 @@ test_that("is_json_word_error recognises the DashScope rejection", {
   expect_false(is_json_word_error(NA_character_))
   expect_false(is_json_word_error(character(0)))
 })
+
+
+# cost that cannot be priced (#135) --------------------------------------------
+
+# The handler with only the round trip stubbed out: the chat is built for
+# real, off the environment, so the diagnosis reads the provider the run
+# would use.
+json_offline_handler <- function(attempts) {
+  h <- code_handler_json
+  mockery::stub(h, "model_name_hint", function(...) character())
+  i <- 0L
+  mockery::stub(h, "json_chat_turns", function(chat, prompts, pc_args) {
+    i <<- i + 1L
+    attempt <- attempts[[i]]
+    n <- length(attempt$text)
+    list(
+      text = attempt$text,
+      error = rep(NA_character_, n),
+      status = rep(NA_integer_, n),
+      finish = rep(NA_character_, n),
+      usage = json_test_usage(n)
+    )
+  })
+  h
+}
+offline_args <- list(credentials = function() list(Authorization = "Bearer x"))
+
+test_that("the JSON path diagnoses cost from its own chat, and stays quiet when told (#135)", {
+  attempts <- list(list(text = "{\"score\":1,\"lab\":\"pos\"}"))
+
+  h <- json_offline_handler(attempts)
+  expect_message(
+    result <- h(x = "a", codebook = json_test_codebook(), model = "deepseek/deepseek-chat",
+                chat_args = offline_args, execution_args = list(include_cost = TRUE)),
+    "no prices for DeepSeek models"
+  )
+  expect_equal(attr(result, "qlm_backend_meta")$unpriced$kind, "provider")
+  expect_equal(attr(result, "qlm_backend_meta")$unpriced$provider, "DeepSeek")
+
+  # As the fallback after a structured attempt that already said it
+  h <- json_offline_handler(attempts)
+  expect_no_message(
+    result <- h(x = "a", codebook = json_test_codebook(), model = "deepseek/deepseek-chat",
+                chat_args = offline_args, execution_args = list(include_cost = TRUE),
+                cost_message = FALSE)
+  )
+  expect_equal(attr(result, "qlm_backend_meta")$unpriced$kind, "provider")
+
+  # No cost asked for: nothing said, nothing kept
+  h <- json_offline_handler(attempts)
+  expect_no_message(
+    result <- h(x = "a", codebook = json_test_codebook(), model = "deepseek/deepseek-chat",
+                chat_args = offline_args, execution_args = list())
+  )
+  expect_null(attr(result, "qlm_backend_meta")$unpriced)
+})


### PR DESCRIPTION
First half of #135. The second half, a `prices` argument that costs a run from its token counts, follows as a separate PR stacked on this one.

## What was wrong

`qlm_code(..., include_cost = TRUE)` returned a column of `NA` for DeepSeek and six other providers with nothing to say why. ellmer prices a turn by exact lookup of provider name and model in a table frozen at its release, and answers `NA` on any miss. It does not distinguish the two kinds of miss, and the remedies differ:

| miss | example | remedy |
|---|---|---|
| provider absent from the table | DeepSeek, cloudflare, databricks, github, huggingface, perplexity, portkey | supply rates yourself (next PR) |
| model newer than the installed ellmer, provider priced | a just-released OpenAI model | upgrade ellmer |
| local endpoint | ollama, lmstudio, vllm | nothing to fix |

## What this does

- **Says so once, before the run.** A new internal `unpriced_reason()` in [providers.R](R/providers.R) builds the provider (which sends nothing) and asks ellmer's own `has_cost()` predicate, then classifies the miss against ellmer's price table. `qlm_code()` emits one `cli_inform()` naming the provider or model. Local prefixes are classified without building a chat, since ellmer's constructors for them look for a running server.
- **Keeps the reason with the object.** A `cost_note` in the run's user metadata, shown by `print.qlm_coded()` as `# Cost: NA (ellmer has no prices for DeepSeek models)`, so the answer outlives the console and reaches the trail.
- **Fails quiet, not loud.** The table and predicate are read from ellmer's namespace at run time, as #133 reads the listing functions. If a later ellmer drops either, or the chat cannot be built, nothing is said and the `NA` stands as before. Both are tested.

Token counts are recorded regardless, so a run can still be costed from the provider's published rates.

## Tests

Seven new tests: priced model is `NULL`; provider gap versus model gap; local endpoints without a chat; silence when the chat cannot be built or ellmer lacks the internals; message and note wording for each kind; and `qlm_code()` end to end with the structured call stubbed, checking the message, the metadata, and the print line, plus silence when cost was not asked for or is priced. Full suite passes; `R CMD check --as-cran --no-manual` gives only the dev-version NOTE.
