### PR TITLE
Cost a run from supplied rates where ellmer has none

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,9 +31,9 @@
   rows ellmer leaves `NA` are filled, by the sum ellmer applies to its own
   table; where ellmer prices the model its figure stands. The rates are kept
   in the run's metadata, shown by `print()` and the trail report, and reused
-  by `qlm_replicate()` when the model, endpoint and batch setting are
-  unchanged, so a cost resting on entered figures is always labelled as
-  such. quallmer bundles no prices of its own
+  by `qlm_replicate()` when the model, endpoint, batch setting and service
+  tier are unchanged, so a cost resting on entered figures is always
+  labelled as such. quallmer bundles no prices of its own
   (#135).
 
 * `qlm_compare()` now honours `tolerance`, and computes its numeric

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,15 @@
   cost could be worked out from are being recorded, which needs
   `include_tokens = TRUE` (#135).
 
+* `qlm_code()` gains `prices`, rates in US dollars per million tokens that
+  cost a run ellmer cannot price, from the token counts it records. Only the
+  rows ellmer leaves `NA` are filled, by the sum ellmer applies to its own
+  table; where ellmer prices the model its figure stands. The rates are kept
+  in the run's metadata, shown by `print()` and the trail report, and reused
+  by `qlm_replicate()` for the same model, so a cost resting on entered
+  figures is always labelled as such. quallmer bundles no prices of its own
+  (#135).
+
 * `qlm_compare()` now honours `tolerance`, and computes its numeric
   statistics on the ratings' values, when a coder stores the ratings as
   text. The ratings were assembled into one matrix before their type was

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,16 @@
   is needed, through an environment variable or that callback form, keeps
   it out of the record entirely and is the recommended form (#154).
 
+* `qlm_code()` now says why `cost` will be `NA` when `include_cost = TRUE`
+  cannot be honoured, once and before the run, and keeps the reason with the
+  object so `print()` shows it. ellmer prices from a table fixed at its
+  release, matched exactly on provider and model, and answers `NA` on any
+  miss without saying which kind: DeepSeek and six other providers are absent
+  from the table altogether, so no model of theirs is ever priced; a model
+  newer than the installed ellmer is missed on a provider it otherwise
+  prices; and local endpoints have no per-token charge. Each is now named,
+  since the remedies differ. Token counts are recorded regardless (#135).
+
 * `qlm_compare()` now honours `tolerance`, and computes its numeric
   statistics on the ratings' values, when a coder stores the ratings as
   text. The ratings were assembled into one matrix before their type was

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,9 @@
   from the table altogether, so no model of theirs is ever priced; a model
   newer than the installed ellmer is missed on a provider it otherwise
   prices; and local endpoints have no per-token charge. Each is now named,
-  since the remedies differ. Token counts are recorded regardless (#135).
+  since the remedies differ, and the message says whether the token counts a
+  cost could be worked out from are being recorded, which needs
+  `include_tokens = TRUE` (#135).
 
 * `qlm_compare()` now honours `tolerance`, and computes its numeric
   statistics on the ratings' values, when a coder stores the ratings as

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,8 +31,9 @@
   rows ellmer leaves `NA` are filled, by the sum ellmer applies to its own
   table; where ellmer prices the model its figure stands. The rates are kept
   in the run's metadata, shown by `print()` and the trail report, and reused
-  by `qlm_replicate()` for the same model, so a cost resting on entered
-  figures is always labelled as such. quallmer bundles no prices of its own
+  by `qlm_replicate()` when the model, endpoint and batch setting are
+  unchanged, so a cost resting on entered figures is always labelled as
+  such. quallmer bundles no prices of its own
   (#135).
 
 * `qlm_compare()` now honours `tolerance`, and computes its numeric

--- a/R/cost.R
+++ b/R/cost.R
@@ -1,0 +1,123 @@
+#' Rates supplied by the user, checked
+#'
+#' Rates are US dollars per million tokens, the unit ellmer's price table
+#' uses, named `input`, `output` and optionally `cached_input`. A cached rate
+#' that is not given is taken as the input rate: cache hits are then billed at
+#' the full rate, which over-counts rather than under-counts, and no provider
+#' charges more for a hit than for a miss.
+#'
+#' @param prices What the caller passed as `prices`.
+#' @param call The calling environment, for the error message.
+#'
+#' @return `NULL` for `NULL`; otherwise a named numeric vector `input`,
+#'   `output`, `cached_input`, in that order.
+#' @keywords internal
+#' @noRd
+check_prices <- function(prices, call = rlang::caller_env()) {
+  if (is.null(prices)) {
+    return(NULL)
+  }
+
+  required <- c("input", "output")
+  allowed <- c(required, "cached_input")
+  problems <- character()
+
+  if (!(is.numeric(prices) || is.list(prices)) || is.null(names(prices))) {
+    problems <- "It is not a named numeric vector or list."
+  } else {
+    given <- names(prices)
+    missing <- setdiff(required, given)
+    unknown <- setdiff(given, allowed)
+    if (length(missing)) {
+      problems <- c(problems, paste0("Missing: ", paste(missing, collapse = ", "), "."))
+    }
+    if (length(unknown)) {
+      problems <- c(problems, paste0("Not a rate: ", paste(unknown, collapse = ", "), "."))
+    }
+    if (anyDuplicated(given)) {
+      problems <- c(problems, "A rate is given more than once.")
+    }
+    bad <- vapply(prices, function(p) {
+      !is.numeric(p) || length(p) != 1L || is.na(p) || !is.finite(p) || p < 0
+    }, logical(1))
+    if (any(bad)) {
+      problems <- c(problems, paste0(
+        "Not a single non-negative number: ", paste(given[bad], collapse = ", "), "."
+      ))
+    }
+  }
+
+  if (length(problems)) {
+    cli::cli_abort(c(
+      paste0("{.arg prices} must name the rates {.code input} and {.code output}, ",
+             "and optionally {.code cached_input}, in US dollars per million tokens."),
+      stats::setNames(problems, rep("x", length(problems))),
+      "i" = "For example {.code prices = c(input = 0.435, output = 0.87, cached_input = 0.0036)}."
+    ), call = call)
+  }
+
+  c(
+    input = as.numeric(prices[["input"]]),
+    output = as.numeric(prices[["output"]]),
+    cached_input = as.numeric(
+      if ("cached_input" %in% names(prices)) prices[["cached_input"]] else prices[["input"]]
+    )
+  )
+}
+
+
+#' Cost the rows ellmer left unpriced, from their token counts
+#'
+#' The sum is the one ellmer applies to its own table. ellmer normalises every
+#' provider's usage so that `input_tokens` counts the uncached prompt tokens and
+#' `cached_input_tokens` the cache hits, whatever the provider reported, and
+#' bills the three parts at their own rates; so no cache convention is needed
+#' here. A row ellmer did price keeps its figure. A row without token counts,
+#' which is a row the provider did not answer, stays `NA`.
+#'
+#' @param results The coded table, with ellmer's token and cost columns.
+#' @param prices What `check_prices()` returned.
+#'
+#' @return `results`, with `cost` filled where it could be.
+#' @keywords internal
+#' @noRd
+price_from_tokens <- function(results, prices) {
+  needed <- c("input_tokens", "output_tokens", "cached_input_tokens")
+  if (!all(needed %in% names(results))) {
+    return(results)
+  }
+  if (!"cost" %in% names(results)) {
+    results$cost <- rep(NA_real_, nrow(results))
+  }
+
+  input <- results$input_tokens
+  output <- results$output_tokens
+  cached <- results$cached_input_tokens
+  cached[is.na(cached)] <- 0
+
+  fill <- is.na(results$cost) & !is.na(input) & !is.na(output)
+  results$cost[fill] <- (
+    input[fill] * prices[["input"]] +
+      cached[fill] * prices[["cached_input"]] +
+      output[fill] * prices[["output"]]
+  ) / 1e6
+
+  results
+}
+
+
+#' One line saying where a cost came from, for the object and the trail
+#'
+#' @param prices What `check_prices()` returned.
+#'
+#' @return A character scalar.
+#' @keywords internal
+#' @noRd
+prices_note <- function(prices) {
+  rate <- function(x) format(x, scientific = FALSE, trim = TRUE, drop0trailing = TRUE)
+  paste0(
+    "from supplied rates: $", rate(prices[["input"]]), " input, $",
+    rate(prices[["output"]]), " output, $", rate(prices[["cached_input"]]),
+    " cached input, per million tokens"
+  )
+}

--- a/R/providers.R
+++ b/R/providers.R
@@ -408,10 +408,11 @@ unpriced_message <- function(reason, tokens_recorded = FALSE) {
   # Interpolated here, where `reason` is in scope, rather than by the caller
   line <- function(...) cli::format_inline(paste0(...))
   tokens <- if (tokens_recorded) {
-    "Token counts are recorded, so the run can be costed from the provider's published rates."
+    line("Token counts are recorded; supply the provider's published rates as ",
+         "{.arg prices} to cost the run from them.")
   } else {
-    line("Set {.code include_tokens = TRUE} to record the token counts, ",
-         "from which the run can be costed at the provider's published rates.")
+    line("Supply the provider's published rates as {.arg prices} to cost the run ",
+         "from its token counts.")
   }
   switch(reason$kind,
     local = c(

--- a/R/providers.R
+++ b/R/providers.R
@@ -295,3 +295,111 @@ closest_model_names <- function(id, models, n = 3L) {
   candidates <- models[near][order(d[near])]
   utils::head(unique(candidates), n)
 }
+
+
+#' Why a run's cost will be `NA`, if it will be
+#'
+#' ellmer prices a turn by exact lookup of the provider's name and the model
+#' in a table frozen at its build, and answers `NA` on any miss. It does not
+#' say which kind of miss. A provider absent from the table altogether
+#' (DeepSeek and six others as of ellmer 0.4.2) will never price any model,
+#' and only rates supplied by the user can help. A model newer than the
+#' installed ellmer, on a provider it does price, is fixed by upgrading. The
+#' remedies differ, so both are told apart here, before a request is spent,
+#' rather than left to be inferred from a column of `NA` (#135).
+#'
+#' Local endpoints charge nothing per token, so their `NA` is expected rather
+#' than a gap, and is described as such without building a chat: ellmer's
+#' constructors for them look for a running server.
+#'
+#' The table and ellmer's own predicate are read from its namespace at run
+#' time, as the model listing is. Should a later ellmer drop either, no
+#' diagnosis is made and the `NA` stands unexplained, which is what it did
+#' before.
+#'
+#' @param model The model specification, as passed to [qlm_code()].
+#' @param chat_args Arguments for [ellmer::chat()], since the provider's
+#'   display name is known only once the provider is built.
+#'
+#' @return `NULL` when the model is priced. Otherwise a list with `kind`,
+#'   one of `"local"`, `"provider"` or `"model"`; `provider`, ellmer's name
+#'   for it; and `model`.
+#' @keywords internal
+#' @noRd
+unpriced_reason <- function(model, chat_args = list()) {
+  prefix <- model_provider(model)
+  if (prefix %in% c("ollama", "lmstudio", "vllm")) {
+    return(list(kind = "local", provider = prefix,
+                model = sub("^[^/]*/?", "", model)))
+  }
+
+  ns <- asNamespace("ellmer")
+  prices <- get0("prices", envir = ns, inherits = FALSE)
+  has_cost <- get0("has_cost", envir = ns, inherits = FALSE)
+  if (!is.data.frame(prices) || !is.function(has_cost)) {
+    return(NULL)
+  }
+
+  # Building the chat sends nothing. Where it cannot be built, the run itself
+  # will say why; there is nothing to add here.
+  chat <- tryCatch(
+    do.call(ellmer::chat, c(list(name = model), chat_args)),
+    error = function(e) NULL
+  )
+  if (is.null(chat)) {
+    return(NULL)
+  }
+  provider <- chat$get_provider()
+  if (isTRUE(has_cost(provider, provider@model))) {
+    return(NULL)
+  }
+
+  list(
+    kind = if (provider@name %in% prices$provider) "model" else "provider",
+    provider = provider@name,
+    model = provider@model
+  )
+}
+
+
+#' The message for an unpriced run, and the note kept on the object
+#'
+#' @param reason What `unpriced_reason()` returned.
+#'
+#' @return `unpriced_message()`: a character vector for [cli::cli_inform()].
+#'   `unpriced_note()`: one plain sentence, kept in the run's metadata and
+#'   shown by `print.qlm_coded()`.
+#' @keywords internal
+#' @noRd
+unpriced_message <- function(reason) {
+  v <- as.character(utils::packageVersion("ellmer"))
+  # Interpolated here, where `reason` is in scope, rather than by the caller
+  line <- function(...) cli::format_inline(paste0(...))
+  switch(reason$kind,
+    local = c(
+      "i" = line("{.field cost} will be {.code NA}: {reason$provider} runs locally, ",
+                 "and there is no per-token charge to record.")
+    ),
+    provider = c(
+      "i" = line("{.field cost} will be {.code NA}: ellmer {v} has no prices for ",
+                 "{reason$provider} models."),
+      " " = paste0("Token counts are still recorded, so the run can be costed ",
+                   "from the provider's published rates.")
+    ),
+    model = c(
+      "i" = line("{.field cost} will be {.code NA}: ellmer {v} has no price for ",
+                 "{.val {reason$model}}, though it prices other ",
+                 "{reason$provider} models."),
+      " " = "A newer ellmer may price it. Token counts are still recorded."
+    )
+  )
+}
+
+unpriced_note <- function(reason) {
+  switch(reason$kind,
+    local = paste0(reason$provider, " runs locally; no per-token charge"),
+    provider = paste0("ellmer has no prices for ", reason$provider, " models"),
+    model = paste0("ellmer ", utils::packageVersion("ellmer"),
+                   " has no price for ", reason$model)
+  )
+}

--- a/R/providers.R
+++ b/R/providers.R
@@ -308,25 +308,27 @@ closest_model_names <- function(id, models, n = 3L) {
 #' remedies differ, so both are told apart here, before a request is spent,
 #' rather than left to be inferred from a column of `NA` (#135).
 #'
-#' Local endpoints charge nothing per token, so their `NA` is expected rather
-#' than a gap, and is described as such without building a chat: ellmer's
-#' constructors for them look for a running server.
+#' Read from the chat the run itself will use, rather than from one built for
+#' the purpose: building a chat evaluates the credentials, which for some
+#' mechanisms means token discovery or a refresh, and prints ellmer's
+#' default-model message. Local endpoints charge nothing per token, so their
+#' `NA` is expected rather than a gap, and is described as such from the
+#' prefix alone.
 #'
 #' The table and ellmer's own predicate are read from its namespace at run
 #' time, as the model listing is. Should a later ellmer drop either, no
 #' diagnosis is made and the `NA` stands unexplained, which is what it did
 #' before.
 #'
+#' @param chat The [ellmer::Chat] the run will use.
 #' @param model The model specification, as passed to [qlm_code()].
-#' @param chat_args Arguments for [ellmer::chat()], since the provider's
-#'   display name is known only once the provider is built.
 #'
-#' @return `NULL` when the model is priced. Otherwise a list with `kind`,
-#'   one of `"local"`, `"provider"` or `"model"`; `provider`, ellmer's name
-#'   for it; and `model`.
+#' @return `NULL` when the model is priced, or when nothing can be said.
+#'   Otherwise a list with `kind`, one of `"local"`, `"provider"` or
+#'   `"model"`; `provider`, ellmer's name for it; and `model`.
 #' @keywords internal
 #' @noRd
-unpriced_reason <- function(model, chat_args = list()) {
+unpriced_reason <- function(chat, model) {
   prefix <- model_provider(model)
   if (prefix %in% c("ollama", "lmstudio", "vllm")) {
     return(list(kind = "local", provider = prefix,
@@ -340,16 +342,10 @@ unpriced_reason <- function(model, chat_args = list()) {
     return(NULL)
   }
 
-  # Building the chat sends nothing. Where it cannot be built, the run itself
-  # will say why; there is nothing to add here.
-  chat <- tryCatch(
-    do.call(ellmer::chat, c(list(name = model), chat_args)),
-    error = function(e) NULL
-  )
-  if (is.null(chat)) {
+  provider <- tryCatch(chat$get_provider(), error = function(e) NULL)
+  if (is.null(provider)) {
     return(NULL)
   }
-  provider <- chat$get_provider()
   if (isTRUE(has_cost(provider, provider@model))) {
     return(NULL)
   }
@@ -362,19 +358,61 @@ unpriced_reason <- function(model, chat_args = list()) {
 }
 
 
+#' Diagnose an unpriced run from the chat it will use, and say so once
+#'
+#' Called by each coding path right after it builds its chat and before it
+#' sends anything. The structured path may fall back to the JSON path, which
+#' builds a chat of its own; the diagnosis is the same, so the fallback is
+#' told not to repeat the message.
+#'
+#' @param chat The [ellmer::Chat] the path will use.
+#' @param model The model specification.
+#' @param execution_args The caller's execution arguments, for `include_cost`
+#'   and `include_tokens`.
+#' @param say Whether to emit the message.
+#'
+#' @return What `unpriced_reason()` returned, or `NULL` when no cost was
+#'   asked for.
+#' @keywords internal
+#' @noRd
+cost_diagnosis <- function(chat, model, execution_args, say = TRUE) {
+  if (!isTRUE(execution_args$include_cost)) {
+    return(NULL)
+  }
+  reason <- unpriced_reason(chat, model)
+  if (!is.null(reason) && say) {
+    cli::cli_inform(
+      unpriced_message(reason, tokens_recorded = isTRUE(execution_args$include_tokens))
+    )
+  }
+  reason
+}
+
+
 #' The message for an unpriced run, and the note kept on the object
 #'
+#' `include_cost` and `include_tokens` are independent ellmer arguments, so
+#' whether the token counts a cost could be worked out from are being
+#' recorded is a fact about this call, and the message says which.
+#'
 #' @param reason What `unpriced_reason()` returned.
+#' @param tokens_recorded Whether the caller set `include_tokens = TRUE`.
 #'
 #' @return `unpriced_message()`: a character vector for [cli::cli_inform()].
 #'   `unpriced_note()`: one plain sentence, kept in the run's metadata and
 #'   shown by `print.qlm_coded()`.
 #' @keywords internal
 #' @noRd
-unpriced_message <- function(reason) {
+unpriced_message <- function(reason, tokens_recorded = FALSE) {
   v <- as.character(utils::packageVersion("ellmer"))
   # Interpolated here, where `reason` is in scope, rather than by the caller
   line <- function(...) cli::format_inline(paste0(...))
+  tokens <- if (tokens_recorded) {
+    "Token counts are recorded, so the run can be costed from the provider's published rates."
+  } else {
+    line("Set {.code include_tokens = TRUE} to record the token counts, ",
+         "from which the run can be costed at the provider's published rates.")
+  }
   switch(reason$kind,
     local = c(
       "i" = line("{.field cost} will be {.code NA}: {reason$provider} runs locally, ",
@@ -383,14 +421,13 @@ unpriced_message <- function(reason) {
     provider = c(
       "i" = line("{.field cost} will be {.code NA}: ellmer {v} has no prices for ",
                  "{reason$provider} models."),
-      " " = paste0("Token counts are still recorded, so the run can be costed ",
-                   "from the provider's published rates.")
+      " " = tokens
     ),
     model = c(
       "i" = line("{.field cost} will be {.code NA}: ellmer {v} has no price for ",
                  "{.val {reason$model}}, though it prices other ",
                  "{reason$provider} models."),
-      " " = "A newer ellmer may price it. Token counts are still recorded."
+      " " = paste("A newer ellmer may price it.", tokens)
     )
   )
 }

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -33,6 +33,13 @@
 #'   separate from ellmer's transport-level retries for rate limits and server
 #'   errors, which apply to every provider and are set with
 #'   `options(ellmer_max_tries = )`.
+#' @param prices Optional. Rates for costing the run when ellmer cannot: a
+#'   named numeric vector or list with `input` and `output`, and optionally
+#'   `cached_input`, in US dollars per million tokens, for example
+#'   `c(input = 0.435, output = 0.87, cached_input = 0.0036)`. Where ellmer
+#'   prices the model itself its figure stands and these are not used. A
+#'   `cached_input` rate that is not given is taken as the `input` rate. See
+#'   the section on cost. Default is `NULL`.
 #' @param batch Logical. If `TRUE`, uses [ellmer::batch_chat_structured()]
 #'   instead of [ellmer::parallel_chat_structured()]. Batch processing is more
 #'   cost-effective for large jobs but may have longer turnaround times.
@@ -114,6 +121,17 @@
 #' and the reason is kept with the object and shown when it is printed. With
 #' `include_tokens = TRUE` the token counts are recorded, from which such a
 #' run can be costed at the provider's published rates.
+#'
+#' `prices` does that costing, at rates you supply from the provider's
+#' published price list. Supplying them implies `include_tokens = TRUE` and
+#' `include_cost = TRUE`. Only rows ellmer left `NA` are filled, by the same
+#' sum ellmer applies to its own table: uncached input tokens at the `input`
+#' rate, cache hits at the `cached_input` rate, output at the `output` rate,
+#' each per million. Where ellmer priced every row itself the rates are not
+#' used, and you are told so. The rates are kept in the run's metadata, shown
+#' by `print()` and in the trail report, and reused by [qlm_replicate()] for
+#' the same model, so a cost that rests on entered figures is always labelled
+#' as such. quallmer bundles no prices of its own.
 #'
 #' @section Schema enforcement:
 #'
@@ -249,7 +267,7 @@
 qlm_code <- function(x, codebook, model, ...,
                      batch = FALSE,
                      structured = c("auto", "structured", "json"),
-                     max_retries = 2L, name = NULL, notes = NULL) {
+                     max_retries = 2L, prices = NULL, name = NULL, notes = NULL) {
   # Distinguishes a value the user chose from the default, so that the default
   # never errors but an explicit setting is never silently ignored.
   explicit_retries <- !missing(max_retries)
@@ -335,6 +353,14 @@ qlm_code <- function(x, codebook, model, ...,
   # to pass through to ellmer::chat() which forwards them to the provider
   chat_args <- dots[!dot_names %in% execution_arg_names]
 
+  # Supplied rates cost the run from its token counts, so both must be asked
+  # of ellmer; the caller asked for a cost by supplying them.
+  prices <- check_prices(prices)
+  if (!is.null(prices)) {
+    execution_args$include_tokens <- TRUE
+    execution_args$include_cost <- TRUE
+  }
+
   # ellmer returns a bare list under convert = FALSE, which has no rows to
   # merge an .id into and no columns for new_qlm_coded() to reorder. It has
   # never worked here; say so rather than failing later with "incorrect number
@@ -364,7 +390,8 @@ qlm_code <- function(x, codebook, model, ...,
     attempt <- try_structured_call(
       x = x, codebook = codebook, model = model,
       chat_args = chat_args, execution_args = execution_args, batch = batch,
-      allow_skip = identical(structured, "auto") && !batch
+      allow_skip = identical(structured, "auto") && !batch,
+      cost_message = is.null(prices)
     )
 
     unpriced <- attempt$unpriced
@@ -437,7 +464,7 @@ qlm_code <- function(x, codebook, model, ...,
       batch = batch,
       max_retries = max_retries,
       model_hint = model_hint,
-      cost_message = is.null(attempt)
+      cost_message = is.null(attempt) && is.null(prices)
     )
     backend_meta <- attr(results, "qlm_backend_meta") %||% list()
     attr(results, "qlm_backend_meta") <- NULL
@@ -454,6 +481,25 @@ qlm_code <- function(x, codebook, model, ...,
 
   # Add ID column from input names or sequence
   results$id <- names(x) %||% seq_along(x)
+
+  # Where the cost came from, when ellmer could not fill it (#135). Supplied
+  # rates cost the rows ellmer left NA from their token counts; decided from
+  # the table rather than from the diagnosis, which cannot always be made.
+  # Where ellmer priced every row itself, its figures are the published
+  # rates and the supplied ones have nothing to do.
+  cost_note <- if (!is.null(unpriced)) paste0("NA (", unpriced_note(unpriced), ")")
+  if (!is.null(prices)) {
+    priced <- price_from_tokens(results, prices)
+    if (identical(priced$cost, results$cost)) {
+      cli::cli_inform(c(
+        "i" = "ellmer priced this run itself; {.arg prices} is not used."
+      ))
+      prices <- NULL
+    } else {
+      results <- priced
+      cost_note <- prices_note(prices)
+    }
+  }
 
   # Build metadata list
   metadata <- list(
@@ -473,8 +519,11 @@ qlm_code <- function(x, codebook, model, ...,
 
   # Fields contributed by a provider-specific handler (backend, max_retries, ...)
   metadata <- c(metadata, backend_meta)
-  if (!is.null(unpriced)) {
-    metadata$cost_note <- unpriced_note(unpriced)
+  if (!is.null(cost_note)) {
+    metadata$cost_note <- cost_note
+  }
+  if (!is.null(prices)) {
+    metadata$prices <- prices
   }
 
   # Add model to chat_args for easy access
@@ -1240,9 +1289,10 @@ print.qlm_coded <- function(x, ...) {
     cat("# Parent:   ", meta_attr$object$parent, "\n", sep = "")
   }
 
-  # Why the cost column is NA, when it was asked for and could not be filled
+  # Where the cost column came from, when ellmer could not fill it: why it
+  # is NA, or the supplied rates it was computed from
   if (!is.null(meta_attr$user$cost_note)) {
-    cat("# Cost:     NA (", meta_attr$user$cost_note, ")\n", sep = "")
+    cat("# Cost:     ", meta_attr$user$cost_note, "\n", sep = "")
   }
 
   # Show notes if present

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -130,9 +130,9 @@
 #' each per million. Where ellmer priced every row itself the rates are not
 #' used, and you are told so. The rates are kept in the run's metadata, shown
 #' by `print()` and in the trail report, and reused by [qlm_replicate()] when
-#' the model, the endpoint and the batch setting are unchanged, so a cost that
-#' rests on entered figures is always labelled as such. quallmer bundles no
-#' prices of its own.
+#' the model, the endpoint, the batch setting and the service tier are
+#' unchanged, so a cost that rests on entered figures is always labelled as
+#' such. quallmer bundles no prices of its own.
 #'
 #' @section Schema enforcement:
 #'

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -111,9 +111,9 @@
 #' a model newer than the installed ellmer is missed on a provider it otherwise
 #' prices, which upgrading fixes; and local endpoints such as ollama have no
 #' per-token charge. In each case `qlm_code()` says so once before the run,
-#' and the reason is kept with the object and shown when it is printed. Token
-#' counts are recorded regardless, so a run can be costed from the provider's
-#' published rates.
+#' and the reason is kept with the object and shown when it is printed. With
+#' `include_tokens = TRUE` the token counts are recorded, from which such a
+#' run can be costed at the provider's published rates.
 #'
 #' @section Schema enforcement:
 #'
@@ -351,17 +351,11 @@ qlm_code <- function(x, codebook, model, ...,
   backend_meta <- list()
   results <- NULL
 
-  # A cost that will come back NA is knowable before any request, and the
-  # reason decides the remedy, so say it once here rather than per row (#135).
-  # The note travels with the object so that the answer outlives the console.
-  cost_note <- NULL
-  if (isTRUE(execution_args$include_cost)) {
-    unpriced <- unpriced_reason(model, chat_args)
-    if (!is.null(unpriced)) {
-      cli::cli_inform(unpriced_message(unpriced))
-      cost_note <- unpriced_note(unpriced)
-    }
-  }
+  # Whether the cost will come back NA, and why, is read by each path from
+  # the chat it builds, before it sends anything (#135). Kept here so the
+  # reason outlives the console: it travels with the object.
+  unpriced <- NULL
+  attempt <- NULL
   fallback_reason <- NULL
   model_hint <- NULL
 
@@ -372,6 +366,8 @@ qlm_code <- function(x, codebook, model, ...,
       chat_args = chat_args, execution_args = execution_args, batch = batch,
       allow_skip = identical(structured, "auto") && !batch
     )
+
+    unpriced <- attempt$unpriced
 
     if (isTRUE(attempt$ok)) {
       results <- attempt$value
@@ -440,10 +436,15 @@ qlm_code <- function(x, codebook, model, ...,
       execution_args = execution_args,
       batch = batch,
       max_retries = max_retries,
-      model_hint = model_hint
+      model_hint = model_hint,
+      cost_message = is.null(attempt)
     )
     backend_meta <- attr(results, "qlm_backend_meta") %||% list()
     attr(results, "qlm_backend_meta") <- NULL
+    if (is.null(unpriced)) {
+      unpriced <- backend_meta$unpriced
+    }
+    backend_meta$unpriced <- NULL
   }
 
   backend_meta$structured <- structured
@@ -472,8 +473,8 @@ qlm_code <- function(x, codebook, model, ...,
 
   # Fields contributed by a provider-specific handler (backend, max_retries, ...)
   metadata <- c(metadata, backend_meta)
-  if (!is.null(cost_note)) {
-    metadata$cost_note <- cost_note
+  if (!is.null(unpriced)) {
+    metadata$cost_note <- unpriced_note(unpriced)
   }
 
   # Add model to chat_args for easy access
@@ -534,7 +535,7 @@ default_structured_mode <- function(model) {
 #' @keywords internal
 #' @noRd
 try_structured_call <- function(x, codebook, model, chat_args, execution_args, batch,
-                                allow_skip = FALSE) {
+                                allow_skip = FALSE, cost_message = TRUE) {
   system_prompt <- if (!is.null(codebook$role)) {
     paste(codebook$role, codebook$instructions, sep = "\n\n")
   } else {
@@ -551,6 +552,9 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
     do.call(ellmer::chat, c(list(name = model, system_prompt = prompt), chat_args))
   }
   chat <- build_chat(system_prompt)
+
+  # From the chat the run will use, before anything is sent (#135)
+  unpriced <- cost_diagnosis(chat, model, execution_args, say = cost_message)
 
   # Whether a failed structured call would even be visible depends on the
   # codebook. Failure is detected from required scalar fields coming back all
@@ -571,6 +575,7 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
   if (undetectable) {
     return(list(
       ok = FALSE,
+      unpriced = unpriced,
       undetectable = TRUE,
       error = paste0(
         "this endpoint's schema enforcement cannot be verified, and the ",
@@ -674,6 +679,7 @@ try_structured_call <- function(x, codebook, model, chat_args, execution_args, b
     )
   }
 
+  attempt$unpriced <- unpriced
   attempt
 }
 

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -101,6 +101,20 @@
 #' level does not work: those reach [ellmer::chat()], which has no such
 #' argument. Use `params`.
 #'
+#' @section Cost:
+#'
+#' `include_tokens = TRUE` and `include_cost = TRUE` are forwarded to ellmer,
+#' which adds per-unit token counts and a `cost` column in US dollars. ellmer
+#' prices from a table fixed at its release, matched exactly on provider and
+#' model, and returns `NA` on any miss. Some providers are absent from that
+#' table altogether, DeepSeek among them, so no model of theirs is ever priced;
+#' a model newer than the installed ellmer is missed on a provider it otherwise
+#' prices, which upgrading fixes; and local endpoints such as ollama have no
+#' per-token charge. In each case `qlm_code()` says so once before the run,
+#' and the reason is kept with the object and shown when it is printed. Token
+#' counts are recorded regardless, so a run can be costed from the provider's
+#' published rates.
+#'
 #' @section Schema enforcement:
 #'
 #' Some providers accept a JSON Schema without enforcing it, so a response can
@@ -336,6 +350,18 @@ qlm_code <- function(x, codebook, model, ...,
   # Metadata contributed by the coding path
   backend_meta <- list()
   results <- NULL
+
+  # A cost that will come back NA is knowable before any request, and the
+  # reason decides the remedy, so say it once here rather than per row (#135).
+  # The note travels with the object so that the answer outlives the console.
+  cost_note <- NULL
+  if (isTRUE(execution_args$include_cost)) {
+    unpriced <- unpriced_reason(model, chat_args)
+    if (!is.null(unpriced)) {
+      cli::cli_inform(unpriced_message(unpriced))
+      cost_note <- unpriced_note(unpriced)
+    }
+  }
   fallback_reason <- NULL
   model_hint <- NULL
 
@@ -446,6 +472,9 @@ qlm_code <- function(x, codebook, model, ...,
 
   # Fields contributed by a provider-specific handler (backend, max_retries, ...)
   metadata <- c(metadata, backend_meta)
+  if (!is.null(cost_note)) {
+    metadata$cost_note <- cost_note
+  }
 
   # Add model to chat_args for easy access
   chat_args$name <- model
@@ -1203,6 +1232,11 @@ print.qlm_coded <- function(x, ...) {
 
   if (!is.null(meta_attr$object$parent)) {
     cat("# Parent:   ", meta_attr$object$parent, "\n", sep = "")
+  }
+
+  # Why the cost column is NA, when it was asked for and could not be filled
+  if (!is.null(meta_attr$user$cost_note)) {
+    cat("# Cost:     NA (", meta_attr$user$cost_note, ")\n", sep = "")
   }
 
   # Show notes if present

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -129,9 +129,10 @@
 #' rate, cache hits at the `cached_input` rate, output at the `output` rate,
 #' each per million. Where ellmer priced every row itself the rates are not
 #' used, and you are told so. The rates are kept in the run's metadata, shown
-#' by `print()` and in the trail report, and reused by [qlm_replicate()] for
-#' the same model, so a cost that rests on entered figures is always labelled
-#' as such. quallmer bundles no prices of its own.
+#' by `print()` and in the trail report, and reused by [qlm_replicate()] when
+#' the model, the endpoint and the batch setting are unchanged, so a cost that
+#' rests on entered figures is always labelled as such. quallmer bundles no
+#' prices of its own.
 #'
 #' @section Schema enforcement:
 #'
@@ -483,20 +484,29 @@ qlm_code <- function(x, codebook, model, ...,
   results$id <- names(x) %||% seq_along(x)
 
   # Where the cost came from, when ellmer could not fill it (#135). Supplied
-  # rates cost the rows ellmer left NA from their token counts; decided from
-  # the table rather than from the diagnosis, which cannot always be made.
-  # Where ellmer priced every row itself, its figures are the published
-  # rates and the supplied ones have nothing to do.
+  # rates cost the rows ellmer left NA from their token counts, which is
+  # decided from the table rather than from the diagnosis, since that cannot
+  # always be made. Three outcomes: no row was NA, so ellmer priced the run
+  # itself at the published rates and the supplied ones have nothing to do;
+  # rows were NA but none had the counts to cost them, so the rates could not
+  # be applied; or some were costed. Only the last records the rates.
   cost_note <- if (!is.null(unpriced)) paste0("NA (", unpriced_note(unpriced), ")")
   if (!is.null(prices)) {
-    priced <- price_from_tokens(results, prices)
-    if (identical(priced$cost, results$cost)) {
+    before <- results$cost %||% rep(NA_real_, nrow(results))
+    results <- price_from_tokens(results, prices)
+    filled <- is.na(before) & !is.na(results$cost)
+    if (!anyNA(before)) {
       cli::cli_inform(c(
         "i" = "ellmer priced this run itself; {.arg prices} is not used."
       ))
       prices <- NULL
+    } else if (!any(filled)) {
+      cli::cli_inform(c(
+        "i" = paste0("{.arg prices} could not be applied: no token counts came back ",
+                     "for the unpriced units, so their {.field cost} stays {.code NA}.")
+      ))
+      prices <- NULL
     } else {
-      results <- priced
       cost_note <- prices_note(prices)
     }
   }

--- a/R/qlm_code_json.R
+++ b/R/qlm_code_json.R
@@ -25,6 +25,8 @@
 #' @param model_hint What `model_name_hint()` answered when [qlm_code()]
 #'   already asked it for this run, so a wholly rejected run asks the provider
 #'   at most once; `NULL` when it has not been asked.
+#' @param cost_message Whether to say so when the cost will be `NA`. `FALSE`
+#'   when the structured path already has, for this run.
 #'
 #' @return A data frame with one row per unit, carrying `.error` for units that
 #'   never validated, plus token and cost columns when requested. Handler
@@ -33,7 +35,7 @@
 #' @noRd
 code_handler_json <- function(x, codebook, model, chat_args, execution_args,
                               batch = FALSE, max_retries = 2L,
-                              model_hint = NULL) {
+                              model_hint = NULL, cost_message = TRUE) {
   # The handler is reached via do.call(), so report guard failures against
   # qlm_code() rather than against an anonymous function.
   error_call <- rlang::caller_env()
@@ -82,6 +84,10 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
     ),
     chat_args
   ))
+
+  # From the chat the run will use, before anything is sent (#135). Silent
+  # when the structured path already said it for this run.
+  unpriced <- cost_diagnosis(chat, model, execution_args, say = cost_message)
 
   include_tokens <- isTRUE(execution_args$include_tokens)
   include_cost <- isTRUE(execution_args$include_cost)
@@ -253,7 +259,8 @@ code_handler_json <- function(x, codebook, model, chat_args, execution_args,
   attr(results, "qlm_backend_meta") <- list(
     backend = "json_mode",
     max_retries = max_retries,
-    n_invalid = sum(failed)
+    n_invalid = sum(failed),
+    unpriced = unpriced
   )
   results
 }

--- a/R/qlm_replicate.R
+++ b/R/qlm_replicate.R
@@ -198,18 +198,28 @@ qlm_replicate <- function(x, ..., codebook = NULL, model = NULL, batch = NULL, n
     }
   }
 
-  # Rates supplied to cost the original run belong to its model: the same
-  # model is costed the same way again, a different one is not costed on the
-  # old model's rates. An explicit `prices` in `...` is left alone (#135).
+  # Rates supplied to cost the original run belong to a pricing context:
+  # the model, the endpoint it was reached through (provider and base_url,
+  # the identity used above), and whether it ran as a batch, which providers
+  # price differently. A replication that keeps all three is costed the same
+  # way again; one that changes any of them is not costed on the old rates,
+  # and says so. An explicit `prices` in `...` is left alone (#135).
   original_prices <- meta_attr$user$prices
   if (!"prices" %in% names(call_args) && !is.null(original_prices)) {
-    if (identical(use_model, original_model)) {
+    changed <- c(
+      if (!identical(use_model, original_model)) "model",
+      if (!identical(use_endpoint, original_endpoint)) "endpoint",
+      if (!identical(use_batch, original_batch)) "batch setting"
+    )
+    if (length(changed) == 0L) {
       call_args$prices <- original_prices
     } else {
       cli::cli_inform(c(
         "i" = paste0(
-          "Not carrying over `prices`: the rates were for \"", original_model,
-          "\". Supply this model's rates in `...` to cost the replication."
+          "Not carrying over `prices`: the ", paste(changed, collapse = ", "),
+          if (length(changed) == 1L) " differs" else " differ",
+          " from the run that supplied them. Supply this run's rates in `...` ",
+          "to cost the replication."
         )
       ))
     }

--- a/R/qlm_replicate.R
+++ b/R/qlm_replicate.R
@@ -200,16 +200,21 @@ qlm_replicate <- function(x, ..., codebook = NULL, model = NULL, batch = NULL, n
 
   # Rates supplied to cost the original run belong to a pricing context:
   # the model, the endpoint it was reached through (provider and base_url,
-  # the identity used above), and whether it ran as a batch, which providers
-  # price differently. A replication that keeps all three is costed the same
-  # way again; one that changes any of them is not costed on the old rates,
-  # and says so. An explicit `prices` in `...` is left alone (#135).
+  # the identity used above), whether it ran as a batch, and the service
+  # tier, each of which providers price differently. A replication that keeps
+  # all four is costed the same way again; one that changes any of them is
+  # not costed on the old rates, and says so. A tier left unset is ellmer's
+  # default, "auto", and a change to any explicit tier counts. An explicit
+  # `prices` in `...` is left alone (#135).
   original_prices <- meta_attr$user$prices
   if (!"prices" %in% names(call_args) && !is.null(original_prices)) {
+    original_tier <- meta_attr$object$chat_args$service_tier %||% "auto"
+    use_tier <- call_args$service_tier %||% "auto"
     changed <- c(
       if (!identical(use_model, original_model)) "model",
       if (!identical(use_endpoint, original_endpoint)) "endpoint",
-      if (!identical(use_batch, original_batch)) "batch setting"
+      if (!identical(use_batch, original_batch)) "batch setting",
+      if (!identical(use_tier, original_tier)) "service tier"
     )
     if (length(changed) == 0L) {
       call_args$prices <- original_prices

--- a/R/qlm_replicate.R
+++ b/R/qlm_replicate.R
@@ -198,6 +198,23 @@ qlm_replicate <- function(x, ..., codebook = NULL, model = NULL, batch = NULL, n
     }
   }
 
+  # Rates supplied to cost the original run belong to its model: the same
+  # model is costed the same way again, a different one is not costed on the
+  # old model's rates. An explicit `prices` in `...` is left alone (#135).
+  original_prices <- meta_attr$user$prices
+  if (!"prices" %in% names(call_args) && !is.null(original_prices)) {
+    if (identical(use_model, original_model)) {
+      call_args$prices <- original_prices
+    } else {
+      cli::cli_inform(c(
+        "i" = paste0(
+          "Not carrying over `prices`: the rates were for \"", original_model,
+          "\". Supply this model's rates in `...` to cost the replication."
+        )
+      ))
+    }
+  }
+
   # Call qlm_code with merged arguments, including batch flag
   result <- do.call(qlm_code, c(
     list(

--- a/R/qlm_trail.R
+++ b/R/qlm_trail.R
@@ -151,6 +151,8 @@ qlm_trail <- function(..., path = NULL) {
       run$batch <- meta_attr$object$batch
       run$chat_args <- meta_attr$object$chat_args
       run$execution_args <- meta_attr$object$execution_args
+      run$prices <- meta_attr$user$prices
+      run$cost_note <- meta_attr$user$cost_note
       run$metadata$n_units <- meta_attr$object$n_units
       run$metadata$ellmer_version <- meta_attr$system$ellmer_version
     } else if (inherits(obj, "qlm_comparison")) {
@@ -518,6 +520,12 @@ generate_trail_report <- function(trail, file) {
       ))
     }
 
+    # Where the cost column came from, when ellmer could not fill it: a
+    # figure resting on entered rates must say so in the artefact (#135)
+    if (!is.null(run$cost_note)) {
+      lines <- c(lines, paste("**Cost:**", run$cost_note))
+    }
+
     # Codebook reference
     if (!is.null(run$codebook$name)) {
       lines <- c(lines, paste("**Codebook:**", run$codebook$name))
@@ -795,6 +803,13 @@ generate_trail_report <- function(trail, file) {
 
       if (!is.null(run$batch) && run$batch) {
         code_call <- paste0(code_call, ",\n  batch = TRUE")
+      }
+
+      if (!is.null(run$prices)) {
+        code_call <- paste0(
+          code_call, ",\n  prices = c(",
+          paste(Map(format_param, names(run$prices), run$prices), collapse = ", "), ")"
+        )
       }
 
       code_call <- paste0(code_call, ",\n  name = \"", run$name, "\"")

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -169,9 +169,10 @@ sum ellmer applies to its own table: uncached input tokens at the \code{input}
 rate, cache hits at the \code{cached_input} rate, output at the \code{output} rate,
 each per million. Where ellmer priced every row itself the rates are not
 used, and you are told so. The rates are kept in the run's metadata, shown
-by \code{print()} and in the trail report, and reused by \code{\link[=qlm_replicate]{qlm_replicate()}} for
-the same model, so a cost that rests on entered figures is always labelled
-as such. quallmer bundles no prices of its own.
+by \code{print()} and in the trail report, and reused by \code{\link[=qlm_replicate]{qlm_replicate()}} when
+the model, the endpoint and the batch setting are unchanged, so a cost that
+rests on entered figures is always labelled as such. quallmer bundles no
+prices of its own.
 }
 
 \section{Schema enforcement}{

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -149,9 +149,9 @@ table altogether, DeepSeek among them, so no model of theirs is ever priced;
 a model newer than the installed ellmer is missed on a provider it otherwise
 prices, which upgrading fixes; and local endpoints such as ollama have no
 per-token charge. In each case \code{qlm_code()} says so once before the run,
-and the reason is kept with the object and shown when it is printed. Token
-counts are recorded regardless, so a run can be costed from the provider's
-published rates.
+and the reason is kept with the object and shown when it is printed. With
+\code{include_tokens = TRUE} the token counts are recorded, from which such a
+run can be costed at the provider's published rates.
 }
 
 \section{Schema enforcement}{

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -170,9 +170,9 @@ rate, cache hits at the \code{cached_input} rate, output at the \code{output} ra
 each per million. Where ellmer priced every row itself the rates are not
 used, and you are told so. The rates are kept in the run's metadata, shown
 by \code{print()} and in the trail report, and reused by \code{\link[=qlm_replicate]{qlm_replicate()}} when
-the model, the endpoint and the batch setting are unchanged, so a cost that
-rests on entered figures is always labelled as such. quallmer bundles no
-prices of its own.
+the model, the endpoint, the batch setting and the service tier are
+unchanged, so a cost that rests on entered figures is always labelled as
+such. quallmer bundles no prices of its own.
 }
 
 \section{Schema enforcement}{

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -12,6 +12,7 @@ qlm_code(
   batch = FALSE,
   structured = c("auto", "structured", "json"),
   max_retries = 2L,
+  prices = NULL,
   name = NULL,
   notes = NULL
 )
@@ -58,6 +59,14 @@ error. Default is 2, giving at most three attempts per unit. This is
 separate from ellmer's transport-level retries for rate limits and server
 errors, which apply to every provider and are set with
 \code{options(ellmer_max_tries = )}.}
+
+\item{prices}{Optional. Rates for costing the run when ellmer cannot: a
+named numeric vector or list with \code{input} and \code{output}, and optionally
+\code{cached_input}, in US dollars per million tokens, for example
+\code{c(input = 0.435, output = 0.87, cached_input = 0.0036)}. Where ellmer
+prices the model itself its figure stands and these are not used. A
+\code{cached_input} rate that is not given is taken as the \code{input} rate. See
+the section on cost. Default is \code{NULL}.}
 
 \item{name}{Character string identifying this coding run. Default is \code{NULL}.}
 
@@ -152,6 +161,17 @@ per-token charge. In each case \code{qlm_code()} says so once before the run,
 and the reason is kept with the object and shown when it is printed. With
 \code{include_tokens = TRUE} the token counts are recorded, from which such a
 run can be costed at the provider's published rates.
+
+\code{prices} does that costing, at rates you supply from the provider's
+published price list. Supplying them implies \code{include_tokens = TRUE} and
+\code{include_cost = TRUE}. Only rows ellmer left \code{NA} are filled, by the same
+sum ellmer applies to its own table: uncached input tokens at the \code{input}
+rate, cache hits at the \code{cached_input} rate, output at the \code{output} rate,
+each per million. Where ellmer priced every row itself the rates are not
+used, and you are told so. The rates are kept in the run's metadata, shown
+by \code{print()} and in the trail report, and reused by \code{\link[=qlm_replicate]{qlm_replicate()}} for
+the same model, so a cost that rests on entered figures is always labelled
+as such. quallmer bundles no prices of its own.
 }
 
 \section{Schema enforcement}{

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -138,6 +138,22 @@ level does not work: those reach \code{\link[ellmer:chat]{ellmer::chat()}}, whic
 argument. Use \code{params}.
 }
 
+\section{Cost}{
+
+
+\code{include_tokens = TRUE} and \code{include_cost = TRUE} are forwarded to ellmer,
+which adds per-unit token counts and a \code{cost} column in US dollars. ellmer
+prices from a table fixed at its release, matched exactly on provider and
+model, and returns \code{NA} on any miss. Some providers are absent from that
+table altogether, DeepSeek among them, so no model of theirs is ever priced;
+a model newer than the installed ellmer is missed on a provider it otherwise
+prices, which upgrading fixes; and local endpoints such as ollama have no
+per-token charge. In each case \code{qlm_code()} says so once before the run,
+and the reason is kept with the object and shown when it is printed. Token
+counts are recorded regardless, so a run can be costed from the provider's
+published rates.
+}
+
 \section{Schema enforcement}{
 
 

--- a/tests/testthat/test-cost.R
+++ b/tests/testthat/test-cost.R
@@ -1,0 +1,81 @@
+# check_prices() --------------------------------------------------------------
+
+test_that("check_prices() accepts the documented shapes and fills the cached rate", {
+  expect_null(check_prices(NULL))
+
+  full <- check_prices(c(input = 0.435, output = 0.87, cached_input = 0.0036))
+  expect_equal(full, c(input = 0.435, output = 0.87, cached_input = 0.0036))
+
+  # A list works too, and a missing cached rate is the input rate
+  from_list <- check_prices(list(input = 2, output = 8))
+  expect_equal(from_list, c(input = 2, output = 8, cached_input = 2))
+
+  # Order of the names does not matter
+  expect_equal(check_prices(c(output = 8, input = 2)), c(input = 2, output = 8, cached_input = 2))
+})
+
+test_that("check_prices() names what is wrong", {
+  expect_error(check_prices(0.5), "not a named numeric vector")
+  expect_error(check_prices(c(0.5, 1)), "not a named numeric vector")
+  expect_error(check_prices(c(input = 1)), "Missing: output")
+  expect_error(check_prices(c(input = 1, output = 2, cache = 3)), "Not a rate: cache")
+  expect_error(check_prices(c(input = 1, output = 2, input = 3)), "more than once")
+  expect_error(check_prices(c(input = -1, output = 2)), "non-negative number: input")
+  expect_error(check_prices(list(input = "1", output = 2)), "non-negative number: input")
+  expect_error(check_prices(list(input = c(1, 2), output = 2)), "non-negative number: input")
+  expect_error(check_prices(c(input = NA, output = 2)), "non-negative number: input")
+  expect_error(check_prices(c(input = Inf, output = 2)), "non-negative number: input")
+})
+
+
+# price_from_tokens() ---------------------------------------------------------
+
+prices <- c(input = 1, output = 10, cached_input = 0.1)
+
+test_that("price_from_tokens() fills only what ellmer left NA, by ellmer's sum", {
+  results <- data.frame(
+    score = 1:4,
+    input_tokens = c(1e6, 2e6, 1e6, NA),
+    output_tokens = c(1e5, 1e5, 1e5, 1e5),
+    cached_input_tokens = c(0, 5e5, NA, 0),
+    cost = c(NA, NA, 0.42, NA)
+  )
+  out <- price_from_tokens(results, prices)
+
+  # 1e6 * 1 + 0 * 0.1 + 1e5 * 10, per million
+  expect_equal(out$cost[1], 2)
+  # cached tokens are additive to input, as ellmer normalises them
+  expect_equal(out$cost[2], (2e6 * 1 + 5e5 * 0.1 + 1e5 * 10) / 1e6)
+  # ellmer's own figure stands
+  expect_equal(out$cost[3], 0.42)
+  # no token counts, no cost
+  expect_true(is.na(out$cost[4]))
+  # nothing else touched
+  expect_equal(out$score, 1:4)
+})
+
+test_that("price_from_tokens() leaves a table without token columns alone", {
+  results <- data.frame(score = 1:2, cost = c(NA, NA))
+  expect_identical(price_from_tokens(results, prices), results)
+})
+
+test_that("price_from_tokens() adds the cost column when ellmer did not", {
+  results <- data.frame(score = 1:2, input_tokens = c(1e6, 0), output_tokens = c(0, 1e5),
+                        cached_input_tokens = c(0, 0))
+  out <- price_from_tokens(results, prices)
+  expect_equal(out$cost, c(1, 1))
+})
+
+
+# prices_note() ---------------------------------------------------------------
+
+test_that("prices_note() states the rates without scientific notation", {
+  expect_equal(
+    prices_note(c(input = 0.435, output = 0.87, cached_input = 0.0036)),
+    "from supplied rates: $0.435 input, $0.87 output, $0.0036 cached input, per million tokens"
+  )
+  expect_equal(
+    prices_note(c(input = 2, output = 8, cached_input = 2)),
+    "from supplied rates: $2 input, $8 output, $2 cached input, per million tokens"
+  )
+})

--- a/tests/testthat/test-providers.R
+++ b/tests/testthat/test-providers.R
@@ -313,48 +313,95 @@ test_that("a diagnosis never reaches the network in tests", {
 
 # unpriced_reason() -----------------------------------------------------------
 
-# A credentials function keeps construction off the environment and sends
-# nothing: ellmer builds the provider without contacting it.
-no_creds <- list(credentials = function() list(Authorization = "Bearer x"))
+# A chat as the run would build it. The credentials function keeps
+# construction off the environment, and construction sends nothing.
+test_chat <- function(model) {
+  ellmer::chat(model, credentials = function() list(Authorization = "Bearer x"))
+}
 
 test_that("unpriced_reason() is NULL for a model ellmer prices (#135)", {
-  expect_null(unpriced_reason("openai/gpt-4.1-mini", no_creds))
-  expect_null(unpriced_reason("anthropic/claude-sonnet-4-5", no_creds))
+  expect_null(unpriced_reason(test_chat("openai/gpt-4.1-mini"), "openai/gpt-4.1-mini"))
+  expect_null(unpriced_reason(test_chat("anthropic/claude-sonnet-4-5"),
+                              "anthropic/claude-sonnet-4-5"))
 })
 
 test_that("unpriced_reason() tells a provider gap from a model gap (#135)", {
   # DeepSeek is absent from ellmer's table as a whole
-  r <- unpriced_reason("deepseek/deepseek-chat", no_creds)
+  r <- unpriced_reason(test_chat("deepseek/deepseek-chat"), "deepseek/deepseek-chat")
   expect_equal(r$kind, "provider")
   expect_equal(r$provider, "DeepSeek")
   expect_equal(r$model, "deepseek-chat")
 
   # OpenAI is priced, this model is not
-  r <- unpriced_reason("openai/gpt-99-not-yet-released", no_creds)
+  r <- unpriced_reason(test_chat("openai/gpt-99-not-yet-released"),
+                       "openai/gpt-99-not-yet-released")
   expect_equal(r$kind, "model")
   expect_equal(r$provider, "OpenAI")
   expect_equal(r$model, "gpt-99-not-yet-released")
 })
 
-test_that("unpriced_reason() names a local endpoint without building a chat (#135)", {
-  # ellmer's ollama constructor looks for a running server; none is here
-  r <- unpriced_reason("ollama/llama3")
+test_that("unpriced_reason() names a local endpoint from the prefix alone (#135)", {
+  # No chat is consulted: ellmer's ollama constructor looks for a running server
+  r <- unpriced_reason(NULL, "ollama/llama3")
   expect_equal(r$kind, "local")
   expect_equal(r$provider, "ollama")
   expect_equal(r$model, "llama3")
-  expect_equal(unpriced_reason("vllm/x")$kind, "local")
-  expect_equal(unpriced_reason("lmstudio/x")$kind, "local")
+  expect_equal(unpriced_reason(NULL, "vllm/x")$kind, "local")
+  expect_equal(unpriced_reason(NULL, "lmstudio/x")$kind, "local")
 })
 
 test_that("unpriced_reason() stays silent where it cannot decide (#135)", {
-  # The chat cannot be built: openai_compatible needs a base_url. The run
-  # itself will say so; nothing to add.
-  expect_null(unpriced_reason("openai_compatible/qwen3", no_creds))
+  # Not an ellmer chat, so no provider to read
+  expect_null(unpriced_reason(structure(list(), class = "fake_chat"), "deepseek/deepseek-chat"))
+  expect_null(unpriced_reason(NULL, "deepseek/deepseek-chat"))
 
   # ellmer without the price table or its predicate: no diagnosis
   f <- unpriced_reason
   mockery::stub(f, "get0", function(x, ...) NULL)
-  expect_null(f("deepseek/deepseek-chat", no_creds))
+  expect_null(f(test_chat("deepseek/deepseek-chat"), "deepseek/deepseek-chat"))
+})
+
+test_that("cost_diagnosis() speaks only when a cost was asked for, and only when told to (#135)", {
+  chat <- test_chat("deepseek/deepseek-chat")
+
+  # No cost asked for: no lookup, nothing said
+  expect_no_message(r <- cost_diagnosis(chat, "deepseek/deepseek-chat", list()))
+  expect_null(r)
+  expect_no_message(r <- cost_diagnosis(chat, "deepseek/deepseek-chat", list(include_cost = FALSE)))
+  expect_null(r)
+
+  # Asked for and unpriced: said once, and the reason comes back
+  expect_message(
+    r <- cost_diagnosis(chat, "deepseek/deepseek-chat", list(include_cost = TRUE)),
+    "no prices for DeepSeek models"
+  )
+  expect_equal(r$kind, "provider")
+
+  # The fallback path is told not to repeat it, but still learns the reason
+  expect_no_message(
+    r <- cost_diagnosis(chat, "deepseek/deepseek-chat", list(include_cost = TRUE), say = FALSE)
+  )
+  expect_equal(r$kind, "provider")
+
+  # Priced: nothing to say
+  expect_no_message(
+    r <- cost_diagnosis(test_chat("openai/gpt-4.1-mini"), "openai/gpt-4.1-mini",
+                        list(include_cost = TRUE))
+  )
+  expect_null(r)
+})
+
+test_that("unpriced_message() says whether the token counts are being recorded (#135)", {
+  provider <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
+  model <- list(kind = "model", provider = "OpenAI", model = "gpt-99")
+
+  # include_cost alone records no counts, and the message must not claim it does
+  expect_match(unpriced_message(provider)[[2]], "Set `include_tokens = TRUE` to record")
+  expect_match(unpriced_message(model)[[2]], "Set `include_tokens = TRUE` to record")
+  expect_match(unpriced_message(provider, tokens_recorded = TRUE)[[2]],
+               "^Token counts are recorded")
+  expect_match(unpriced_message(model, tokens_recorded = TRUE)[[2]],
+               "Token counts are recorded")
 })
 
 test_that("unpriced_message() and unpriced_note() cover every kind (#135)", {
@@ -367,6 +414,7 @@ test_that("unpriced_message() and unpriced_note() cover every kind (#135)", {
   expect_match(unpriced_message(model)[["i"]], "other OpenAI models")
   expect_match(unpriced_message(local)[["i"]], "runs locally")
   expect_length(unpriced_message(provider), 2)
+  expect_length(unpriced_message(local), 1)
 
   expect_equal(unpriced_note(provider), "ellmer has no prices for DeepSeek models")
   expect_match(unpriced_note(model), "^ellmer [0-9.]+ has no price for gpt-99$")

--- a/tests/testthat/test-providers.R
+++ b/tests/testthat/test-providers.R
@@ -309,3 +309,66 @@ test_that("a diagnosis never reaches the network in tests", {
   mockery::stub(f, "models_lister", function(provider) function(...) stop("no key"))
   expect_null(f("openai"))
 })
+
+
+# unpriced_reason() -----------------------------------------------------------
+
+# A credentials function keeps construction off the environment and sends
+# nothing: ellmer builds the provider without contacting it.
+no_creds <- list(credentials = function() list(Authorization = "Bearer x"))
+
+test_that("unpriced_reason() is NULL for a model ellmer prices (#135)", {
+  expect_null(unpriced_reason("openai/gpt-4.1-mini", no_creds))
+  expect_null(unpriced_reason("anthropic/claude-sonnet-4-5", no_creds))
+})
+
+test_that("unpriced_reason() tells a provider gap from a model gap (#135)", {
+  # DeepSeek is absent from ellmer's table as a whole
+  r <- unpriced_reason("deepseek/deepseek-chat", no_creds)
+  expect_equal(r$kind, "provider")
+  expect_equal(r$provider, "DeepSeek")
+  expect_equal(r$model, "deepseek-chat")
+
+  # OpenAI is priced, this model is not
+  r <- unpriced_reason("openai/gpt-99-not-yet-released", no_creds)
+  expect_equal(r$kind, "model")
+  expect_equal(r$provider, "OpenAI")
+  expect_equal(r$model, "gpt-99-not-yet-released")
+})
+
+test_that("unpriced_reason() names a local endpoint without building a chat (#135)", {
+  # ellmer's ollama constructor looks for a running server; none is here
+  r <- unpriced_reason("ollama/llama3")
+  expect_equal(r$kind, "local")
+  expect_equal(r$provider, "ollama")
+  expect_equal(r$model, "llama3")
+  expect_equal(unpriced_reason("vllm/x")$kind, "local")
+  expect_equal(unpriced_reason("lmstudio/x")$kind, "local")
+})
+
+test_that("unpriced_reason() stays silent where it cannot decide (#135)", {
+  # The chat cannot be built: openai_compatible needs a base_url. The run
+  # itself will say so; nothing to add.
+  expect_null(unpriced_reason("openai_compatible/qwen3", no_creds))
+
+  # ellmer without the price table or its predicate: no diagnosis
+  f <- unpriced_reason
+  mockery::stub(f, "get0", function(x, ...) NULL)
+  expect_null(f("deepseek/deepseek-chat", no_creds))
+})
+
+test_that("unpriced_message() and unpriced_note() cover every kind (#135)", {
+  provider <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
+  model <- list(kind = "model", provider = "OpenAI", model = "gpt-99")
+  local <- list(kind = "local", provider = "ollama", model = "llama3")
+
+  expect_match(unpriced_message(provider)[["i"]], "no prices for DeepSeek models")
+  expect_match(unpriced_message(model)[["i"]], "no price for \"gpt-99\"")
+  expect_match(unpriced_message(model)[["i"]], "other OpenAI models")
+  expect_match(unpriced_message(local)[["i"]], "runs locally")
+  expect_length(unpriced_message(provider), 2)
+
+  expect_equal(unpriced_note(provider), "ellmer has no prices for DeepSeek models")
+  expect_match(unpriced_note(model), "^ellmer [0-9.]+ has no price for gpt-99$")
+  expect_equal(unpriced_note(local), "ollama runs locally; no per-token charge")
+})

--- a/tests/testthat/test-providers.R
+++ b/tests/testthat/test-providers.R
@@ -396,12 +396,14 @@ test_that("unpriced_message() says whether the token counts are being recorded (
   model <- list(kind = "model", provider = "OpenAI", model = "gpt-99")
 
   # include_cost alone records no counts, and the message must not claim it does
-  expect_match(unpriced_message(provider)[[2]], "Set `include_tokens = TRUE` to record")
-  expect_match(unpriced_message(model)[[2]], "Set `include_tokens = TRUE` to record")
+  # Supplying `prices` records the counts itself, so that is the advice
+  expect_match(unpriced_message(provider)[[2]],
+               "^Supply the provider's published rates as `prices`")
+  expect_match(unpriced_message(model)[[2]], "Supply the provider's published rates as `prices`")
   expect_match(unpriced_message(provider, tokens_recorded = TRUE)[[2]],
-               "^Token counts are recorded")
+               "^Token counts are recorded; supply")
   expect_match(unpriced_message(model, tokens_recorded = TRUE)[[2]],
-               "Token counts are recorded")
+               "Token counts are recorded; supply")
 })
 
 test_that("unpriced_message() and unpriced_note() cover every kind (#135)", {

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -1433,3 +1433,58 @@ test_that("every entry point refuses an object a row operation has left with a r
   expect_error(qlm_trail(doubled), "must be unique")
   expect_error(qlm_replicate(doubled), "must be unique")
 })
+
+
+# cost that cannot be priced (#135) --------------------------------------------
+
+# qlm_code() with the structured call stubbed to return `results`, and the
+# pricing lookup stubbed to answer `reason`. Callers pin
+# structured = "structured": DeepSeek defaults to the JSON path, which the
+# stub does not cover.
+coding_run <- function(results, reason) {
+  tsc <- function(...) list(ok = TRUE, value = results)
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
+  mockery::stub(f, "unpriced_reason", function(model, chat_args) reason)
+  f
+}
+
+test_that("qlm_code says once, before the run, why cost will be NA (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Test prompt", type_obj)
+  results <- data.frame(score = c(0.5, 0.8), input_tokens = c(10, 12),
+                        output_tokens = c(3, 4), cached_input_tokens = c(0, 0),
+                        cost = c(NA_real_, NA_real_))
+  reason <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
+
+  f <- coding_run(results, reason)
+  expect_message(
+    coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
+               include_cost = TRUE, structured = "structured"),
+    "no prices for DeepSeek models"
+  )
+  expect_equal(qlm_meta(coded)$cost_note, "ellmer has no prices for DeepSeek models")
+  expect_output(print(coded), "# Cost:     NA (ellmer has no prices for DeepSeek models)",
+                fixed = TRUE)
+})
+
+test_that("qlm_code is silent about cost when it was not asked for, or is priced (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Test prompt", type_obj)
+  results <- data.frame(score = c(0.5, 0.8))
+  reason <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
+
+  # Not asked for: the lookup is not even made
+  f <- coding_run(results, reason)
+  expect_no_message(coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
+                               structured = "structured"))
+  expect_null(qlm_meta(coded)$cost_note)
+  expect_output(print(coded), "# Units:")
+  expect_no_match(paste(capture.output(print(coded)), collapse = "\n"), "# Cost:")
+
+  # Asked for and priced: nothing to say
+  f <- coding_run(results, NULL)
+  expect_no_message(coded <- f(c("a", "b"), codebook, model = "openai/gpt-4.1-mini",
+                               include_cost = TRUE, structured = "structured"))
+  expect_null(qlm_meta(coded)$cost_note)
+})

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -1576,6 +1576,28 @@ test_that("qlm_code leaves ellmer's own prices in charge (#135)", {
   expect_null(qlm_meta(coded)$cost_note)
 })
 
+test_that("qlm_code says when supplied rates could not be applied (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Test prompt", type_obj)
+  # Unpriced, and no counts came back to cost it from
+  results <- data.frame(score = c(0.5, 0.8), input_tokens = c(NA_real_, NA_real_),
+                        output_tokens = c(NA_real_, NA_real_),
+                        cached_input_tokens = c(NA_real_, NA_real_),
+                        cost = c(NA_real_, NA_real_))
+
+  f <- priced_run(results, new.env())
+  expect_message(
+    coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
+               credentials = offline, structured = "structured",
+               prices = c(input = 1, output = 10)),
+    "could not be applied"
+  )
+  expect_true(all(is.na(coded$cost)))
+  # The rates are not recorded, and the note says why the cost is NA
+  expect_null(qlm_meta(coded)$prices)
+  expect_equal(qlm_meta(coded)$cost_note, "NA (ellmer has no prices for DeepSeek models)")
+})
+
 test_that("qlm_code rejects malformed prices before any request (#135)", {
   type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
   codebook <- qlm_codebook("Test", "Test prompt", type_obj)

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -1461,7 +1461,7 @@ test_that("qlm_code says once, before the run, why cost will be NA (#135)", {
                credentials = offline, include_cost = TRUE, structured = "structured"),
     "no prices for DeepSeek models"
   )
-  expect_equal(qlm_meta(coded)$cost_note, "ellmer has no prices for DeepSeek models")
+  expect_equal(qlm_meta(coded)$cost_note, "NA (ellmer has no prices for DeepSeek models)")
   expect_output(print(coded), "# Cost:     NA (ellmer has no prices for DeepSeek models)",
                 fixed = TRUE)
 })
@@ -1475,7 +1475,7 @@ test_that("qlm_code's cost message says whether token counts are recorded (#135)
   expect_message(
     coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
                credentials = offline, include_cost = TRUE, structured = "structured"),
-    "Set `include_tokens = TRUE` to record"
+    "Supply the provider's published rates as `prices`"
   )
   expect_false("input_tokens" %in% names(coded))
 
@@ -1488,7 +1488,7 @@ test_that("qlm_code's cost message says whether token counts are recorded (#135)
     coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
                credentials = offline, include_cost = TRUE, include_tokens = TRUE,
                structured = "structured"),
-    "Token counts are recorded"
+    "Token counts are recorded; supply"
   )
   expect_true("input_tokens" %in% names(coded))
 })
@@ -1511,4 +1511,78 @@ test_that("qlm_code is silent about cost when it was not asked for, or is priced
                                credentials = offline, include_cost = TRUE,
                                structured = "structured"))
   expect_null(qlm_meta(coded)$cost_note)
+})
+
+
+# cost from supplied rates (#135) ----------------------------------------------
+
+# coding_run() from above, with the execution arguments the structured call
+# received recorded in `seen`.
+priced_run <- function(results, seen) {
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", function(chat, prompts, type, ...) {
+    seen$execution_args <- list(...)
+    results
+  })
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
+  f
+}
+
+test_that("qlm_code costs an unpriced run from supplied rates (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Test prompt", type_obj)
+  results <- data.frame(score = c(0.5, 0.8), input_tokens = c(1e6, 2e6),
+                        output_tokens = c(1e5, 1e5), cached_input_tokens = c(0, 5e5),
+                        cost = c(NA_real_, NA_real_))
+  seen <- new.env()
+
+  f <- priced_run(results, seen)
+  # No "cost will be NA" message: it will not be
+  expect_no_message(
+    coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
+               credentials = offline, structured = "structured",
+               prices = c(input = 1, output = 10, cached_input = 0.1))
+  )
+
+  # Costed by ellmer's sum, per million tokens
+  expect_equal(coded$cost, c(2, (2e6 + 5e5 * 0.1 + 1e6) / 1e6))
+  # Supplying rates asked ellmer for tokens and cost
+  expect_true(isTRUE(seen$execution_args$include_tokens))
+  expect_true(isTRUE(seen$execution_args$include_cost))
+  # The rates travel with the object, and print says where the cost came from
+  expect_equal(qlm_meta(coded)$prices, c(input = 1, output = 10, cached_input = 0.1))
+  expect_equal(qlm_meta(coded)$cost_note,
+               "from supplied rates: $1 input, $10 output, $0.1 cached input, per million tokens")
+  expect_output(print(coded), "# Cost:     from supplied rates: $1 input", fixed = TRUE)
+})
+
+test_that("qlm_code leaves ellmer's own prices in charge (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Test prompt", type_obj)
+  results <- data.frame(score = c(0.5, 0.8), input_tokens = c(1e6, 2e6),
+                        output_tokens = c(1e5, 1e5), cached_input_tokens = c(0, 0),
+                        cost = c(0.3, 0.6))
+
+  f <- priced_run(results, new.env())
+  expect_message(
+    coded <- f(c("a", "b"), codebook, model = "openai/gpt-4.1-mini",
+               credentials = offline, structured = "structured",
+               prices = c(input = 1, output = 10)),
+    "prices.*is not used"
+  )
+  expect_equal(coded$cost, c(0.3, 0.6))
+  expect_null(qlm_meta(coded)$prices)
+  expect_null(qlm_meta(coded)$cost_note)
+})
+
+test_that("qlm_code rejects malformed prices before any request (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Test prompt", type_obj)
+  f <- priced_run(data.frame(score = 1), new.env())
+  expect_error(
+    f("a", codebook, model = "openai/gpt-4.1-mini", credentials = offline,
+      prices = c(input = 1), structured = "structured"),
+    "Missing: output"
+  )
 })

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -453,7 +453,7 @@ test_that("qlm_code delegates to the handler and records the backend", {
 
   handler_args <- NULL
   fake_handler <- function(x, codebook, model, chat_args, execution_args, batch,
-                           max_retries = 2L, model_hint = NULL) {
+                           max_retries = 2L, model_hint = NULL, ...) {
     handler_args <<- list(model = model, batch = batch, max_retries = max_retries,
                           chat_args = chat_args, execution_args = execution_args)
     results <- tibble::tibble(score = c(0.5, 0.8))
@@ -542,7 +542,7 @@ test_that("qlm_code passes its max_retries default to the handler", {
 
   seen <- NULL
   fake_handler <- function(x, codebook, model, chat_args, execution_args, batch,
-                           max_retries, model_hint = NULL) {
+                           max_retries, model_hint = NULL, ...) {
     seen <<- max_retries
     tibble::tibble(score = 0.5)
   }
@@ -590,7 +590,7 @@ structured_stub <- function(results = data.frame(score = 0.5), errors = NULL,
 
 json_stub <- function(calls = NULL) {
   function(x, codebook, model, chat_args, execution_args, batch, max_retries,
-           model_hint = NULL) {
+           model_hint = NULL, ...) {
     if (!is.null(calls)) {
       calls$json <- TRUE
       calls$max_retries <- max_retries
@@ -1438,29 +1438,27 @@ test_that("every entry point refuses an object a row operation has left with a r
 # cost that cannot be priced (#135) --------------------------------------------
 
 # qlm_code() with the structured call stubbed to return `results`, and the
-# pricing lookup stubbed to answer `reason`. Callers pin
-# structured = "structured": DeepSeek defaults to the JSON path, which the
-# stub does not cover.
-coding_run <- function(results, reason) {
-  tsc <- function(...) list(ok = TRUE, value = results)
+# chat built for real, off the environment and sending nothing, so that the
+# diagnosis reads the provider the run would use. Callers pin
+# structured = "structured": DeepSeek defaults to the JSON path.
+coding_run <- function(results) {
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", results)
   f <- qlm_code
   mockery::stub(f, "try_structured_call", tsc)
-  mockery::stub(f, "unpriced_reason", function(model, chat_args) reason)
   f
 }
+offline <- function() list(Authorization = "Bearer x")
 
 test_that("qlm_code says once, before the run, why cost will be NA (#135)", {
   type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
   codebook <- qlm_codebook("Test", "Test prompt", type_obj)
-  results <- data.frame(score = c(0.5, 0.8), input_tokens = c(10, 12),
-                        output_tokens = c(3, 4), cached_input_tokens = c(0, 0),
-                        cost = c(NA_real_, NA_real_))
-  reason <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
+  results <- data.frame(score = c(0.5, 0.8), cost = c(NA_real_, NA_real_))
 
-  f <- coding_run(results, reason)
+  f <- coding_run(results)
   expect_message(
     coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
-               include_cost = TRUE, structured = "structured"),
+               credentials = offline, include_cost = TRUE, structured = "structured"),
     "no prices for DeepSeek models"
   )
   expect_equal(qlm_meta(coded)$cost_note, "ellmer has no prices for DeepSeek models")
@@ -1468,23 +1466,49 @@ test_that("qlm_code says once, before the run, why cost will be NA (#135)", {
                 fixed = TRUE)
 })
 
+test_that("qlm_code's cost message says whether token counts are recorded (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Test prompt", type_obj)
+
+  # include_cost alone: no token columns come back, and the message says so
+  f <- coding_run(data.frame(score = c(0.5, 0.8), cost = c(NA_real_, NA_real_)))
+  expect_message(
+    coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
+               credentials = offline, include_cost = TRUE, structured = "structured"),
+    "Set `include_tokens = TRUE` to record"
+  )
+  expect_false("input_tokens" %in% names(coded))
+
+  # With include_tokens the counts are there, and the message says that instead
+  with_tokens <- data.frame(score = c(0.5, 0.8), input_tokens = c(10, 12),
+                            output_tokens = c(3, 4), cached_input_tokens = c(0, 0),
+                            cost = c(NA_real_, NA_real_))
+  f <- coding_run(with_tokens)
+  expect_message(
+    coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
+               credentials = offline, include_cost = TRUE, include_tokens = TRUE,
+               structured = "structured"),
+    "Token counts are recorded"
+  )
+  expect_true("input_tokens" %in% names(coded))
+})
+
 test_that("qlm_code is silent about cost when it was not asked for, or is priced (#135)", {
   type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
   codebook <- qlm_codebook("Test", "Test prompt", type_obj)
   results <- data.frame(score = c(0.5, 0.8))
-  reason <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
 
   # Not asked for: the lookup is not even made
-  f <- coding_run(results, reason)
+  f <- coding_run(results)
   expect_no_message(coded <- f(c("a", "b"), codebook, model = "deepseek/deepseek-chat",
-                               structured = "structured"))
+                               credentials = offline, structured = "structured"))
   expect_null(qlm_meta(coded)$cost_note)
   expect_output(print(coded), "# Units:")
   expect_no_match(paste(capture.output(print(coded)), collapse = "\n"), "# Cost:")
 
   # Asked for and priced: nothing to say
-  f <- coding_run(results, NULL)
   expect_no_message(coded <- f(c("a", "b"), codebook, model = "openai/gpt-4.1-mini",
-                               include_cost = TRUE, structured = "structured"))
+                               credentials = offline, include_cost = TRUE,
+                               structured = "structured"))
   expect_null(qlm_meta(coded)$cost_note)
 })

--- a/tests/testthat/test-qlm_code_json.R
+++ b/tests/testthat/test-qlm_code_json.R
@@ -1018,3 +1018,59 @@ test_that("is_json_word_error recognises the DashScope rejection", {
   expect_false(is_json_word_error(NA_character_))
   expect_false(is_json_word_error(character(0)))
 })
+
+
+# cost that cannot be priced (#135) --------------------------------------------
+
+# The handler with only the round trip stubbed out: the chat is built for
+# real, off the environment, so the diagnosis reads the provider the run
+# would use.
+json_offline_handler <- function(attempts) {
+  h <- code_handler_json
+  mockery::stub(h, "model_name_hint", function(...) character())
+  i <- 0L
+  mockery::stub(h, "json_chat_turns", function(chat, prompts, pc_args) {
+    i <<- i + 1L
+    attempt <- attempts[[i]]
+    n <- length(attempt$text)
+    list(
+      text = attempt$text,
+      error = rep(NA_character_, n),
+      status = rep(NA_integer_, n),
+      finish = rep(NA_character_, n),
+      usage = json_test_usage(n)
+    )
+  })
+  h
+}
+offline_args <- list(credentials = function() list(Authorization = "Bearer x"))
+
+test_that("the JSON path diagnoses cost from its own chat, and stays quiet when told (#135)", {
+  attempts <- list(list(text = "{\"score\":1,\"lab\":\"pos\"}"))
+
+  h <- json_offline_handler(attempts)
+  expect_message(
+    result <- h(x = "a", codebook = json_test_codebook(), model = "deepseek/deepseek-chat",
+                chat_args = offline_args, execution_args = list(include_cost = TRUE)),
+    "no prices for DeepSeek models"
+  )
+  expect_equal(attr(result, "qlm_backend_meta")$unpriced$kind, "provider")
+  expect_equal(attr(result, "qlm_backend_meta")$unpriced$provider, "DeepSeek")
+
+  # As the fallback after a structured attempt that already said it
+  h <- json_offline_handler(attempts)
+  expect_no_message(
+    result <- h(x = "a", codebook = json_test_codebook(), model = "deepseek/deepseek-chat",
+                chat_args = offline_args, execution_args = list(include_cost = TRUE),
+                cost_message = FALSE)
+  )
+  expect_equal(attr(result, "qlm_backend_meta")$unpriced$kind, "provider")
+
+  # No cost asked for: nothing said, nothing kept
+  h <- json_offline_handler(attempts)
+  expect_no_message(
+    result <- h(x = "a", codebook = json_test_codebook(), model = "deepseek/deepseek-chat",
+                chat_args = offline_args, execution_args = list())
+  )
+  expect_null(attr(result, "qlm_backend_meta")$unpriced)
+})

--- a/tests/testthat/test-qlm_replicate.R
+++ b/tests/testthat/test-qlm_replicate.R
@@ -871,8 +871,26 @@ test_that("qlm_replicate carries supplied prices to the same model, not to anoth
 
   # Different model: dropped, with a note
   expect_message(f(coded, model = "deepseek/deepseek-reasoner", name = "other"),
-                 "Not carrying over `prices`")
+                 "Not carrying over `prices`: the model differs")
   expect_null(seen$prices)
+
+  # Same model string reached through another endpoint: a different price
+  # list, so dropped too
+  expect_message(
+    f(coded, base_url = "https://other.example/v1", credentials = function() list(),
+      name = "moved"),
+    "the endpoint differs"
+  )
+  expect_null(seen$prices)
+
+  # Same model and endpoint, run as a batch: providers price batches
+  # differently, so dropped
+  expect_message(f(coded, batch = TRUE, name = "batched"), "the batch setting differs")
+  expect_null(seen$prices)
+
+  # Several changes are all named
+  expect_message(f(coded, model = "deepseek/deepseek-reasoner", batch = TRUE, name = "both"),
+                 "the model, batch setting differ")
 
   # An explicit override is left alone
   f(coded, model = "deepseek/deepseek-reasoner", prices = c(input = 2, output = 20))

--- a/tests/testthat/test-qlm_replicate.R
+++ b/tests/testthat/test-qlm_replicate.R
@@ -835,3 +835,46 @@ test_that("qlm_replicate keeps an explicitly supplied credential across an endpo
     seen$credentials()$Authorization, "Bearer dashscope-key"
   )
 })
+
+
+# supplied prices (#135) -------------------------------------------------------
+
+priced_coded <- function() {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+  new_qlm_coded(
+    results = data.frame(id = 1:2, score = c(0.5, 0.8)),
+    codebook = codebook,
+    data = c("a", "b"),
+    input_type = "text",
+    chat_args = list(name = "deepseek/deepseek-chat"),
+    execution_args = list(include_tokens = TRUE, include_cost = TRUE),
+    batch = FALSE,
+    metadata = list(n_units = 2, prices = c(input = 1, output = 10, cached_input = 0.1)),
+    name = "run1",
+    call = quote(qlm_code())
+  )
+}
+
+test_that("qlm_replicate carries supplied prices to the same model, not to another (#135)", {
+  coded <- priced_coded()
+  seen <- NULL
+  f <- qlm_replicate
+  mockery::stub(f, "qlm_code", function(...) {
+    seen <<- list(...)
+    coded
+  })
+
+  # Same model: the rates come back
+  f(coded, name = "again")
+  expect_equal(seen$prices, c(input = 1, output = 10, cached_input = 0.1))
+
+  # Different model: dropped, with a note
+  expect_message(f(coded, model = "deepseek/deepseek-reasoner", name = "other"),
+                 "Not carrying over `prices`")
+  expect_null(seen$prices)
+
+  # An explicit override is left alone
+  f(coded, model = "deepseek/deepseek-reasoner", prices = c(input = 2, output = 20))
+  expect_equal(seen$prices, c(input = 2, output = 20))
+})

--- a/tests/testthat/test-qlm_replicate.R
+++ b/tests/testthat/test-qlm_replicate.R
@@ -892,6 +892,25 @@ test_that("qlm_replicate carries supplied prices to the same model, not to anoth
   expect_message(f(coded, model = "deepseek/deepseek-reasoner", batch = TRUE, name = "both"),
                  "the model, batch setting differ")
 
+  # A service tier is priced on its own: from unset (ellmer's "auto") to an
+  # explicit tier, dropped; the same tier again, carried
+  expect_message(f(coded, service_tier = "priority", name = "fast"),
+                 "the service tier differs")
+  expect_null(seen$prices)
+  expect_message(f(coded, service_tier = "default", name = "std"),
+                 "the service tier differs")
+  expect_null(seen$prices)
+  f(coded, service_tier = "auto", name = "same")
+  expect_equal(seen$prices, c(input = 1, output = 10, cached_input = 0.1))
+
+  # An original run on an explicit tier carries to the same tier only
+  tiered <- priced_coded()
+  attr(tiered, "meta")$object$chat_args$service_tier <- "priority"
+  f(tiered, name = "again")
+  expect_equal(seen$prices, c(input = 1, output = 10, cached_input = 0.1))
+  expect_message(f(tiered, service_tier = "flex", name = "cheap"), "the service tier differs")
+  expect_null(seen$prices)
+
   # An explicit override is left alone
   f(coded, model = "deepseek/deepseek-reasoner", prices = c(input = 2, output = 20))
   expect_equal(seen$prices, c(input = 2, output = 20))

--- a/tests/testthat/test-qlm_trail.R
+++ b/tests/testthat/test-qlm_trail.R
@@ -984,3 +984,65 @@ test_that("redaction names every affected run once (#154)", {
     "\"one\" and \"two\""
   )
 })
+
+
+# cost provenance (#135) -------------------------------------------------------
+
+test_that("qlm_trail() report states where a cost came from and reproduces the rates (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+  coded <- new_qlm_coded(
+    results = data.frame(id = 1:2, score = c(0.5, 0.8), cost = c(2, 3)),
+    codebook = codebook,
+    data = c("a", "b"),
+    input_type = "text",
+    chat_args = list(name = "deepseek/deepseek-chat"),
+    execution_args = list(include_tokens = TRUE, include_cost = TRUE),
+    batch = FALSE,
+    metadata = list(
+      n_units = 2,
+      prices = c(input = 1, output = 10, cached_input = 0.1),
+      cost_note = "from supplied rates: $1 input, $10 output, $0.1 cached input, per million tokens"
+    ),
+    name = "run1",
+    call = quote(qlm_code())
+  )
+
+  path <- file.path(tempdir(), "test_trail_prices")
+  withr::defer(unlink(paste0(path, c(".rds", ".qmd"))))
+  qlm_trail(coded, path = path)
+  content <- readLines(paste0(path, ".qmd"))
+
+  expect_true(any(grepl("^\\*\\*Cost:\\*\\* from supplied rates: \\$1 input", content)))
+
+  # The replication call carries the rates, so the script costs the run the same way
+  args <- qlm_code_call(content)
+  expect_equal(eval(args$prices), c(input = 1, output = 10, cached_input = 0.1))
+})
+
+test_that("qlm_trail() report says why a cost is NA (#135)", {
+  type_obj <- ellmer::type_object(score = ellmer::type_number("Score"))
+  codebook <- qlm_codebook("Test", "Prompt", type_obj)
+  coded <- new_qlm_coded(
+    results = data.frame(id = 1:2, score = c(0.5, 0.8), cost = c(NA_real_, NA_real_)),
+    codebook = codebook,
+    data = c("a", "b"),
+    input_type = "text",
+    chat_args = list(name = "deepseek/deepseek-chat"),
+    execution_args = list(include_cost = TRUE),
+    batch = FALSE,
+    metadata = list(n_units = 2, cost_note = "NA (ellmer has no prices for DeepSeek models)"),
+    name = "run1",
+    call = quote(qlm_code())
+  )
+
+  path <- file.path(tempdir(), "test_trail_cost_na")
+  withr::defer(unlink(paste0(path, c(".rds", ".qmd"))))
+  qlm_trail(coded, path = path)
+  content <- readLines(paste0(path, ".qmd"))
+
+  expect_true(any(grepl(
+    "^\\*\\*Cost:\\*\\* NA \\(ellmer has no prices for DeepSeek models\\)$", content
+  )))
+  expect_null(qlm_code_call(content)$prices)
+})


### PR DESCRIPTION
Second half of #135, stacked on #167 (merge that first; this branch contains it).

## What this adds

A `prices` argument on `qlm_code()`: rates in US dollars per million tokens, the unit ellmer's own table uses, that cost a run ellmer cannot price from the token counts it records.

```r
qlm_code(x, codebook, model = "deepseek/deepseek-chat",
         prices = c(input = 0.435, output = 0.87, cached_input = 0.0036))
```

- **Fills only what ellmer leaves `NA`.** Decided from the table, not from the diagnosis in #167, which cannot always be made. Three outcomes, told apart: no row was `NA`, so ellmer priced the run itself at the published rates and the caller is told the supplied ones were not used; rows were `NA` but none had token counts to cost them from, so the rates could not be applied, the cost stays `NA`, and the caller is told that instead; or rows were costed. Only the last records the rates. When rates are supplied, the "cost will be NA" message from #167 is not shown.
- **Uses ellmer's own sum.** ellmer normalises every provider's usage at parse time so that `input_tokens` counts uncached prompt tokens and `cached_input_tokens` the cache hits (checked for OpenAI, DeepSeek and Anthropic), and bills the three parts additively. So the formula here is the same one, and the cache-convention flag the issue discussed is unnecessary at this layer. A missing `cached_input` rate defaults to the `input` rate, which over-counts rather than under-counts.
- **Implies `include_tokens = TRUE` and `include_cost = TRUE`**, since the cost is computed from the counts and should be auditable against them.
- **Labels the provenance everywhere.** The rates are kept in the run's metadata. `print()` shows `# Cost: from supplied rates: $0.435 input, $0.87 output, $0.0036 cached input, per million tokens`. The trail report carries a `**Cost:**` line with the same text (or the `NA (...)` reason from #167) and puts `prices = c(...)` into the generated replication call, so the script costs the run the same way.
- **`qlm_replicate()` reuses the rates only within the same pricing context**: model, endpoint identity (provider plus `base_url`, as the credential logic already defines it), batch setting, and service tier all unchanged. Any of them changing drops the rates with a note naming what differs, since the same model string can be priced differently through another endpoint, as a batch, or at another tier (ellmer lists gpt-4.1-mini at $0.40/$1.60 by default and $0.70/$2.80 at priority). An unset tier is ellmer's `"auto"`, and a change to any explicit tier counts. An explicit `prices` in `...` wins.
- **No bundled prices.** quallmer ships no rates of its own, per the issue.

Malformed `prices` is rejected before any request, naming what is wrong.

## Scope

`qlm_segment()` is untouched: it drops ellmer's token and cost columns today, which is #119 and comes next.

## Tests

New tests across `test-cost.R` (validation, the sum, the cached default, untouched rows), `test-qlm_code.R` (end to end with the structured call stubbed: costs, implied flags, metadata, print; ellmer's price winning; malformed input), `test-qlm_replicate.R` (carry, drop with note, override) and `test-qlm_trail.R` (the Cost line and the reproduced `prices` argument). Full suite passes; `R CMD check --as-cran --no-manual` gives only the dev-version NOTE.
