### PR TITLE
Record the usage of a segmentation run, per source document

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,18 @@
 
 ## Bug fixes
 
+* `qlm_segment()` now records token counts and cost when asked, and takes
+  `prices` as `qlm_code()` does. It forwarded `include_tokens` and
+  `include_cost` to ellmer, but ellmer attaches usage only to a converted
+  result that is a data frame, and converts the array a segmentation asks
+  for to a plain list, so the counts were lost before quallmer saw them. The
+  array is now requested inside an object, which converts to one row per
+  source document with the usage beside it. Usage belongs to the document,
+  not the segment: it is kept in the corpus metadata as `usage`, one row per
+  input document including those that yielded no segments, and repeated on
+  each segment as docvars; sum the metadata table for the run's total. The
+  four usage names are reserved when usage is requested (#119).
+
 * `qlm_trail()` no longer writes credentials into the trail. An `api_key`,
   a credential-named `api_headers` entry, or a `base_url` carrying userinfo
   or a credential-named query parameter, given to `qlm_code()` as a literal,

--- a/R/cost.R
+++ b/R/cost.R
@@ -121,3 +121,51 @@ prices_note <- function(prices) {
     " cached input, per million tokens"
   )
 }
+
+
+#' Settle a run's cost against supplied rates
+#'
+#' Three outcomes, decided from the table rather than from the diagnosis,
+#' which cannot always be made. No row was `NA`: ellmer priced the run itself
+#' at the published rates, and the supplied ones have nothing to do. Rows were
+#' `NA` but none had the token counts to cost them from: the rates could not
+#' be applied and the cost stays `NA`. Some rows were costed. Only the last
+#' keeps the rates, so a recorded rate always means a cost that rests on it.
+#'
+#' @param results A table with ellmer's token and cost columns, one row per
+#'   unit the provider was asked about.
+#' @param prices What `check_prices()` returned, possibly `NULL`.
+#' @param unpriced What `cost_diagnosis()` returned, possibly `NULL`.
+#'
+#' @return A list: `results`, with `cost` filled where it could be; `prices`,
+#'   kept only where they were applied; `cost_note`, one line saying where the
+#'   cost came from, or `NULL` when ellmer priced it.
+#' @keywords internal
+#' @noRd
+reconcile_prices <- function(results, prices, unpriced) {
+  cost_note <- if (!is.null(unpriced)) paste0("NA (", unpriced_note(unpriced), ")")
+  if (is.null(prices)) {
+    return(list(results = results, prices = NULL, cost_note = cost_note))
+  }
+
+  before <- results$cost %||% rep(NA_real_, nrow(results))
+  results <- price_from_tokens(results, prices)
+  filled <- is.na(before) & !is.na(results$cost)
+
+  if (!anyNA(before)) {
+    cli::cli_inform(c(
+      "i" = "ellmer priced this run itself; {.arg prices} is not used."
+    ))
+    prices <- NULL
+  } else if (!any(filled)) {
+    cli::cli_inform(c(
+      "i" = paste0("{.arg prices} could not be applied: no token counts came back ",
+                   "for the unpriced units, so their {.field cost} stays {.code NA}.")
+    ))
+    prices <- NULL
+  } else {
+    cost_note <- prices_note(prices)
+  }
+
+  list(results = results, prices = prices, cost_note = cost_note)
+}

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -483,33 +483,11 @@ qlm_code <- function(x, codebook, model, ...,
   # Add ID column from input names or sequence
   results$id <- names(x) %||% seq_along(x)
 
-  # Where the cost came from, when ellmer could not fill it (#135). Supplied
-  # rates cost the rows ellmer left NA from their token counts, which is
-  # decided from the table rather than from the diagnosis, since that cannot
-  # always be made. Three outcomes: no row was NA, so ellmer priced the run
-  # itself at the published rates and the supplied ones have nothing to do;
-  # rows were NA but none had the counts to cost them, so the rates could not
-  # be applied; or some were costed. Only the last records the rates.
-  cost_note <- if (!is.null(unpriced)) paste0("NA (", unpriced_note(unpriced), ")")
-  if (!is.null(prices)) {
-    before <- results$cost %||% rep(NA_real_, nrow(results))
-    results <- price_from_tokens(results, prices)
-    filled <- is.na(before) & !is.na(results$cost)
-    if (!anyNA(before)) {
-      cli::cli_inform(c(
-        "i" = "ellmer priced this run itself; {.arg prices} is not used."
-      ))
-      prices <- NULL
-    } else if (!any(filled)) {
-      cli::cli_inform(c(
-        "i" = paste0("{.arg prices} could not be applied: no token counts came back ",
-                     "for the unpriced units, so their {.field cost} stays {.code NA}.")
-      ))
-      prices <- NULL
-    } else {
-      cost_note <- prices_note(prices)
-    }
-  }
+  # Where the cost came from, when ellmer could not fill it (#135)
+  settled <- reconcile_prices(results, prices, unpriced)
+  results <- settled$results
+  prices <- settled$prices
+  cost_note <- settled$cost_note
 
   # Build metadata list
   metadata <- list(

--- a/R/qlm_segment.R
+++ b/R/qlm_segment.R
@@ -22,6 +22,11 @@
 #'   [ellmer::parallel_chat_structured()] are routed there; all other arguments
 #'   (including provider-specific arguments like `base_url`, `credentials`, or
 #'   `api_args` for OpenAI-compatible endpoints) are passed to [ellmer::chat()].
+#' @param prices Optional. Rates for costing the run when ellmer cannot: a
+#'   named numeric vector or list with `input` and `output`, and optionally
+#'   `cached_input`, in US dollars per million tokens. As for [qlm_code()];
+#'   see the section on cost there. Supplying them implies `include_tokens =
+#'   TRUE` and `include_cost = TRUE`. Default is `NULL`.
 #' @param notes Optional character string with descriptive notes about this
 #'   segmentation run. Default is `NULL`.
 #'
@@ -32,9 +37,34 @@
 #'     \item{`docid`}{Name of the source document.}
 #'     \item{`segid`}{Integer segment index within the source document.}
 #'     \item{...}{Any fields defined in the codebook schema.}
+#'     \item{`input_tokens`, `output_tokens`, `cached_input_tokens`,
+#'       `cost`}{With `include_tokens = TRUE` or `include_cost = TRUE`: the
+#'       usage of the call made for the source document, repeated on each of
+#'       its segments. See the section on cost.}
 #'     \item{...}{Original docvars inherited from the input (if `x` is a
 #'       corpus).}
 #'   }
+#'   The corpus metadata (see [quanteda::meta()]) carries `name`,
+#'   `continuum_lengths`, and, when usage was requested, `usage`, a data frame
+#'   with one row per source document, plus `cost_note` and `prices` where
+#'   they apply.
+#'
+#' @section Cost:
+#'
+#' Each source document is one request, so token counts and cost belong to
+#' the document, not to a segment. With `include_tokens = TRUE` or
+#' `include_cost = TRUE` they are recorded twice: in the corpus metadata as
+#' `usage`, one row per input document including documents that yielded no
+#' segments, and on each segment as docvars for convenience. Sum the metadata
+#' table for the run's total; summing the docvars counts a document once per
+#' segment, and a document that produced no segments has no docvars at all.
+#'
+#' ellmer prices from a table fixed at its release and returns `NA` for a
+#' model it does not list; `qlm_segment()` says so once before the run, as
+#' [qlm_code()] does, and `prices` costs the run from the token counts at
+#' rates you supply. The four usage names are reserved when usage is
+#' requested: a codebook field or an inherited docvar of the same name is an
+#' error rather than silently overwritten.
 #'
 #' @seealso [qlm_code()] for document-level coding, [qlm_codebook()] for
 #'   creating codebooks, [quanteda::corpus_segment()] for pattern-based
@@ -86,7 +116,8 @@
 #' }
 #'
 #' @export
-qlm_segment <- function(x, codebook, model, ..., name = NULL, notes = NULL) {
+qlm_segment <- function(x, codebook, model, ..., prices = NULL, name = NULL,
+                        notes = NULL) {
   rlang::check_installed(
     "quanteda",
     reason = "to return a segmented corpus from {.fn qlm_segment}"
@@ -160,7 +191,17 @@ qlm_segment <- function(x, codebook, model, ..., name = NULL, notes = NULL) {
       user_props
     )
   )
-  internal_schema <- ellmer::type_array(items = items_schema)
+  # Wrapped in an object rather than sent as a bare array. ellmer attaches
+  # token counts and cost only to a converted result that is a data frame,
+  # and converts a bare array to a plain list of tibbles, so the usage of an
+  # array-typed request is lost inside ellmer before it reaches here (#119).
+  # An object with one array property converts to one row per document with
+  # a list-column of segments, and the usage columns beside it. ellmer wraps
+  # arrays this way itself for providers that require an object at the top
+  # level, so the request shape is not new to models.
+  internal_schema <- ellmer::type_object(
+    segments = ellmer::type_array(items = items_schema)
+  )
 
   # Build system prompt from role and instructions
   system_prompt <- if (!is.null(codebook$role)) {
@@ -179,17 +220,74 @@ qlm_segment <- function(x, codebook, model, ..., name = NULL, notes = NULL) {
   # to pass through to ellmer::chat() which forwards them to the provider
   chat_args      <- dots[!dot_names %in% pcs_arg_names]
 
+  # Supplied rates cost the run from its token counts, so both must be asked
+  # of ellmer; the caller asked for a cost by supplying them (#135).
+  prices <- check_prices(prices)
+  if (!is.null(prices)) {
+    execution_args$include_tokens <- TRUE
+    execution_args$include_cost <- TRUE
+  }
+
+  # The result is read as one row per document; a bare list has none.
+  if (identical(execution_args$convert, FALSE)) {
+    cli::cli_abort(c(
+      "{.code convert = FALSE} is not supported by {.fn qlm_segment}.",
+      "i" = "For the unconverted list, call {.fn ellmer::parallel_chat_structured} directly."
+    ))
+  }
+
+  # Usage is recorded as docvars beside the codebook fields and any inherited
+  # docvars, so its names are reserved when it is asked for: a clash would
+  # silently overwrite one or the other.
+  usage_cols <- c(
+    if (isTRUE(execution_args$include_tokens)) {
+      c("input_tokens", "output_tokens", "cached_input_tokens")
+    },
+    if (isTRUE(execution_args$include_cost)) "cost"
+  )
+  taken <- intersect(usage_cols, c(names(user_props), names(parent_dvars)))
+  if (length(taken)) {
+    cli::cli_abort(c(
+      "{.val {taken}} {?is/are} reserved for the run's usage when it is requested.",
+      "x" = paste0("The codebook schema or the input's docvars already ",
+                   "{cli::qty(length(taken))}{?use/use} {?this name/these names}."),
+      "i" = "Rename {cli::qty(length(taken))}{?it/them}, or do not request tokens and cost."
+    ))
+  }
+
   # Build chat object
   chat <- do.call(ellmer::chat, c(
     list(name = model, system_prompt = system_prompt),
     chat_args
   ))
 
-  # Execute: returns a list of tibbles (one per document) for array types
-  results_list <- do.call(ellmer::parallel_chat_structured, c(
+  # Whether the cost will come back NA, and why, from the chat the run will
+  # use and before anything is sent (#135). Not said when rates were
+  # supplied, since it will not be NA; the reason is still kept.
+  unpriced <- cost_diagnosis(chat, model, execution_args, say = is.null(prices))
+
+  # Execute: one row per document, the segments in a list-column, usage
+  # beside them when requested
+  results <- do.call(ellmer::parallel_chat_structured, c(
     list(chat = chat, prompts = as.list(doc_texts), type = internal_schema),
     execution_args
   ))
+  results_list <- results$segments
+
+  # Usage per source document, every document included: one that produced
+  # no segments may still have been answered and charged for. Settled
+  # against any supplied rates before it is spread over the segments.
+  usage <- NULL
+  if (length(usage_cols)) {
+    usage <- data.frame(docid = doc_names, stringsAsFactors = FALSE)
+    for (col in usage_cols) {
+      usage[[col]] <- if (is.null(results[[col]])) NA_real_ else as.numeric(results[[col]])
+    }
+  }
+  settled <- reconcile_prices(usage %||% data.frame(), prices, unpriced)
+  if (!is.null(usage)) {
+    usage <- settled$results
+  }
 
   # Collect per-segment data across all documents
   all_texts    <- character(0)
@@ -226,6 +324,11 @@ qlm_segment <- function(x, codebook, model, ..., name = NULL, notes = NULL) {
       dv[[field]] <- segs[[field]]
     }
 
+    # The document's usage, on each of its segments
+    for (col in usage_cols) {
+      dv[[col]] <- rep(usage[[col]][i], n_segs)
+    }
+
     # Inherit parent docvars when input is a corpus
     if (!is.null(parent_dvars) && ncol(parent_dvars) > 0L) {
       for (col in names(parent_dvars)) {
@@ -251,6 +354,15 @@ qlm_segment <- function(x, codebook, model, ..., name = NULL, notes = NULL) {
     doc_names
   )
   quanteda::meta(out, "continuum_lengths") <- continuum_lengths
+  if (!is.null(usage)) {
+    quanteda::meta(out, "usage") <- usage
+  }
+  if (!is.null(settled$cost_note)) {
+    quanteda::meta(out, "cost_note") <- settled$cost_note
+  }
+  if (!is.null(settled$prices)) {
+    quanteda::meta(out, "prices") <- settled$prices
+  }
 
   out
 }

--- a/man/qlm_segment.Rd
+++ b/man/qlm_segment.Rd
@@ -4,7 +4,7 @@
 \alias{qlm_segment}
 \title{Segment texts using an LLM}
 \usage{
-qlm_segment(x, codebook, model, ..., name = NULL, notes = NULL)
+qlm_segment(x, codebook, model, ..., prices = NULL, name = NULL, notes = NULL)
 }
 \arguments{
 \item{x}{A character vector of texts or a \code{\link[quanteda:corpus]{quanteda::corpus()}} object.
@@ -28,6 +28,11 @@ Examples: \code{"openai/gpt-4o-mini"}, \code{"anthropic/claude-3-5-sonnet-202410
 (including provider-specific arguments like \code{base_url}, \code{credentials}, or
 \code{api_args} for OpenAI-compatible endpoints) are passed to \code{\link[ellmer:chat]{ellmer::chat()}}.}
 
+\item{prices}{Optional. Rates for costing the run when ellmer cannot: a
+named numeric vector or list with \code{input} and \code{output}, and optionally
+\code{cached_input}, in US dollars per million tokens. As for \code{\link[=qlm_code]{qlm_code()}};
+see the section on cost there. Supplying them implies \code{include_tokens = TRUE} and \code{include_cost = TRUE}. Default is \code{NULL}.}
+
 \item{name}{Character string identifying this coding run. Default is \code{NULL}.}
 
 \item{notes}{Optional character string with descriptive notes about this
@@ -41,9 +46,17 @@ Docvars include:
 \item{\code{docid}}{Name of the source document.}
 \item{\code{segid}}{Integer segment index within the source document.}
 \item{...}{Any fields defined in the codebook schema.}
+\item{\code{input_tokens}, \code{output_tokens}, \code{cached_input_tokens},
+\code{cost}}{With \code{include_tokens = TRUE} or \code{include_cost = TRUE}: the
+usage of the call made for the source document, repeated on each of
+its segments. See the section on cost.}
 \item{...}{Original docvars inherited from the input (if \code{x} is a
 corpus).}
 }
+The corpus metadata (see \code{\link[quanteda:meta]{quanteda::meta()}}) carries \code{name},
+\code{continuum_lengths}, and, when usage was requested, \code{usage}, a data frame
+with one row per source document, plus \code{cost_note} and \code{prices} where
+they apply.
 }
 \description{
 Applies a codebook to input texts to segment them into thematic or conceptual
@@ -56,6 +69,25 @@ for each segment. A \code{text} field (the verbatim segment text) is always adde
 automatically and must not appear in the schema. Measurement \code{levels} defined
 in the codebook are not applicable to segmentation and are silently ignored.
 }
+\section{Cost}{
+
+
+Each source document is one request, so token counts and cost belong to
+the document, not to a segment. With \code{include_tokens = TRUE} or
+\code{include_cost = TRUE} they are recorded twice: in the corpus metadata as
+\code{usage}, one row per input document including documents that yielded no
+segments, and on each segment as docvars for convenience. Sum the metadata
+table for the run's total; summing the docvars counts a document once per
+segment, and a document that produced no segments has no docvars at all.
+
+ellmer prices from a table fixed at its release and returns \code{NA} for a
+model it does not list; \code{qlm_segment()} says so once before the run, as
+\code{\link[=qlm_code]{qlm_code()}} does, and \code{prices} costs the run from the token counts at
+rates you supply. The four usage names are reserved when usage is
+requested: a codebook field or an inherited docvar of the same name is an
+error rather than silently overwritten.
+}
+
 \examples{
 \dontrun{
 # Aspect-based segmentation of a hotel review (character vector input

--- a/tests/testthat/test-cost.R
+++ b/tests/testthat/test-cost.R
@@ -79,3 +79,41 @@ test_that("prices_note() states the rates without scientific notation", {
     "from supplied rates: $2 input, $8 output, $2 cached input, per million tokens"
   )
 })
+
+
+# reconcile_prices() ----------------------------------------------------------
+
+test_that("reconcile_prices() tells the three outcomes apart", {
+  prices <- c(input = 1, output = 10, cached_input = 0.1)
+  unpriced <- list(kind = "provider", provider = "DeepSeek", model = "deepseek-chat")
+  tokens <- data.frame(input_tokens = c(1e6, 2e6), output_tokens = c(0, 0),
+                       cached_input_tokens = c(0, 0))
+
+  # No rates: the note says why the cost is NA, nothing else changes
+  out <- reconcile_prices(cbind(tokens, cost = NA_real_), NULL, unpriced)
+  expect_true(all(is.na(out$results$cost)))
+  expect_null(out$prices)
+  expect_equal(out$cost_note, "NA (ellmer has no prices for DeepSeek models)")
+  expect_null(reconcile_prices(cbind(tokens, cost = 1), NULL, NULL)$cost_note)
+
+  # ellmer priced every row: rates not used
+  expect_message(out <- reconcile_prices(cbind(tokens, cost = c(1, 2)), prices, NULL),
+                 "is not used")
+  expect_equal(out$results$cost, c(1, 2))
+  expect_null(out$prices)
+  expect_null(out$cost_note)
+
+  # Rows NA but no counts: rates could not be applied, the reason stands
+  none <- data.frame(input_tokens = NA_real_, output_tokens = NA_real_,
+                     cached_input_tokens = NA_real_, cost = NA_real_)
+  expect_message(out <- reconcile_prices(none, prices, unpriced), "could not be applied")
+  expect_true(is.na(out$results$cost))
+  expect_null(out$prices)
+  expect_equal(out$cost_note, "NA (ellmer has no prices for DeepSeek models)")
+
+  # Rows costed: rates kept and named
+  expect_no_message(out <- reconcile_prices(cbind(tokens, cost = NA_real_), prices, unpriced))
+  expect_equal(out$results$cost, c(1, 2))
+  expect_equal(out$prices, prices)
+  expect_match(out$cost_note, "^from supplied rates")
+})

--- a/tests/testthat/test-qlm_segment.R
+++ b/tests/testthat/test-qlm_segment.R
@@ -85,7 +85,8 @@ test_that("qlm_segment returns a quanteda corpus from character input", {
   )
 
   mockery::stub(qlm_segment, "ellmer::chat", mock_chat)
-  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
+  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured",
+                tibble::tibble(segments = mock_results))
 
   input  <- c(review1 = "Clean room. Basic furnishings.", review2 = "Great location.")
   result <- qlm_segment(input, cb, model = "openai_compatible/test-model")
@@ -115,7 +116,8 @@ test_that("qlm_segment sets docvars correctly from character input", {
   )
 
   mockery::stub(qlm_segment, "ellmer::chat", mock_chat)
-  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
+  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured",
+                tibble::tibble(segments = mock_results))
 
   result <- qlm_segment(
     c(review1 = "Clean room. Basic furnishings.", review2 = "Great location."),
@@ -145,7 +147,8 @@ test_that("qlm_segment uses sequential text labels for unnamed character input",
   )
 
   mockery::stub(qlm_segment, "ellmer::chat", mock_chat)
-  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
+  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured",
+                tibble::tibble(segments = mock_results))
 
   result <- qlm_segment(c("Text one.", "Text two."), cb, model = "openai_compatible/test-model")
 
@@ -177,7 +180,8 @@ test_that("qlm_segment returns a corpus from corpus input", {
   )
 
   mockery::stub(qlm_segment, "ellmer::chat", mock_chat)
-  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
+  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured",
+                tibble::tibble(segments = mock_results))
 
   result <- qlm_segment(corp, cb, model = "openai_compatible/test-model")
 
@@ -208,7 +212,8 @@ test_that("qlm_segment corpus output inherits parent docvars", {
   )
 
   mockery::stub(qlm_segment, "ellmer::chat", mock_chat)
-  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
+  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured",
+                tibble::tibble(segments = mock_results))
 
   result <- qlm_segment(corp, cb, model = "openai_compatible/test-model")
   dv     <- quanteda::docvars(result)
@@ -236,7 +241,8 @@ test_that("qlm_segment warns for documents producing no segments", {
   )
 
   mockery::stub(qlm_segment, "ellmer::chat", mock_chat)
-  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
+  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured",
+                tibble::tibble(segments = mock_results))
 
   expect_warning(
     qlm_segment(c(doc1 = "Text one.", doc2 = "Text two."), cb, model = "openai_compatible/test-model"),
@@ -263,7 +269,8 @@ test_that("qlm_segment passes provider-specific arguments to ellmer::chat", {
   mock_results <- list(tibble::tibble(text = "A.", tag = "a"))
 
   mockery::stub(qlm_segment, "ellmer::chat", mock_chat)
-  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured", mock_results)
+  mockery::stub(qlm_segment, "ellmer::parallel_chat_structured",
+                tibble::tibble(segments = mock_results))
 
   # Call with a provider-specific argument (like base_url for openai_compatible)
   qlm_segment("Text.", cb, model = "openai_compatible/test-model", base_url = "https://my-api.com/v1")
@@ -271,4 +278,174 @@ test_that("qlm_segment passes provider-specific arguments to ellmer::chat", {
   # Verify the provider-specific argument was passed through to ellmer::chat
   expect_true("base_url" %in% names(chat_args_received))
   expect_equal(chat_args_received$base_url, "https://my-api.com/v1")
+})
+
+
+# usage and cost (#119) --------------------------------------------------------
+
+# qlm_segment() with the chat built for real, off the environment and sending
+# nothing, and the structured call stubbed to return `results`: one row per
+# document, segments in a list-column, usage beside them as ellmer attaches
+# it to a data frame. The stub carries ellmer's formals, since qlm_segment()
+# reads them to route `...`. `seen` records the execution arguments received.
+segment_run <- function(results, seen = NULL) {
+  f <- qlm_segment
+  stub <- function(chat, prompts, type, convert = TRUE, include_tokens = FALSE,
+                   include_cost = FALSE, max_active = 10, rpm = 500,
+                   on_error = c("return", "continue", "stop")) {
+    if (!is.null(seen)) {
+      seen$execution_args <- list(include_tokens = include_tokens,
+                                  include_cost = include_cost)
+    }
+    results
+  }
+  mockery::stub(f, "ellmer::parallel_chat_structured", stub)
+  f
+}
+offline <- function() list(Authorization = "Bearer x")
+absa <- function() {
+  qlm_codebook("ABSA", "Segment by aspect.",
+               schema = ellmer::type_object(aspect = ellmer::type_string("Aspect label")))
+}
+# Three documents: two segments, none (answered, charged, nothing extracted),
+# one
+three_docs <- function() {
+  tibble::tibble(
+    segments = list(
+      tibble::tibble(text = c("Clean room.", "Basic furnishings."),
+                     aspect = c("cleanliness", "features")),
+      tibble::tibble(text = character(), aspect = character()),
+      tibble::tibble(text = "Great location.", aspect = "location")
+    ),
+    input_tokens = c(100, 120, 90),
+    output_tokens = c(40, 5, 20),
+    cached_input_tokens = c(0, 0, 0),
+    cost = c(NA_real_, NA_real_, NA_real_)
+  )
+}
+three_texts <- c(a = "Clean room. Basic furnishings.", b = "Nothing here.",
+                 c = "Great location.")
+
+test_that("qlm_segment keeps every document's usage, segments or not (#119)", {
+  skip_if_not_installed("quanteda")
+  f <- segment_run(three_docs())
+  expect_warning(
+    expect_message(
+      result <- f(three_texts, absa(), model = "deepseek/deepseek-chat",
+                  credentials = offline, include_tokens = TRUE, include_cost = TRUE),
+      "no prices for DeepSeek models"
+    ),
+    "produced no segments"
+  )
+
+  # The canonical table has one row per input document, in input order
+  usage <- quanteda::meta(result, "usage")
+  expect_equal(usage$docid, c("a", "b", "c"))
+  expect_equal(usage$input_tokens, c(100, 120, 90))
+  expect_equal(usage$output_tokens, c(40, 5, 20))
+  expect_true(all(is.na(usage$cost)))
+  # Summing it gives the run's total, the zero-segment document included
+  expect_equal(sum(usage$input_tokens), 310)
+
+  # The docvars repeat each document's figures on its own segments, aligned
+  dv <- quanteda::docvars(result)
+  expect_equal(dv$docid, c("a", "a", "c"))
+  expect_equal(dv$input_tokens, c(100, 100, 90))
+  expect_equal(dv$output_tokens, c(40, 40, 20))
+  expect_equal(dv$aspect, c("cleanliness", "features", "location"))
+  expect_true(all(is.na(dv$cost)))
+
+  expect_equal(quanteda::meta(result, "cost_note"), "NA (ellmer has no prices for DeepSeek models)")
+  expect_null(quanteda::meta(result, "prices"))
+})
+
+test_that("qlm_segment records tokens or cost on their own, and nothing unasked (#119)", {
+  skip_if_not_installed("quanteda")
+  seen <- new.env()
+
+  # Neither asked for: no usage anywhere
+  f <- segment_run(three_docs()[, "segments"], seen)
+  expect_no_message(
+    suppressWarnings(result <- f(three_texts, absa(), model = "deepseek/deepseek-chat",
+                                 credentials = offline))
+  )
+  expect_null(quanteda::meta(result, "usage"))
+  expect_false(any(c("input_tokens", "cost") %in% names(quanteda::docvars(result))))
+  expect_null(quanteda::meta(result, "cost_note"))
+
+  # Tokens only
+  f <- segment_run(three_docs()[, c("segments", "input_tokens", "output_tokens",
+                                    "cached_input_tokens")], seen)
+  suppressWarnings(result <- f(three_texts, absa(), model = "deepseek/deepseek-chat",
+                               credentials = offline, include_tokens = TRUE))
+  expect_equal(names(quanteda::meta(result, "usage")),
+               c("docid", "input_tokens", "output_tokens", "cached_input_tokens"))
+  expect_false("cost" %in% names(quanteda::docvars(result)))
+  expect_null(quanteda::meta(result, "cost_note"))
+
+  # Cost only: the diagnosis says the counts are not being recorded
+  f <- segment_run(three_docs()[, c("segments", "cost")], seen)
+  expect_message(
+    suppressWarnings(result <- f(three_texts, absa(), model = "deepseek/deepseek-chat",
+                                 credentials = offline, include_cost = TRUE)),
+    "Supply the provider's published rates as `prices`"
+  )
+  expect_equal(names(quanteda::meta(result, "usage")), c("docid", "cost"))
+  expect_false("input_tokens" %in% names(quanteda::docvars(result)))
+})
+
+test_that("qlm_segment costs an unpriced run from supplied rates, per document (#119)", {
+  skip_if_not_installed("quanteda")
+  seen <- new.env()
+  f <- segment_run(three_docs(), seen)
+  expect_no_message(
+    suppressWarnings(result <- f(three_texts, absa(), model = "deepseek/deepseek-chat",
+                                 credentials = offline,
+                                 prices = c(input = 1, output = 10, cached_input = 0.1)))
+  )
+  # Supplying rates asked ellmer for tokens and cost
+  expect_true(isTRUE(seen$execution_args$include_tokens))
+  expect_true(isTRUE(seen$execution_args$include_cost))
+
+  usage <- quanteda::meta(result, "usage")
+  expect_equal(usage$cost, (c(100, 120, 90) * 1 + c(40, 5, 20) * 10) / 1e6)
+  dv <- quanteda::docvars(result)
+  expect_equal(dv$cost, usage$cost[c(1, 1, 3)])
+  expect_equal(quanteda::meta(result, "prices"), c(input = 1, output = 10, cached_input = 0.1))
+  expect_match(quanteda::meta(result, "cost_note"), "^from supplied rates")
+})
+
+test_that("qlm_segment reserves the usage names when usage is requested (#119)", {
+  skip_if_not_installed("quanteda")
+  cb <- qlm_codebook("ABSA", "Segment.",
+                     schema = ellmer::type_object(cost = ellmer::type_number("Cost of the item")))
+  f <- segment_run(three_docs())
+  expect_error(
+    f(three_texts, cb, model = "deepseek/deepseek-chat", credentials = offline,
+      include_cost = TRUE),
+    "reserved for the run's usage"
+  )
+  # Not requested: the field is the codebook's to use
+  plain <- tibble::tibble(segments = list(tibble::tibble(text = "A.", cost = 3)))
+  f <- segment_run(plain)
+  result <- f(c(a = "A."), cb, model = "deepseek/deepseek-chat", credentials = offline)
+  expect_equal(quanteda::docvars(result)$cost, 3)
+
+  # An inherited docvar clashes the same way
+  corp <- quanteda::corpus(c(a = "A."), docvars = data.frame(input_tokens = 1))
+  f <- segment_run(three_docs()[1, ])
+  expect_error(
+    f(corp, absa(), model = "deepseek/deepseek-chat", credentials = offline,
+      include_tokens = TRUE),
+    "reserved for the run's usage"
+  )
+})
+
+test_that("qlm_segment rejects convert = FALSE (#119)", {
+  f <- segment_run(three_docs())
+  expect_error(
+    f(three_texts, absa(), model = "deepseek/deepseek-chat", credentials = offline,
+      convert = FALSE),
+    "convert = FALSE"
+  )
 })


### PR DESCRIPTION
Fixes #119.

## Root cause

Not the one the TODO assumed. `qlm_segment()` did forward `include_tokens` and `include_cost` to ellmer, but the columns it then failed to keep never existed: ellmer's `multi_convert()` attaches usage only when the converted result is a data frame, and for an array `type` it returns a plain list of tibbles, one per prompt. The counts were lost inside ellmer, silently. Filed upstream as tidyverse/ellmer#1129.

## The fix

- **Wrap the array in an object.** The request is now `type_object(segments = type_array(items))`, which converts to one row per source document with a `segments` list-column and the usage columns beside it. ellmer wraps arrays this way itself for providers that require an object at the top level, so the shape is not new to models. `convert = FALSE` is refused, as in `qlm_code()`, since a bare list has no rows to read.
- **Usage per source document, canonically.** `quanteda::meta(out, "usage")` is a data frame with one row per input document: `docid`, `input_tokens`, `output_tokens`, `cached_input_tokens`, `cost`, whichever were requested. Every input document is in it, including one that produced no segments, which may still have been answered and charged for. The same figures are repeated on each segment as docvars for convenience, as inherited docvars already are. The docs say to sum the metadata table, not the docvars.
- **Reserved names.** When usage is requested, a codebook field or inherited docvar named like one of the four usage columns is an error naming it, rather than a silent overwrite in either direction. When usage is not requested the names are free.
- **`prices`, as in `qlm_code()`.** Validated before the request, implies both inclusion flags, suppresses the "cost will be NA" message while keeping the diagnosis, and fills the per-document `NA` costs before they are spread over segments. The three-outcome settlement (ellmer priced it; rates could not be applied; rows costed) moves into a shared `reconcile_prices()` in `cost.R`, and `qlm_code()` now calls it too. `cost_note` and `prices` land in the corpus metadata next to `name`.

`qlm_compare()` is unaffected: with `by = NULL` the unitizing comparison uses the binary partition only, and with `by` named it reads that field, so the new docvars are never taken for coded variables.

## Live smoke test

One document against Anthropic (`claude-sonnet-4-6`), a provider that does not need the wrapper itself, with both flags on. The wrapped request was accepted, three segments came back with correct character offsets, and the usage landed in both places, priced by ellmer:

```
  docid input_tokens output_tokens cached_input_tokens     cost
1    r1          304            46                   0 0.001602
```

The docvars repeat those figures on each of the three segments, and `cost_note` is `NULL` since ellmer priced it.

## Tests

The existing segment tests now stub the data-frame shape. New: every document's usage kept with a zero-segment document in the middle, aligned with its segments; tokens only, cost only, and neither; `prices` implying both flags and costing per document; collisions with a schema field and with an inherited docvar, and the same name free when usage is not requested; `convert = FALSE` refused; and `reconcile_prices()` on all three outcomes. Full suite: 2038 passed, 0 failed. `R CMD check --as-cran --no-manual` gives only the dev-version NOTE.
