### PR TITLE
Rank ordinal text categories by their declared order

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -341,6 +341,27 @@ Everything in this section postdates quallmer 0.4.0, released on CRAN on
 
 ### Reliability and validation
 
+* `qlm_compare()` and `qlm_validate()` ranked ordinal text categories
+  alphabetically, so a scale of low / medium / high was ranked
+  high < low < medium, and every statistic that uses the order (ordinal
+  alpha, weighted kappa, Kendall's W, Spearman's rho, tau and MAE) was
+  computed on the wrong ranks with nothing in the output to show it; factor
+  levels were flattened to text before they were read, so ordering the
+  categories in advance changed nothing. Text categories at ordinal level
+  are now ranked by the levels of an ordered factor, which every coder must
+  supply and all must agree on, and a plain factor or character column is
+  an error that says how to declare the order, since alphabetical order is
+  not a ranking and a plain factor's levels are alphabetical by default. A
+  `type_enum()` declared `"ordinal"` in `qlm_codebook()` is that
+  declaration: its values, in the order written, are the scale, `qlm_code()`
+  stores the column as an ordered factor with those levels, `as_qlm_coded()`
+  does the same for human-coded data given the codebook (refusing a value
+  outside the enum), and the codebook print shows the order. An enum not
+  declared ordinal stays nominal. Because the ranks are now numbers, a
+  `tolerance` on ordered text counts rank distance, so `tolerance = 1`
+  means adjacent categories agree; the warning that a tolerance on text
+  categories was being ignored is gone with the reason for it (#165).
+
 * `qlm_compare()` now honours `tolerance`, and computes its numeric
   statistics on the ratings' values, when a coder stores the ratings as
   text. The ratings were assembled into one matrix before their type was

--- a/R/as_qlm_coded.R
+++ b/R/as_qlm_coded.R
@@ -145,7 +145,14 @@ as_qlm_coded <- function(x,
 #'     \item{`instructions`}{Text describing coding instructions}
 #'     \item{`schema`}{NULL (not used for human coding)}
 #'   }
-#'   If `NULL` (default), a minimal placeholder codebook is created.
+#'   If `NULL` (default), a minimal placeholder codebook is created. Passing
+#'   the [qlm_codebook()] the LLM coded against gives the human data the same
+#'   measurement levels, and a column that is a [type_enum()] declared
+#'   `"ordinal"` there is stored as an ordered factor in the enum's order, so
+#'   [qlm_compare()] and [qlm_validate()] rank it as they rank the LLM's; a
+#'   value outside the enum is an error. Without a codebook, order a text
+#'   scale yourself with `factor(x, levels = c(...), ordered = TRUE)`. The
+#'   schema itself is not kept.
 #' @param texts Optional vector of original texts or data that were coded.
 #'   Should correspond to the `.id` values in `data`. If provided, enables
 #'   more complete provenance tracking.
@@ -249,6 +256,9 @@ as_qlm_coded.data.frame <- function(
     if (is.null(codebook$instructions)) {
       codebook$instructions <- "Data coded by human annotator"
     }
+    # The schema is dropped below, so the order of an ordinal enum must be
+    # put on the column now or a text scale would have no order later (#165)
+    x <- apply_ordinal_enums(x, codebook)
     codebook$schema <- NULL  # Always NULL for human coding
   }
 

--- a/R/qlm_code.R
+++ b/R/qlm_code.R
@@ -383,7 +383,10 @@
 #'
 #' @return A `qlm_coded` object (a tibble with additional attributes):
 #'   \describe{
-#'     \item{Data columns}{The coded results with a `.id` column for identifiers.}
+#'     \item{Data columns}{The coded results with a `.id` column for identifiers.
+#'       A [type_enum()] declared `"ordinal"` in the codebook is an ordered
+#'       factor whose levels are the enum's values in the order written; see
+#'       the `levels` argument of [qlm_codebook()].}
 #'     \item{Attributes}{`data`, `input_type`, and `run` (list containing name, batch, call, codebook, chat_args, execution_args, metadata, parent).}
 #'   }
 #'   The object prints as a tibble and can be used directly in data manipulation workflows.
@@ -767,6 +770,10 @@ qlm_code <- function(x, codebook, model, ...,
 
   # Add model to chat_args for easy access
   chat_args$name <- model
+
+  # An ordinal enum is stored as an ordered factor in the enum's order, the
+  # shape the reliability statistics read the scale order from (#165)
+  results <- apply_ordinal_enums(results, codebook)
 
   coded <- new_qlm_coded(
     results = results,

--- a/R/qlm_codebook.R
+++ b/R/qlm_codebook.R
@@ -52,6 +52,15 @@
 #'   following mapping: `type_boolean` and `type_enum` = nominal, `type_string`
 #'   = nominal, `type_integer` = ordinal, `type_number` = interval.
 #'
+#'   A [type_enum()] is nominal unless declared `"ordinal"` here. For an
+#'   ordinal enum the values, in the order they are written, are the scale
+#'   order: `type_enum(c("low", "medium", "high"))` with
+#'   `levels = list(severity = "ordinal")` ranks low below medium below high.
+#'   [qlm_code()] stores such a column as an ordered factor with those levels,
+#'   and [as_qlm_coded()] does the same for human-coded data given this
+#'   codebook, so [qlm_compare()] and [qlm_validate()] rank the categories by
+#'   that order rather than alphabetically.
+#'
 #'   Names may refer to properties at any depth of the schema, including those
 #'   inside a nested [type_object()] or the items of a [type_array()]. A level
 #'   declared for a nested variable describes that variable in a table
@@ -322,11 +331,19 @@ print.qlm_codebook <- function(x, ...) {
       if (nchar(x$instructions) > 60) "..." else "", "\n", sep = "")
   cat("  Output schema:", class(x$schema)[1], "\n", sep = "")
 
-  # Print levels if available
+  # Print levels if available, with the scale order of an ordinal enum, the
+  # one place the author can see the enum was written in scale order (#165)
   if (!is.null(x$levels) && length(x$levels) > 0) {
+    enums <- ordinal_enum_levels(x)
     cat("  Levels:\n")
     for (i in seq_along(x$levels)) {
-      cat("    ", names(x$levels)[i], ": ", x$levels[[i]], "\n", sep = "")
+      nm <- names(x$levels)[i]
+      order <- if (nm %in% names(enums)) {
+        paste0(" (", paste(enums[[nm]], collapse = " < "), ")")
+      } else {
+        ""
+      }
+      cat("    ", nm, ": ", x$levels[[i]], order, "\n", sep = "")
     }
   }
 
@@ -516,3 +533,77 @@ qlm_levels <- function(codebook) {
   # Otherwise auto-detect from schema
   auto_detect_levels(codebook$schema)
 }
+
+
+#' Scale order of the ordinal enums in a codebook
+#'
+#' A `type_enum()` declared `"ordinal"` in the codebook's levels carries its
+#' scale order in its values, in the order they were written. Only top-level
+#' properties are returned: nested enums are list columns, not ratings.
+#'
+#' @param codebook A codebook (a `qlm_codebook` or a plain list with `schema`
+#'   and possibly `levels`).
+#' @return A named list, one character vector of values per ordinal enum;
+#'   empty when the codebook has none.
+#' @keywords internal
+#' @noRd
+ordinal_enum_levels <- function(codebook) {
+  schema <- codebook$schema
+  if (!inherits(schema, "ellmer::TypeObject")) {
+    return(list())
+  }
+  levels <- qlm_levels(codebook)
+  props <- schema@properties
+  out <- list()
+  for (nm in names(props)) {
+    declared <- if (nm %in% names(levels)) levels[[nm]] else NA_character_
+    if (inherits(props[[nm]], "ellmer::TypeEnum") && identical(declared, "ordinal")) {
+      out[[nm]] <- props[[nm]]@values
+    }
+  }
+  out
+}
+
+
+#' Store ordinal enum columns as ordered factors
+#'
+#' Every column of `x` that is an ordinal enum of the codebook becomes
+#' `factor(x, levels = values, ordered = TRUE)`, the shape that carries the
+#' scale order to [qlm_compare()] and [qlm_validate()] (#165). A plain factor
+#' is read by its values, since its levels may be alphabetical and say nothing
+#' about order; an ordered factor must already agree with the codebook. A
+#' value outside the enum is an error, never a silent `NA`: on the coding
+#' paths ellmer has already reduced such a value to `NA`, so this guards the
+#' human-coded path.
+#'
+#' @param x A data frame of coded results.
+#' @param codebook The codebook the results were coded against.
+#' @return `x`, with the ordinal enum columns as ordered factors.
+#' @keywords internal
+#' @noRd
+apply_ordinal_enums <- function(x, codebook) {
+  enums <- ordinal_enum_levels(codebook)
+  for (nm in intersect(names(enums), names(x))) {
+    col <- x[[nm]]
+    values <- enums[[nm]]
+    if (is.ordered(col) && !identical(levels(col), values)) {
+      cli::cli_abort(c(
+        "{.var {nm}} is an ordered factor whose order differs from the codebook.",
+        "x" = "Column: {paste(levels(col), collapse = ' < ')}",
+        "i" = "Codebook: {paste(values, collapse = ' < ')}",
+        "i" = "Store the column as plain text or drop its levels to take the codebook's order."
+      ))
+    }
+    chr <- as.character(col)
+    bad <- setdiff(unique(chr[!is.na(chr)]), values)
+    if (length(bad)) {
+      cli::cli_abort(c(
+        "{.var {nm}} has {length(bad)} value{?s} not among the codebook's categories: {.val {bad}}",
+        "i" = "The codebook declares {.val {values}}."
+      ))
+    }
+    x[[nm]] <- factor(chr, levels = values, ordered = TRUE)
+  }
+  x
+}
+

--- a/R/qlm_compare.R
+++ b/R/qlm_compare.R
@@ -629,13 +629,14 @@ qlm_compare <- function(...,
 #'
 #' At ordinal, interval and ratio level every column is read as numbers. A
 #' value that does not read as a number is an error at interval and ratio
-#' level, which assert numeric data. Ordinal categories may be text, so when
-#' no column reads as numbers the ratings are ranked by their ordered-factor
-#' levels, which every coder must supply and all must agree on (#165); the
-#' ranks are integers, so a tolerance then counts rank distance. A mix of
-#' numeric and text columns at ordinal level is an error, since the ranks of
-#' one cannot be placed against the other. Nominal ratings are left as
-#' stored: categories are compared as text and no tolerance applies.
+#' level, which assert numeric data. Ordinal categories may be text, so an
+#' ordered factor is read first, before any numeric probe, as the declared
+#' order: every coder must then supply one and all must agree on the levels
+#' (#165). The ranks are integers, so a tolerance then counts rank distance.
+#' Text with no ordered factor anywhere is refused by the same helper, and a
+#' mix of numeric and text columns at ordinal level is an error, since the
+#' ranks of one cannot be placed against the other. Nominal ratings are left
+#' as stored: categories are compared as text and no tolerance applies.
 #'
 #' @param columns Data frame with one column per coder and no `.id`.
 #' @param level Character; the measurement level.
@@ -651,6 +652,20 @@ qlm_compare <- function(...,
 ratings_matrix <- function(columns, level, var, coders = names(columns)) {
   if (level == "nominal") {
     return(as.matrix(columns))
+  }
+
+  # An ordered factor is a declared order and wins over anything its labels
+  # look like: reading it as numbers first took "1" < "10" < "2" as 1, 10, 2,
+  # rejected coders on the labels they happened to observe, and let two
+  # conflicting orders pass whenever the observed labels were all digits.
+  # One ordered factor commits the variable to declared order, so a coder
+  # without one is refused by name rather than read as numbers.
+  if (level == "ordinal" && any(vapply(columns, is.ordered, logical(1)))) {
+    lvls <- ordinal_levels(columns, var, coders)
+    ratings <- do.call(cbind, lapply(columns, as.integer))
+    colnames(ratings) <- names(columns)
+    attr(ratings, "levels") <- lvls
+    return(ratings)
   }
 
   numbers <- lapply(columns, function(col) {

--- a/R/qlm_compare.R
+++ b/R/qlm_compare.R
@@ -31,10 +31,10 @@
 #'   and `0.1 + 0.2` equals `0.3`; it is numerical equality rather than bit
 #'   identity. The allowance is far smaller than any meaningful rating
 #'   difference, so a genuinely different pair is never counted as agreeing.
-#'   Used for percent agreement at ordinal, interval and ratio level, where
-#'   the ratings are numbers. Nominal categories agree only when identical,
-#'   as do ordinal categories given as text, and a positive `tolerance` on
-#'   text categories draws a warning since it cannot be applied.
+#'   Used for percent agreement at ordinal, interval and ratio level. Ordinal
+#'   categories given as text are ranked by their ordered-factor levels, and
+#'   the tolerance then counts rank distance: `tolerance = 1` means adjacent
+#'   categories agree. Nominal categories agree only when identical.
 #' @param ci Confidence interval method:
 #'   \describe{
 #'     \item{`"none"`}{No confidence intervals (default)}
@@ -105,10 +105,16 @@
 #' column of digits held as text is compared on its values and not on the
 #' alphabetical order of its strings. A value that does not read as a number
 #' is an error at interval and ratio level, naming the coder and the values.
-#' At ordinal level the categories may instead all be text, in which case they
-#' are ranked by their sorted labels; numbers from one coder and text from
-#' another cannot be placed on one scale and are an error. Nominal ratings are
-#' compared as text.
+#' At ordinal level the categories may instead all be text, in which case
+#' every coder's column must be an ordered factor with the same levels in the
+#' same order, and the categories are ranked by those levels; alphabetical
+#' order is never used, since it is not a ranking. A plain factor or a
+#' character column at ordinal level is an error that says how to declare the
+#' order: `factor(x, levels = c(...), ordered = TRUE)` for data built by hand,
+#' or a [type_enum()] written in scale order and declared `"ordinal"` in the
+#' codebook, which [qlm_code()] and [as_qlm_coded()] store as that ordered
+#' factor. Numbers from one coder and text from another cannot be placed on
+#' one scale and are an error. Nominal ratings are compared as text.
 #'
 #' **Per-category statistics.** When `by_category = TRUE` and `level = "nominal"`,
 #' the result also includes one row per category for `alpha_per_value` (from
@@ -475,8 +481,7 @@ qlm_compare <- function(...,
     # Rating matrix, typed by the level rather than by how each coder stored
     # the values (#150)
     ratings <- ratings_matrix(coder_columns[complete_rows, , drop = FALSE],
-                              var_level, var,
-                              coders = coder_labels, tolerance = tolerance)
+                              var_level, var, coders = coder_labels)
     n_subjects <- nrow(ratings)
 
     # Store n_subjects for first variable (for metadata)
@@ -625,25 +630,25 @@ qlm_compare <- function(...,
 #' At ordinal, interval and ratio level every column is read as numbers. A
 #' value that does not read as a number is an error at interval and ratio
 #' level, which assert numeric data. Ordinal categories may be text, so when
-#' no column reads as numbers the ratings stay text and are ranked by their
-#' sorted labels, as before; a positive `tolerance` cannot be honoured on
-#' labels and draws a warning rather than being ignored. A mix of numeric and
-#' text columns at ordinal level is an error, since the ranks of one cannot be
-#' placed against the other. Nominal ratings are left as stored: categories
-#' are compared as text and no tolerance applies.
+#' no column reads as numbers the ratings are ranked by their ordered-factor
+#' levels, which every coder must supply and all must agree on (#165); the
+#' ranks are integers, so a tolerance then counts rank distance. A mix of
+#' numeric and text columns at ordinal level is an error, since the ranks of
+#' one cannot be placed against the other. Nominal ratings are left as
+#' stored: categories are compared as text and no tolerance applies.
 #'
 #' @param columns Data frame with one column per coder and no `.id`.
 #' @param level Character; the measurement level.
 #' @param var Character; the variable's name, for messages.
 #' @param coders Character; one label per column, for messages.
-#' @param tolerance Numeric; the tolerance the caller asked for.
 #'
 #' @return A matrix with one column per coder: numeric where the level is
-#'   numeric and every column reads as numbers, otherwise of the stored type.
+#'   numeric and every column reads as numbers; integer ranks, with the shared
+#'   levels in attribute `"levels"`, for ordered text at ordinal level;
+#'   otherwise of the stored type.
 #' @keywords internal
 #' @noRd
-ratings_matrix <- function(columns, level, var, coders = names(columns),
-                           tolerance = 0) {
+ratings_matrix <- function(columns, level, var, coders = names(columns)) {
   if (level == "nominal") {
     return(as.matrix(columns))
   }
@@ -663,14 +668,11 @@ ratings_matrix <- function(columns, level, var, coders = names(columns),
   }
 
   if (level == "ordinal" && all(unreadable)) {
-    if (tolerance > 0) {
-      cli::cli_warn(c(
-        "Ignoring {.arg tolerance} for variable {.var {var}}: its ordinal categories are text.",
-        "i" = "A tolerance applies only to numbers; text categories agree only when identical.",
-        "i" = "Store the categories as numbers to compare them within a tolerance."
-      ))
-    }
-    return(as.matrix(columns))
+    lvls <- ordinal_levels(columns, var, coders)
+    ratings <- do.call(cbind, lapply(columns, as.integer))
+    colnames(ratings) <- names(columns)
+    attr(ratings, "levels") <- lvls
+    return(ratings)
   }
 
   offending <- vapply(which(unreadable), function(i) {
@@ -694,6 +696,51 @@ ratings_matrix <- function(columns, level, var, coders = names(columns),
     offending,
     "i" = hint
   ))
+}
+
+
+#' The declared order of ordinal text categories
+#'
+#' Text categories at ordinal level carry an order only when someone declared
+#' one, and the declaration quallmer reads is an ordered factor: a plain
+#' factor's levels are alphabetical by default and say nothing, which is the
+#' fault of #165. Every coder's column must be an ordered factor and all must
+#' have the same levels in the same order.
+#'
+#' @param columns Data frame with one column per coder and no `.id`.
+#' @param var Character; the variable's name, for messages.
+#' @param coders Character; one label per column, for messages.
+#'
+#' @return The shared character vector of levels, lowest first.
+#' @keywords internal
+#' @noRd
+ordinal_levels <- function(columns, var, coders = names(columns)) {
+  ordered <- vapply(columns, is.ordered, logical(1))
+  if (!all(ordered)) {
+    plain <- coders[!ordered]
+    declare <- paste0("levels = list(", var, " = \"ordinal\")")
+    cli::cli_abort(c(
+      "Ordinal categories for {.var {var}} carry no declared order for coder{?s} {.val {plain}}.",
+      "i" = "Text categories are ranked by the levels of an ordered factor; alphabetical order is not a ranking.",
+      "i" = "For data built by hand, use {.code factor(x, levels = c(...), ordered = TRUE)}.",
+      "i" = "For a codebook, write the {.fn type_enum} values in scale order and declare {.code {declare}}; {.fn qlm_code} and {.fn as_qlm_coded} then store the column as an ordered factor."
+    ))
+  }
+
+  lvls <- lapply(columns, levels)
+  same <- vapply(lvls, identical, logical(1), lvls[[1]])
+  if (!all(same)) {
+    shown <- vapply(seq_along(lvls), function(i) {
+      cli::format_inline("{.val {coders[i]}}: {paste(lvls[[i]], collapse = ' < ')}")
+    }, character(1))
+    names(shown) <- rep("x", length(shown))
+    cli::cli_abort(c(
+      "The ordered categories of {.var {var}} differ between coders:",
+      shown,
+      "i" = "Every coder's ordered factor must have the same levels in the same order."
+    ))
+  }
+  lvls[[1]]
 }
 
 

--- a/R/qlm_validate.R
+++ b/R/qlm_validate.R
@@ -283,8 +283,14 @@ bootstrap_validation_ci <- function(merged, var_level, metrics_to_compute, estim
 #' read as numbers, whatever type they are stored as, so a column of digits
 #' held as text is compared on its values and not on the alphabetical order of
 #' its strings. A value that does not read as a number is an error at interval
-#' level. Ordinal categories may instead all be text, in which case they are
-#' ranked by their sorted labels.
+#' level. Ordinal categories may instead all be text, in which case both
+#' columns must be ordered factors with the same levels in the same order, and
+#' the categories are ranked by those levels; alphabetical order is never
+#' used. A plain factor or a character column at ordinal level is an error
+#' that says how to declare the order: `factor(x, levels = c(...), ordered =
+#' TRUE)` for data built by hand, or a [type_enum()] written in scale order
+#' and declared `"ordinal"` in the codebook, which [qlm_code()] and
+#' [as_qlm_coded()] store as that ordered factor.
 #'
 #' For multiclass problems with nominal data, the `average` parameter controls
 #' how per-class metrics are aggregated:
@@ -754,8 +760,25 @@ qlm_validate <- function(
       n_subjects_total <- nrow(merged)
     }
 
-    # Get unique levels from both columns
-    all_levels <- sort(unique(c(
+    # Numbers for the ordinal and interval measures, read by the declared
+    # level rather than taken as codes of the string-sorted factor levels,
+    # which ranked "10" between "1" and "2" (#150). Ordinal categories that
+    # are all text are ranked by their ordered-factor levels (#165); the
+    # helper refuses text with no declared order.
+    numbers <- NULL
+    if (var_level != "nominal") {
+      numbers <- ratings_matrix(
+        merged[, c("estimate", "truth")], var_level, var,
+        coders = c(if (is.na(x_obj_name)) "x" else x_obj_name,
+                   if (is.na(gold_name)) "gold" else gold_name)
+      )
+      merged$estimate_num <- numbers[, "estimate"]
+      merged$truth_num <- numbers[, "truth"]
+    }
+
+    # Shared levels for both columns: the declared order where there is one,
+    # otherwise the sorted labels, which only nominal statistics then use
+    all_levels <- attr(numbers, "levels") %||% sort(unique(c(
       as.character(merged$estimate),
       as.character(merged$truth)
     )))
@@ -763,31 +786,11 @@ qlm_validate <- function(
     # Convert both to factors with shared levels
     # For ordinal data, use ordered factors for proper weighted kappa
     if (var_level == "ordinal") {
-      merged$estimate <- factor(merged$estimate, levels = all_levels, ordered = TRUE)
-      merged$truth <- factor(merged$truth, levels = all_levels, ordered = TRUE)
+      merged$estimate <- factor(as.character(merged$estimate), levels = all_levels, ordered = TRUE)
+      merged$truth <- factor(as.character(merged$truth), levels = all_levels, ordered = TRUE)
     } else {
-      merged$estimate <- factor(merged$estimate, levels = all_levels)
-      merged$truth <- factor(merged$truth, levels = all_levels)
-    }
-
-    # Numbers for the ordinal and interval measures, read by the declared
-    # level rather than taken as codes of the string-sorted factor levels,
-    # which ranked "10" between "1" and "2" (#150). Ordinal categories that
-    # are all text keep those codes: their sorted labels are the only order
-    # there is.
-    if (var_level != "nominal") {
-      numbers <- ratings_matrix(
-        merged[, c("estimate", "truth")], var_level, var,
-        coders = c(if (is.na(x_obj_name)) "x" else x_obj_name,
-                   if (is.na(gold_name)) "gold" else gold_name)
-      )
-      if (is.numeric(numbers)) {
-        merged$estimate_num <- numbers[, "estimate"]
-        merged$truth_num <- numbers[, "truth"]
-      } else {
-        merged$estimate_num <- as.numeric(merged$estimate)
-        merged$truth_num <- as.numeric(merged$truth)
-      }
+      merged$estimate <- factor(as.character(merged$estimate), levels = all_levels)
+      merged$truth <- factor(as.character(merged$truth), levels = all_levels)
     }
 
     # Map `average` to the estimator label used by the metric_* functions.

--- a/man/as_qlm_coded.Rd
+++ b/man/as_qlm_coded.Rd
@@ -73,7 +73,14 @@ Default is \code{FALSE}.}
 \item{\code{instructions}}{Text describing coding instructions}
 \item{\code{schema}}{NULL (not used for human coding)}
 }
-If \code{NULL} (default), a minimal placeholder codebook is created.}
+If \code{NULL} (default), a minimal placeholder codebook is created. Passing
+the \code{\link[=qlm_codebook]{qlm_codebook()}} the LLM coded against gives the human data the same
+measurement levels, and a column that is a \code{\link[ellmer:type_enum]{type_enum()}} declared
+\code{"ordinal"} there is stored as an ordered factor in the enum's order, so
+\code{\link[=qlm_compare]{qlm_compare()}} and \code{\link[=qlm_validate]{qlm_validate()}} rank it as they rank the LLM's; a
+value outside the enum is an error. Without a codebook, order a text
+scale yourself with \code{factor(x, levels = c(...), ordered = TRUE)}. The
+schema itself is not kept.}
 
 \item{texts}{Optional vector of original texts or data that were coded.
 Should correspond to the \code{.id} values in \code{data}. If provided, enables

--- a/man/qlm_code.Rd
+++ b/man/qlm_code.Rd
@@ -112,7 +112,10 @@ results in \code{\link[=qlm_trail]{qlm_trail()}}. Default is \code{NULL}.}
 \value{
 A \code{qlm_coded} object (a tibble with additional attributes):
 \describe{
-\item{Data columns}{The coded results with a \code{.id} column for identifiers.}
+\item{Data columns}{The coded results with a \code{.id} column for identifiers.
+A \code{\link[ellmer:type_enum]{type_enum()}} declared \code{"ordinal"} in the codebook is an ordered
+factor whose levels are the enum's values in the order written; see
+the \code{levels} argument of \code{\link[=qlm_codebook]{qlm_codebook()}}.}
 \item{Attributes}{\code{data}, \code{input_type}, and \code{run} (list containing name, batch, call, codebook, chat_args, execution_args, metadata, parent).}
 }
 The object prints as a tibble and can be used directly in data manipulation workflows.

--- a/man/qlm_codebook.Rd
+++ b/man/qlm_codebook.Rd
@@ -40,6 +40,15 @@ If \code{NULL} (default), levels are auto-detected from schema types using the
 following mapping: \code{type_boolean} and \code{type_enum} = nominal, \code{type_string}
 = nominal, \code{type_integer} = ordinal, \code{type_number} = interval.
 
+A \code{\link[ellmer:type_enum]{type_enum()}} is nominal unless declared \code{"ordinal"} here. For an
+ordinal enum the values, in the order they are written, are the scale
+order: \code{type_enum(c("low", "medium", "high"))} with
+\code{levels = list(severity = "ordinal")} ranks low below medium below high.
+\code{\link[=qlm_code]{qlm_code()}} stores such a column as an ordered factor with those levels,
+and \code{\link[=as_qlm_coded]{as_qlm_coded()}} does the same for human-coded data given this
+codebook, so \code{\link[=qlm_compare]{qlm_compare()}} and \code{\link[=qlm_validate]{qlm_validate()}} rank the categories by
+that order rather than alphabetically.
+
 Names may refer to properties at any depth of the schema, including those
 inside a nested \code{\link[ellmer:type_object]{type_object()}} or the items of a \code{\link[ellmer:type_array]{type_array()}}. A level
 declared for a nested variable describes that variable in a table

--- a/man/qlm_compare.Rd
+++ b/man/qlm_compare.Rd
@@ -44,10 +44,10 @@ being compared, so a difference of exactly \code{tolerance} counts as agreement
 and \code{0.1 + 0.2} equals \code{0.3}; it is numerical equality rather than bit
 identity. The allowance is far smaller than any meaningful rating
 difference, so a genuinely different pair is never counted as agreeing.
-Used for percent agreement at ordinal, interval and ratio level, where
-the ratings are numbers. Nominal categories agree only when identical,
-as do ordinal categories given as text, and a positive \code{tolerance} on
-text categories draws a warning since it cannot be applied.}
+Used for percent agreement at ordinal, interval and ratio level. Ordinal
+categories given as text are ranked by their ordered-factor levels, and
+the tolerance then counts rank distance: \code{tolerance = 1} means adjacent
+categories agree. Nominal categories agree only when identical.}
 
 \item{ci}{Confidence interval method:
 \describe{
@@ -132,10 +132,16 @@ coder's ratings are read as numbers, whatever type they are stored as, so a
 column of digits held as text is compared on its values and not on the
 alphabetical order of its strings. A value that does not read as a number
 is an error at interval and ratio level, naming the coder and the values.
-At ordinal level the categories may instead all be text, in which case they
-are ranked by their sorted labels; numbers from one coder and text from
-another cannot be placed on one scale and are an error. Nominal ratings are
-compared as text.
+At ordinal level the categories may instead all be text, in which case
+every coder's column must be an ordered factor with the same levels in the
+same order, and the categories are ranked by those levels; alphabetical
+order is never used, since it is not a ranking. A plain factor or a
+character column at ordinal level is an error that says how to declare the
+order: \code{factor(x, levels = c(...), ordered = TRUE)} for data built by hand,
+or a \code{\link[ellmer:type_enum]{type_enum()}} written in scale order and declared \code{"ordinal"} in the
+codebook, which \code{\link[=qlm_code]{qlm_code()}} and \code{\link[=as_qlm_coded]{as_qlm_coded()}} store as that ordered
+factor. Numbers from one coder and text from another cannot be placed on
+one scale and are an error. Nominal ratings are compared as text.
 
 \strong{Per-category statistics.} When \code{by_category = TRUE} and \code{level = "nominal"},
 the result also includes one row per category for \code{alpha_per_value} (from

--- a/man/qlm_validate.Rd
+++ b/man/qlm_validate.Rd
@@ -124,8 +124,13 @@ At ordinal and interval level the predictions and the gold standard are
 read as numbers, whatever type they are stored as, so a column of digits
 held as text is compared on its values and not on the alphabetical order of
 its strings. A value that does not read as a number is an error at interval
-level. Ordinal categories may instead all be text, in which case they are
-ranked by their sorted labels.
+level. Ordinal categories may instead all be text, in which case both
+columns must be ordered factors with the same levels in the same order, and
+the categories are ranked by those levels; alphabetical order is never
+used. A plain factor or a character column at ordinal level is an error
+that says how to declare the order: \code{factor(x, levels = c(...), ordered = TRUE)} for data built by hand, or a \code{\link[ellmer:type_enum]{type_enum()}} written in scale order
+and declared \code{"ordinal"} in the codebook, which \code{\link[=qlm_code]{qlm_code()}} and
+\code{\link[=as_qlm_coded]{as_qlm_coded()}} store as that ordered factor.
 
 For multiclass problems with nominal data, the \code{average} parameter controls
 how per-class metrics are aggregated:

--- a/tests/testthat/test-as_qlm_coded.R
+++ b/tests/testthat/test-as_qlm_coded.R
@@ -460,3 +460,31 @@ test_that("as_qlm_coded rejects a missing .id, and an id= beside an existing .id
   # ... whereas naming the existing column is fine
   expect_equal(as_qlm_coded(x, id = .id)$.id, c("old1", "old2"))
 })
+
+
+test_that("as_qlm_coded orders an ordinal enum column by the codebook (#165)", {
+  lv <- c("low", "medium", "high")
+  cb <- qlm_codebook("Sev", "Rate.", ellmer::type_object(sev = ellmer::type_enum(lv)),
+                     levels = list(sev = "ordinal"))
+
+  x <- as_qlm_coded(data.frame(.id = 1:3, sev = c("high", "low", "medium")),
+                    name = "coder", codebook = cb)
+  expect_identical(x$sev, factor(c("high", "low", "medium"), levels = lv, ordered = TRUE))
+  # The schema is still not kept, but the level is
+  expect_null(codebook(x)$schema)
+  expect_equal(qlm_levels(codebook(x)), list(sev = "ordinal"))
+
+  # A value outside the enum is an error naming it
+  err <- expect_error(
+    as_qlm_coded(data.frame(.id = 1:2, sev = c("low", "severe")), name = "coder", codebook = cb),
+    "not among the codebook"
+  )
+  expect_match(conditionMessage(err), "severe")
+
+  # Without a codebook the column is left as given: an ordered factor is the declaration
+  y <- as_qlm_coded(data.frame(.id = 1:2, sev = c("low", "high")), name = "coder")
+  expect_type(y$sev, "character")
+  ordered <- factor(c("low", "high"), levels = lv, ordered = TRUE)
+  z <- as_qlm_coded(data.frame(.id = 1:2, sev = ordered), name = "coder")
+  expect_identical(z$sev, ordered)
+})

--- a/tests/testthat/test-qlm_backfill.R
+++ b/tests/testthat/test-qlm_backfill.R
@@ -9,8 +9,8 @@ backfill_schema <- ellmer::type_object(
 # `id` column; the inputs are named by it so the backfill can subset them.
 make_run <- function(results, schema = backfill_schema, chat_args = list(),
                      execution_args = list(), backend = "structured",
-                     name = "run1", n_units = nrow(results)) {
-  codebook <- qlm_codebook("Test", "Test prompt", schema)
+                     name = "run1", n_units = nrow(results), levels = NULL) {
+  codebook <- qlm_codebook("Test", "Test prompt", schema, levels = levels)
   data <- stats::setNames(paste0("text ", results$id), results$id)
   new_qlm_coded(
     results = results,
@@ -1096,4 +1096,25 @@ test_that("a backfill keeps the pass's file hashes and registration (#124)", {
     suppressMessages(qlm_backfill(filled2, model = "google_gemini/gemini-4-ultra")),
     "qlm_register_input_model"
   )
+})
+
+
+test_that("qlm_backfill keeps an ordinal enum's ordered levels (#165)", {
+  skip_if_not_installed("mockery")
+  lv <- c("low", "medium", "high")
+  schema <- ellmer::type_object(sev = ellmer::type_enum(lv))
+  results <- data.frame(
+    id = c("a", "b", "c"),
+    sev = factor(c("high", NA, "low"), levels = lv, ordered = TRUE)
+  )
+  results$.error <- error_col(NULL, "Invalid JSON", NULL)
+  run <- make_run(results, schema = schema, levels = list(sev = "ordinal"))
+  expect_true(is.ordered(run$sev))
+
+  pass <- data.frame(id = "b", sev = factor("medium", levels = lv, ordered = TRUE))
+  f <- backfill_with(list(pass))
+  expect_message(filled <- f(run), "Recovered 1 unit")
+
+  expect_identical(filled$sev, factor(c("high", "medium", "low"), levels = lv, ordered = TRUE))
+  expect_equal(nrow(qlm_failures(filled)), 0)
 })

--- a/tests/testthat/test-qlm_code.R
+++ b/tests/testthat/test-qlm_code.R
@@ -757,6 +757,57 @@ test_that("qlm_code still uses parallel_chat_structured for other providers", {
 })
 
 
+test_that("qlm_code stores an ordinal enum as an ordered factor in the enum's order (#165)", {
+  skip_if_not_installed("mockery")
+  lv <- c("low", "medium", "high")
+  schema <- ellmer::type_object(
+    sev = ellmer::type_enum(lv),
+    tone = ellmer::type_enum(c("pos", "neg"))
+  )
+  ordinal <- qlm_codebook("Test", "Prompt", schema, levels = list(sev = "ordinal"))
+  nominal <- qlm_codebook("Test", "Prompt", schema)
+
+  # Structured path: ellmer converts an enum to a plain factor in enum order
+  returned <- data.frame(
+    sev = factor(c("high", "low"), levels = lv),
+    tone = factor(c("pos", "neg"), levels = c("pos", "neg"))
+  )
+  tsc <- try_structured_call
+  mockery::stub(tsc, "ellmer::chat", structure(list(), class = "Chat"))
+  mockery::stub(tsc, "ellmer::parallel_chat_structured", returned)
+  f <- qlm_code
+  mockery::stub(f, "try_structured_call", tsc)
+
+  res <- f(c("a", "b"), ordinal, model = "openai/gpt-4o-mini")
+  expect_identical(res$sev, factor(c("high", "low"), levels = lv, ordered = TRUE))
+  # Nominal unless declared: left as ellmer returned it
+  expect_false(is.ordered(res$tone))
+  expect_equal(levels(res$tone), c("pos", "neg"))
+  res <- f(c("a", "b"), nominal, model = "openai/gpt-4o-mini")
+  expect_false(is.ordered(res$sev))
+
+  # JSON path, from a handler that returns the values as text
+  fake_handler <- function(x, codebook, model, chat_args, execution_args, batch,
+                           json_retries = 2L, model_hint = NULL, ...) {
+    results <- tibble::tibble(sev = c("high", "low"), tone = c("pos", "neg"))
+    attr(results, "qlm_backend_meta") <- list(backend = "json_mode")
+    results
+  }
+  g <- qlm_code
+  mockery::stub(g, "code_handler_json", fake_handler)
+  res <- g(c("a", "b"), ordinal, model = "deepseek/deepseek-chat")
+  expect_identical(res$sev, factor(c("high", "low"), levels = lv, ordered = TRUE))
+  expect_type(res$tone, "character")
+
+  # The order survives row subsetting and a save/load round trip
+  expect_identical(res[2, ]$sev, factor("low", levels = lv, ordered = TRUE))
+  path <- tempfile(fileext = ".rds")
+  on.exit(unlink(path), add = TRUE)
+  saveRDS(res, path)
+  expect_identical(readRDS(path)$sev, res$sev)
+})
+
+
 test_that("qlm_code errors on json_retries only where JSON mode cannot be reached", {
   skip_if_not_installed("mockery")
 

--- a/tests/testthat/test-qlm_codebook.R
+++ b/tests/testthat/test-qlm_codebook.R
@@ -477,3 +477,70 @@ test_that("nested levels reach qlm_compare through an unnested, re-wrapped table
   expect_true(all(res$level == "ordinal"))
   expect_equal(res$value[res$measure == "percent_agreement"], 2 / 3)
 })
+
+
+# ---- ordinal enums carry their scale order (#165) ----------------------------
+
+test_that("an ordinal type_enum carries its scale order (#165)", {
+  schema <- ellmer::type_object(
+    sev = ellmer::type_enum(c("low", "medium", "high")),
+    tone = ellmer::type_enum(c("pos", "neg")),
+    n = ellmer::type_integer("Count")
+  )
+  # Nominal unless declared
+  expect_equal(ordinal_enum_levels(qlm_codebook("T", "P", schema)), list())
+
+  cb <- qlm_codebook("T", "P", schema, levels = list(sev = "ordinal"))
+  expect_equal(ordinal_enum_levels(cb), list(sev = c("low", "medium", "high")))
+
+  # A plain list, as as_qlm_coded() accepts, works too; without a schema there is nothing
+  expect_equal(
+    ordinal_enum_levels(list(schema = schema, levels = list(sev = "ordinal"))),
+    list(sev = c("low", "medium", "high"))
+  )
+  expect_equal(ordinal_enum_levels(list(schema = NULL, levels = list(sev = "ordinal"))), list())
+
+  # Shown in the print, where the author can see the enum was written in scale order
+  out <- capture.output(print(cb))
+  expect_true(any(grepl("sev: ordinal (low < medium < high)", out, fixed = TRUE)))
+  # A nominal enum shows no order
+  out <- capture.output(print(qlm_codebook("T", "P", schema)))
+  expect_true(any(grepl("sev: nominal$", out)))
+})
+
+
+test_that("apply_ordinal_enums stores ordinal enum columns as ordered factors (#165)", {
+  lv <- c("low", "medium", "high")
+  cb <- qlm_codebook(
+    "T", "P",
+    ellmer::type_object(sev = ellmer::type_enum(lv), tone = ellmer::type_enum(c("pos", "neg"))),
+    levels = list(sev = "ordinal")
+  )
+
+  out <- apply_ordinal_enums(data.frame(sev = c("high", "low", NA), tone = c("pos", "neg", "pos")), cb)
+  expect_identical(out$sev, factor(c("high", "low", NA), levels = lv, ordered = TRUE))
+  # Nominal enums are left alone
+  expect_type(out$tone, "character")
+
+  # A plain factor is read by its values, whatever its (alphabetical) levels say
+  out <- apply_ordinal_enums(data.frame(sev = factor(c("high", "low"))), cb)
+  expect_identical(out$sev, factor(c("high", "low"), levels = lv, ordered = TRUE))
+
+  # An ordered factor that already agrees passes through
+  ok <- factor(c("high", "low"), levels = lv, ordered = TRUE)
+  expect_identical(apply_ordinal_enums(data.frame(sev = ok), cb)$sev, ok)
+
+  # One that disagrees is a conflicting declaration
+  expect_error(
+    apply_ordinal_enums(data.frame(sev = factor(c("high", "low"), levels = rev(lv), ordered = TRUE)), cb),
+    "differs from the codebook"
+  )
+
+  # A value outside the enum is never a silent NA
+  err <- expect_error(apply_ordinal_enums(data.frame(sev = c("low", "severe")), cb),
+                      "not among the codebook")
+  expect_match(conditionMessage(err), "severe")
+
+  # Columns the codebook does not know are untouched
+  expect_equal(apply_ordinal_enums(data.frame(other = 1:2), cb), data.frame(other = 1:2))
+})

--- a/tests/testthat/test-qlm_compare.R
+++ b/tests/testthat/test-qlm_compare.R
@@ -722,18 +722,149 @@ test_that("a rating that is not a number is an error at interval level (#150)", 
 })
 
 
-test_that("ordinal text categories rank as before, and a tolerance on them warns (#150)", {
+# ---- ordinal text categories ranked by their declared order (#165) ----------
+
+# Two coders' text ratings as ordered factors on the same scale
+ordered_pair <- function(a, b, lv = c("low", "medium", "high"), ...) {
+  x <- as_qlm_coded(data.frame(.id = seq_along(a), g = factor(a, levels = lv, ordered = TRUE)),
+                    id = .id, name = "A")
+  y <- as_qlm_coded(data.frame(.id = seq_along(b), g = factor(b, levels = lv, ordered = TRUE)),
+                    id = .id, name = "B")
+  as.data.frame(qlm_compare(x, y, by = "g", level = "ordinal", ...))
+}
+
+test_that("ordinal text categories are ranked by their ordered-factor levels (#165)", {
+  # The issue's case: B is always at or one step above A on the scale
+  a <- c("low", "low", "medium", "medium", "high", "high")
+  b <- c("low", "medium", "medium", "high", "high", "high")
+  from_text <- ordered_pair(a, b)
+
+  x <- as_qlm_coded(data.frame(.id = 1:6, g = c(1, 1, 2, 2, 3, 3)), id = .id, name = "A")
+  y <- as_qlm_coded(data.frame(.id = 1:6, g = c(1, 2, 2, 3, 3, 3)), id = .id, name = "B")
+  from_numbers <- as.data.frame(qlm_compare(x, y, by = "g", level = "ordinal"))
+
+  expect_equal(from_text$measure, from_numbers$measure)
+  expect_equal(from_text$value, from_numbers$value)
+  # The alphabetical ranking put "high" lowest and gave 0.45
+  expect_gt(from_text$value[from_text$measure == "rho"], 0.8)
+})
+
+
+test_that("a plain factor or character column has no order at ordinal level (#165)", {
   a <- c("low", "mid", "high", "low")
   b <- c("low", "high", "high", "mid")
 
-  expect_no_warning(pct <- compare_pair(a, b, tolerance = 0, level = "ordinal"))
-  expect_equal(pct, 0.5)
+  err <- expect_error(compare_pair(a, b, tolerance = 0, level = "ordinal"), "no declared order")
+  expect_match(conditionMessage(err), "ordered = TRUE")
+  expect_match(conditionMessage(err), "type_enum")
+  expect_match(conditionMessage(err), 'levels = list(g = "ordinal")', fixed = TRUE)
 
-  expect_warning(
-    pct_tol <- compare_pair(a, b, tolerance = 1, level = "ordinal"),
-    "Ignoring `tolerance`"
+  # A plain factor's levels are alphabetical by default and say nothing
+  err <- expect_error(compare_pair(factor(a), factor(b), tolerance = 0, level = "ordinal"),
+                      "no declared order")
+  expect_match(conditionMessage(err), '"A" and "B"')
+
+  # An ordered factor in one coder does not order the other's text
+  fa <- factor(a, levels = c("low", "mid", "high"), ordered = TRUE)
+  err <- expect_error(compare_pair(fa, b, tolerance = 0, level = "ordinal"), "no declared order")
+  expect_match(conditionMessage(err), '"B"')
+  expect_no_match(conditionMessage(err), '"A"')
+
+  # Nominal level takes the categories as they are
+  expect_equal(compare_pair(a, b, tolerance = 0, level = "nominal"), 0.5)
+})
+
+
+test_that("ordered factors must agree on their levels (#165)", {
+  a <- c("low", "mid", "high", "low")
+  b <- c("low", "high", "high", "mid")
+  fa <- factor(a, levels = c("low", "mid", "high"), ordered = TRUE)
+
+  err <- expect_error(
+    compare_pair(fa, factor(b, levels = c("high", "mid", "low"), ordered = TRUE),
+                 tolerance = 0, level = "ordinal"),
+    "differ between coders"
   )
-  expect_equal(pct_tol, 0.5)
+  expect_match(conditionMessage(err), "low < mid < high")
+  expect_match(conditionMessage(err), "high < mid < low")
+
+  expect_error(
+    compare_pair(fa, factor(b, levels = c("low", "mid", "high", "extreme"), ordered = TRUE),
+                 tolerance = 0, level = "ordinal"),
+    "differ between coders"
+  )
+})
+
+
+test_that("an enum is ordered only when the codebook declares it ordinal (#165)", {
+  schema <- ellmer::type_object(g = ellmer::type_enum(c("low", "mid", "high")))
+  nominal <- qlm_codebook("Sev", "Rate.", schema)
+  x <- as_qlm_coded(data.frame(.id = 1:3, g = c("low", "mid", "high")), id = .id,
+                    name = "A", codebook = nominal)
+  y <- as_qlm_coded(data.frame(.id = 1:3, g = c("low", "high", "high")), id = .id,
+                    name = "B", codebook = nominal)
+  expect_type(x$g, "character")
+  # Compared as declared, the categories are nominal
+  res <- as.data.frame(qlm_compare(x, y, by = "g"))
+  expect_true(all(res$level == "nominal"))
+  # Asked for an order the codebook did not declare, refused with the declaration to add
+  err <- expect_error(qlm_compare(x, y, by = "g", level = "ordinal"), "no declared order")
+  expect_match(conditionMessage(err), 'levels = list(g = "ordinal")', fixed = TRUE)
+
+  ordinal <- qlm_codebook("Sev", "Rate.", schema, levels = list(g = "ordinal"))
+  x <- as_qlm_coded(data.frame(.id = 1:3, g = c("low", "mid", "high")), id = .id,
+                    name = "A", codebook = ordinal)
+  y <- as_qlm_coded(data.frame(.id = 1:3, g = c("low", "high", "high")), id = .id,
+                    name = "B", codebook = ordinal)
+  expect_true(is.ordered(x$g))
+  res <- as.data.frame(qlm_compare(x, y, by = "g"))
+  expect_true(all(res$level == "ordinal"))
+  expect_equal(res$value[res$measure == "percent_agreement"], 2 / 3)
+})
+
+
+test_that("an unused middle category keeps its rank (#165)", {
+  a <- c("low", "high", "low", "high")
+  b <- c("high", "high", "low", "low")
+  from_text <- ordered_pair(a, b)
+
+  x <- as_qlm_coded(data.frame(.id = 1:4, g = c(1, 3, 1, 3)), id = .id, name = "A")
+  y <- as_qlm_coded(data.frame(.id = 1:4, g = c(3, 3, 1, 1)), id = .id, name = "B")
+  from_numbers <- as.data.frame(qlm_compare(x, y, by = "g", level = "ordinal"))
+  expect_equal(from_text$value, from_numbers$value)
+
+  # low and high are two steps apart, so a tolerance of one does not join them
+  with_tol <- ordered_pair(a, b, tolerance = 1)
+  expect_equal(with_tol$value[with_tol$measure == "percent_agreement"], 0.5)
+})
+
+
+test_that("a tolerance on ordered text categories counts rank distance (#165)", {
+  a <- c("low", "medium", "high", "low")
+  b <- c("medium", "high", "high", "high")
+  pct <- function(res) res$value[res$measure == "percent_agreement"]
+
+  expect_equal(pct(ordered_pair(a, b)), 0.25)
+  expect_no_warning(adjacent <- ordered_pair(a, b, tolerance = 1))
+  expect_equal(pct(adjacent), 0.75)
+  expect_equal(pct(ordered_pair(a, b, tolerance = 2)), 1)
+})
+
+
+test_that("bootstrap CIs on ordered text equal those on the same ranks as numbers (#165)", {
+  a <- c("low", "low", "medium", "medium", "high", "high")
+  b <- c("low", "medium", "medium", "high", "high", "high")
+  set.seed(165)
+  from_text <- ordered_pair(a, b, ci = "bootstrap", bootstrap_n = 20)
+
+  x <- as_qlm_coded(data.frame(.id = 1:6, g = c(1, 1, 2, 2, 3, 3)), id = .id, name = "A")
+  y <- as_qlm_coded(data.frame(.id = 1:6, g = c(1, 2, 2, 3, 3, 3)), id = .id, name = "B")
+  set.seed(165)
+  from_numbers <- as.data.frame(qlm_compare(x, y, by = "g", level = "ordinal",
+                                            ci = "bootstrap", bootstrap_n = 20))
+
+  cols <- c("measure", "value", "ci_lower", "ci_upper")
+  expect_equal(from_text[cols], from_numbers[cols])
 })
 
 

--- a/tests/testthat/test-qlm_compare.R
+++ b/tests/testthat/test-qlm_compare.R
@@ -796,6 +796,42 @@ test_that("ordered factors must agree on their levels (#165)", {
 })
 
 
+test_that("an ordered factor is read as declared, whatever its labels look like (#165)", {
+  # Coders on the same declared scale are not rejected on the labels each
+  # happened to observe: A's ratings all read as numbers, B's do not
+  lv <- c("0", "low", "high")
+  a <- factor(c("0", "0", "0"), levels = lv, ordered = TRUE)
+  b <- factor(c("low", "high", "0"), levels = lv, ordered = TRUE)
+  # (a constant coder has no variance, so the correlations warn)
+  expect_no_error(pct <- suppressWarnings(compare_pair(a, b, tolerance = 0, level = "ordinal")))
+  expect_equal(pct, 1 / 3)
+
+  # Numeric-looking labels take their declared ranks, not their values
+  lv <- c("1", "10", "2")
+  a <- factor(c("1", "10", "2", "1"), levels = lv, ordered = TRUE)
+  b <- factor(c("10", "2", "2", "2"), levels = lv, ordered = TRUE)
+  ranks <- ratings_matrix(data.frame(a = a, b = b), "ordinal", "g")
+  expect_equal(unname(ranks[, "a"]), c(1L, 2L, 3L, 1L))
+  expect_equal(unname(ranks[, "b"]), c(2L, 3L, 3L, 3L))
+  expect_equal(attr(ranks, "levels"), lv)
+  # "1" and "10" are adjacent on the declared scale
+  expect_equal(compare_pair(a, b, tolerance = 1, level = "ordinal"), 0.75)
+
+  # Conflicting orders are caught even when every observed label is digits
+  c_ <- factor(c("10", "2", "2", "2"), levels = rev(lv), ordered = TRUE)
+  expect_error(ratings_matrix(data.frame(a = a, c = c_), "ordinal", "g"), "differ between coders")
+
+  # One ordered factor commits the variable to declared order: numbers from
+  # the other coder are not read against it
+  err <- expect_error(compare_pair(a, c(1, 10, 2, 1), tolerance = 0, level = "ordinal"),
+                      "no declared order")
+  expect_match(conditionMessage(err), '"B"')
+
+  # Interval level still reads a factor by its labels (#150)
+  expect_equal(compare_pair(factor(c("1", "2", "10"), ordered = TRUE), c(1, 2, 10), tolerance = 0), 1)
+})
+
+
 test_that("an enum is ordered only when the codebook declares it ordinal (#165)", {
   schema <- ellmer::type_object(g = ellmer::type_enum(c("low", "mid", "high")))
   nominal <- qlm_codebook("Sev", "Rate.", schema)

--- a/tests/testthat/test-qlm_validate.R
+++ b/tests/testthat/test-qlm_validate.R
@@ -850,10 +850,66 @@ test_that("qlm_validate refuses a rating that is not a number at interval level 
 })
 
 
-test_that("qlm_validate ordinal text categories are still ranked by their sorted labels (#150)", {
+# ---- ordinal text categories ranked by their declared order (#165) ----------
+
+test_that("qlm_validate ranks ordinal text categories by their ordered-factor levels (#165)", {
+  lv <- c("low", "medium", "high")
+  truth <- c("low", "low", "medium", "medium", "high", "high")
+  est <- c("low", "medium", "medium", "high", "high", "high")
+  gold <- as_qlm_coded(data.frame(.id = 1:6, g = factor(truth, levels = lv, ordered = TRUE)),
+                       id = .id, name = "gold")
+  pred <- as_qlm_coded(data.frame(.id = 1:6, g = factor(est, levels = lv, ordered = TRUE)),
+                       id = .id, name = "pred")
+
+  v <- as.data.frame(qlm_validate(pred, gold = gold, by = "g", level = "ordinal"))
+  t_num <- match(truth, lv)
+  e_num <- match(est, lv)
+  expect_equal(v$value[v$measure == "rho"], cor(t_num, e_num, method = "spearman"))
+  expect_equal(v$value[v$measure == "tau"], cor(t_num, e_num, method = "kendall"))
+  expect_equal(v$value[v$measure == "mae"], mean(abs(t_num - e_num)))
+  # The alphabetical ranking put "high" lowest and made rho negative
+  expect_gt(v$value[v$measure == "rho"], 0.8)
+
+  # Bootstrap CIs resample the same ranks
+  set.seed(165)
+  vb <- as.data.frame(qlm_validate(pred, gold = gold, by = "g", level = "ordinal",
+                                   ci = "bootstrap", bootstrap_n = 20))
+  expect_equal(vb$value, v$value)
+  mae <- vb[vb$measure == "mae", ]
+  expect_lte(mae$ci_lower, mae$value)
+  expect_gte(mae$ci_upper, mae$value)
+})
+
+
+test_that("qlm_validate refuses ordinal text with no declared order (#165)", {
   gold <- as_qlm_coded(data.frame(.id = 1:4, g = c("a", "b", "c", "a")), id = .id, name = "gold")
   pred <- as_qlm_coded(data.frame(.id = 1:4, g = c("a", "b", "c", "b")), id = .id, name = "pred")
 
-  v <- as.data.frame(qlm_validate(pred, gold = gold, by = "g", level = "ordinal"))
-  expect_equal(v$value[v$measure == "mae"], 0.25)
+  err <- expect_error(qlm_validate(pred, gold = gold, by = "g", level = "ordinal"),
+                      "no declared order")
+  expect_match(conditionMessage(err), "pred")
+  expect_match(conditionMessage(err), "gold")
+  expect_match(conditionMessage(err), "ordered = TRUE")
+
+  # Ordered on the gold side only does not order the predictions
+  lv <- c("a", "b", "c")
+  gold_o <- as_qlm_coded(
+    data.frame(.id = 1:4, g = factor(c("a", "b", "c", "a"), levels = lv, ordered = TRUE)),
+    id = .id, name = "gold"
+  )
+  err <- expect_error(qlm_validate(pred, gold = gold_o, by = "g", level = "ordinal"),
+                      "no declared order")
+  expect_match(conditionMessage(err), '"pred"')
+  expect_no_match(conditionMessage(err), '"gold"')
+
+  # Two orders are two declarations
+  pred_r <- as_qlm_coded(
+    data.frame(.id = 1:4, g = factor(c("a", "b", "c", "b"), levels = rev(lv), ordered = TRUE)),
+    id = .id, name = "pred"
+  )
+  expect_error(qlm_validate(pred_r, gold = gold_o, by = "g", level = "ordinal"),
+               "differ between coders")
+
+  # Nominal level takes the categories as they are
+  expect_no_error(qlm_validate(pred, gold = gold, by = "g", level = "nominal"))
 })

--- a/tests/testthat/test-qlm_validate.R
+++ b/tests/testthat/test-qlm_validate.R
@@ -881,6 +881,28 @@ test_that("qlm_validate ranks ordinal text categories by their ordered-factor le
 })
 
 
+test_that("qlm_validate reads an ordered factor as declared, whatever its labels look like (#165)", {
+  lv <- c("1", "10", "2")
+  gold <- as_qlm_coded(
+    data.frame(.id = 1:4, g = factor(c("1", "10", "2", "1"), levels = lv, ordered = TRUE)),
+    id = .id, name = "gold"
+  )
+  pred <- as_qlm_coded(
+    data.frame(.id = 1:4, g = factor(c("10", "2", "2", "2"), levels = lv, ordered = TRUE)),
+    id = .id, name = "pred"
+  )
+  v <- as.data.frame(qlm_validate(pred, gold = gold, by = "g", level = "ordinal"))
+  # Declared ranks 1, 2, 3, 1 against 2, 3, 3, 3, not the values 1, 10, 2
+  expect_equal(v$value[v$measure == "mae"], mean(abs(c(1, 2, 3, 1) - c(2, 3, 3, 3))))
+
+  pred_r <- as_qlm_coded(
+    data.frame(.id = 1:4, g = factor(c("10", "2", "2", "2"), levels = rev(lv), ordered = TRUE)),
+    id = .id, name = "pred"
+  )
+  expect_error(qlm_validate(pred_r, gold = gold, by = "g", level = "ordinal"), "differ between coders")
+})
+
+
 test_that("qlm_validate refuses ordinal text with no declared order (#165)", {
   gold <- as_qlm_coded(data.frame(.id = 1:4, g = c("a", "b", "c", "a")), id = .id, name = "gold")
   pred <- as_qlm_coded(data.frame(.id = 1:4, g = c("a", "b", "c", "b")), id = .id, name = "pred")


### PR DESCRIPTION
Fixes #165.

## Summary

At `level = "ordinal"`, `qlm_compare()` and `qlm_validate()` ranked text categories by `sort()` of the labels, so low / medium / high became high < low < medium and every statistic that uses the order (ordinal alpha, weighted kappa, Kendall's W, Spearman's rho, tau, MAE) ran on the wrong ranks with nothing in the output to show it. Factor levels were flattened to text before they were read, so ordering the categories in advance changed nothing: with ordered factors on both sides, the issue's example gave rho 0.45 where the same data as 1/2/3 gives 0.84.

Text categories at ordinal level are now ranked by the levels of an ordered factor, which every coder must supply and all must agree on. Alphabetical order is never used. A plain factor or character column at ordinal level is an error that names the coders and says how to declare the order, because a plain factor's levels are alphabetical by default and accepting them would let the fault back in.

## How an order is declared

- **Through the codebook.** A `type_enum()` declared `"ordinal"` in `qlm_codebook(levels = )` has its values, in the order written, as the scale. `qlm_code()` stores the column as `factor(x, levels = values, ordered = TRUE)` on both the structured and JSON paths, and `as_qlm_coded(codebook = )` does the same for human-coded data, refusing a value outside the enum. An enum not declared ordinal stays nominal. The codebook print shows the order (`sev: ordinal (low < medium < high)`).
- **By hand.** `factor(x, levels = c(...), ordered = TRUE)` on the data passed to `as_qlm_coded()`.

`qlm_codebook(levels = )` keeps its one meaning (measurement level); there is no second argument for category order.

## Behaviour changes

- Character or plain-factor text at ordinal level is now an error rather than a silently wrong ranking.
- Because the ranks are integers, `tolerance` on ordered text counts rank distance (`tolerance = 1` means adjacent categories agree). The warning that a tolerance on text categories was being ignored is gone with the reason for it.
- `as_qlm_coded()` given a codebook with an ordinal enum returns that column as an ordered factor.

## Scope

- `R/qlm_codebook.R`: `ordinal_enum_levels()`, `apply_ordinal_enums()`, print, `levels` docs
- `R/qlm_code.R`, `R/as_qlm_coded.R`: apply the ordered factor before the object is built
- `R/qlm_compare.R`: `ratings_matrix()` returns integer ranks for ordered text via new `ordinal_levels()`; unused `tolerance` parameter removed
- `R/qlm_validate.R`: takes ranks and the shared levels from the same helper; the fallback to codes of the string-sorted factor is removed

## Tests

New tests cover the issue's reprex against the numeric coding, plain factors, an ordered factor against a character coder, mismatched level sets and orders, an enum left nominal in the codebook, an unused middle category keeping its rank, rank tolerance, bootstrap CIs, survival of levels through `[`, backfill and a save/load round trip, `as_qlm_coded()` conversion and refusal, and the codebook print. The two #150 tests that encoded alphabetical ranking are rewritten. Full suite and `devtools::check()` clean.

## Documentation

`qlm_codebook()`, `qlm_code()`, `as_qlm_coded()`, `qlm_compare()` and `qlm_validate()` roxygen updated and regenerated; NEWS bullet under "Reliability and validation".
